### PR TITLE
refactor: Unify the TXT/MD line readers behind a shared LineReaderActivity base

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -529,44 +529,8 @@ void EpubReaderActivity::loop() {
       }
       writeReaderProgressCache(epub->getCachePath(), lastSpineIndex, lastPageIndex, lastPageCount, 100);
 
-      const std::string nextBookPath =
-          BookFinished::findNextBookInDirectory(epub->getPath(), epub->getSeries(), epub->getSeriesIndex());
-      startActivityForResult(
-          std::make_unique<FinishedBookActivity>(renderer, mappedInput, epub->getPath(), nextBookPath),
-          [this, nextBookPath](const ActivityResult& result) {
-            if (result.isCancelled) {
-              requestUpdate();
-              return;
-            }
-            // User confirmed they're done with this book — credit a finish
-            // to the in-flight session before any tear-down side effects.
-            globalReadingSessionTracker().markFinished();
-            const auto& menuResult = std::get<MenuResult>(result.data);
-            if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::GoHome)) {
-              if (SETTINGS.moveFinishedBooksToCompleted) {
-                std::string movedPath;
-                BookFinished::moveFinishedBookToCompleted(epub->getPath(), movedPath);
-              }
-              if (SETTINGS.removeFinishedBooksFromRecents) {
-                RECENT_BOOKS.removeBook(epub->getPath());
-              }
-              activityManager.goHome();
-              return;
-            }
-            if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::OpenNextBook) &&
-                !nextBookPath.empty()) {
-              if (SETTINGS.moveFinishedBooksToCompleted) {
-                std::string movedPath;
-                BookFinished::moveFinishedBookToCompleted(epub->getPath(), movedPath);
-              }
-              if (SETTINGS.removeFinishedBooksFromRecents) {
-                RECENT_BOOKS.removeBook(epub->getPath());
-              }
-              activityManager.goToReader(nextBookPath);
-              return;
-            }
-            requestUpdate();
-          });
+      BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, epub->getPath(), epub->getSeries(),
+                                           epub->getSeriesIndex());
     } else {
       currentSpineIndex = epub->getSpineItemsCount() - 1;
       navTarget = NavigationTarget::makeLastPage();
@@ -1113,44 +1077,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
           writeReaderProgressCache(epub->getCachePath(), lastSpineIndex, 0, 0, 100);
         }
       }
-      {
-        const std::string nextBookPath =
-            BookFinished::findNextBookInDirectory(epub->getPath(), epub->getSeries(), epub->getSeriesIndex());
-        startActivityForResult(
-            std::make_unique<FinishedBookActivity>(renderer, mappedInput, epub->getPath(), nextBookPath),
-            [this, nextBookPath](const ActivityResult& result) {
-              if (result.isCancelled) {
-                requestUpdate();
-                return;
-              }
-              globalReadingSessionTracker().markFinished();
-              const auto& menuResult = std::get<MenuResult>(result.data);
-              if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::GoHome)) {
-                if (SETTINGS.moveFinishedBooksToCompleted) {
-                  std::string movedPath;
-                  BookFinished::moveFinishedBookToCompleted(epub->getPath(), movedPath);
-                }
-                if (SETTINGS.removeFinishedBooksFromRecents) {
-                  RECENT_BOOKS.removeBook(epub->getPath());
-                }
-                activityManager.goHome();
-                return;
-              }
-              if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::OpenNextBook) &&
-                  !nextBookPath.empty()) {
-                if (SETTINGS.moveFinishedBooksToCompleted) {
-                  std::string movedPath;
-                  BookFinished::moveFinishedBookToCompleted(epub->getPath(), movedPath);
-                }
-                if (SETTINGS.removeFinishedBooksFromRecents) {
-                  RECENT_BOOKS.removeBook(epub->getPath());
-                }
-                activityManager.goToReader(nextBookPath);
-                return;
-              }
-              requestUpdate();
-            });
-      }
+      BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, epub->getPath(), epub->getSeries(),
+                                           epub->getSeriesIndex());
       return;
     }
     case EpubReaderMenuActivity::MenuAction::DELETE_CACHE: {
@@ -2188,43 +2116,10 @@ void EpubReaderActivity::renderFinishedBookPass(RenderLock& lock, const int spin
   finishedBookActivityStarted_ = true;
   const int lastSpineIndex = std::max(0, spineCount - 1);
   writeReaderProgressCache(epub->getCachePath(), lastSpineIndex, 0, 0, 100);
-  const std::string nextBookPath =
-      BookFinished::findNextBookInDirectory(epub->getPath(), epub->getSeries(), epub->getSeriesIndex());
   lock.unlock();
-  startActivityForResult(std::make_unique<FinishedBookActivity>(renderer, mappedInput, epub->getPath(), nextBookPath),
-                         [this, nextBookPath](const ActivityResult& result) {
-                           finishedBookActivityStarted_ = false;
-                           if (result.isCancelled) {
-                             requestUpdate();
-                             return;
-                           }
-                           globalReadingSessionTracker().markFinished();
-                           const auto& menuResult = std::get<MenuResult>(result.data);
-                           if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::GoHome)) {
-                             if (SETTINGS.moveFinishedBooksToCompleted) {
-                               std::string movedPath;
-                               BookFinished::moveFinishedBookToCompleted(epub->getPath(), movedPath);
-                             }
-                             if (SETTINGS.removeFinishedBooksFromRecents) {
-                               RECENT_BOOKS.removeBook(epub->getPath());
-                             }
-                             activityManager.goHome();
-                             return;
-                           }
-                           if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::OpenNextBook) &&
-                               !nextBookPath.empty()) {
-                             if (SETTINGS.moveFinishedBooksToCompleted) {
-                               std::string movedPath;
-                               BookFinished::moveFinishedBookToCompleted(epub->getPath(), movedPath);
-                             }
-                             if (SETTINGS.removeFinishedBooksFromRecents) {
-                               RECENT_BOOKS.removeBook(epub->getPath());
-                             }
-                             activityManager.goToReader(nextBookPath);
-                             return;
-                           }
-                           requestUpdate();
-                         });
+  BookFinished::launchFinishedBookFlow(
+      *this, renderer, mappedInput, epub->getPath(), epub->getSeries(), epub->getSeriesIndex(),
+      [](void* ctx) { static_cast<EpubReaderActivity*>(ctx)->finishedBookActivityStarted_ = false; }, this);
 }
 
 bool EpubReaderActivity::renderBufferDisplayPass(const RenderLayout& layout) {

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "ReaderActivity.h"
+#include "ReadingSessionTracker.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -444,6 +445,47 @@ bool moveFinishedBookToCompleted(const std::string& currentBookPath, std::string
 
   outMovedPath = targetPath;
   return true;
+}
+
+void launchFinishedBookFlow(Activity& host, GfxRenderer& renderer, MappedInputManager& mappedInput,
+                            const std::string& bookPath, const std::string& series, const std::string& seriesIndex,
+                            void (*onMenuClosed)(void*), void* onMenuClosedCtx) {
+  const std::string nextBookPath = findNextBookInDirectory(bookPath, series, seriesIndex);
+  Activity* hostPtr = &host;
+  host.startActivityForResult(
+      std::make_unique<FinishedBookActivity>(renderer, mappedInput, bookPath, nextBookPath),
+      [hostPtr, bookPath, nextBookPath, onMenuClosed, onMenuClosedCtx](const ActivityResult& result) {
+        if (onMenuClosed) {
+          onMenuClosed(onMenuClosedCtx);
+        }
+        if (result.isCancelled) {
+          hostPtr->requestUpdate();
+          return;
+        }
+        // User confirmed they're done with this book — credit a finish to the
+        // in-flight session before any tear-down side effects.
+        globalReadingSessionTracker().markFinished();
+        const auto& menuResult = std::get<MenuResult>(result.data);
+        const bool goHome = menuResult.action == static_cast<int>(FinishedBookAction::GoHome);
+        const bool openNext =
+            menuResult.action == static_cast<int>(FinishedBookAction::OpenNextBook) && !nextBookPath.empty();
+        if (!goHome && !openNext) {
+          hostPtr->requestUpdate();
+          return;
+        }
+        if (SETTINGS.moveFinishedBooksToCompleted) {
+          std::string movedPath;
+          moveFinishedBookToCompleted(bookPath, movedPath);
+        }
+        if (SETTINGS.removeFinishedBooksFromRecents) {
+          RECENT_BOOKS.removeBook(bookPath);
+        }
+        if (goHome) {
+          activityManager.goHome();
+        } else {
+          activityManager.goToReader(nextBookPath);
+        }
+      });
 }
 
 }  // namespace BookFinished

--- a/src/activities/reader/FinishedBookActivity.h
+++ b/src/activities/reader/FinishedBookActivity.h
@@ -16,6 +16,20 @@ enum class FinishedBookAction {
   GoHome = 1,
   OpenNextBook = 2,
 };
+
+// Launches the finished-book menu on top of `host` and handles its result:
+// credits a finish to the reading-stats session, applies the move-to-/COMPLETED
+// and remove-from-recents settings, then navigates home or to the next book.
+// On cancel/stay the host gets a requestUpdate() to re-render its last page.
+// The caller is responsible for persisting reading progress beforehand (the
+// progress formats differ per reader).
+// `onMenuClosed` (optional, with `onMenuClosedCtx`) runs first in the result
+// handler regardless of outcome — readers use it to clear a "menu is open"
+// flag. Plain function pointer + context instead of std::function per the
+// project callback convention.
+void launchFinishedBookFlow(Activity& host, GfxRenderer& renderer, MappedInputManager& mappedInput,
+                            const std::string& bookPath, const std::string& series, const std::string& seriesIndex,
+                            void (*onMenuClosed)(void*) = nullptr, void* onMenuClosedCtx = nullptr);
 }  // namespace BookFinished
 
 class FinishedBookActivity : public Activity {

--- a/src/activities/reader/LineReaderActivity.cpp
+++ b/src/activities/reader/LineReaderActivity.cpp
@@ -1,0 +1,164 @@
+#include "LineReaderActivity.h"
+
+#include <HalClock.h>
+#include <HalPowerManager.h>
+#include <HalStorage.h>
+
+#include <algorithm>
+
+#include "CrossPointState.h"
+#include "KOReaderDocumentId.h"
+#include "ReaderActivity.h"
+#include "ReadingSessionTracker.h"
+#include "RecentBooksStore.h"
+#include "components/UITheme.h"
+
+void LineReaderActivity::onEnter() {
+  Activity::onEnter();
+
+  // See ReaderUtils::InputDrainGuard — prevents wake-up power-button hold from leaking into
+  // the first detectPageTurn() call as a page turn or chapter skip.
+  inputDrainGuard.arm();
+
+  if (!txt) {
+    return;
+  }
+
+  {
+    RenderLock lock(*this);
+    ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
+  }
+
+  txt->setupCacheDir();
+  onReaderEnter();
+
+  // Save as last opened file and add to recent books
+  const std::string filePath = txt->getPath();
+  const std::string fileName = filePath.substr(filePath.rfind('/') + 1);
+  APP_STATE.openEpubPath = filePath;
+  APP_STATE.saveToFile();
+  const std::string sidecar = ReaderActivity::sidecarCoverPath(filePath);
+  const std::string cover = sidecar.empty() ? txt->getThumbBmpPath() : sidecar;
+  RECENT_BOOKS.addBook(filePath, fileName, "", "", cover);
+
+  // Start reading-stats session. Same filename-hash policy as EPUB so renamed
+  // files start fresh; author is unknown for plain text formats.
+  globalReadingSessionTracker().begin(KOReaderDocumentId::calculateFromFilename(filePath), fileName, "");
+
+  // Trigger first update
+  requestUpdate();
+}
+
+void LineReaderActivity::onExit() {
+  Activity::onExit();
+
+  // Flush the stats session before tearing down the document — same pattern as
+  // EpubReaderActivity::onExit().
+  globalReadingSessionTracker().end();
+
+  onReaderExit();
+
+  // Reset orientation back to portrait for the rest of the UI
+  renderer.setOrientation(GfxRenderer::Orientation::Portrait);
+
+  pageOffsets.clear();
+  APP_STATE.readerActivityLoadCount = 0;
+  APP_STATE.saveToFile();
+  UITheme::getInstance().getMutableTheme().onBookWillClose(txt ? txt->getPath() : "", nullptr, nullptr, txt.get());
+  txt.reset();
+}
+
+LineReaderActivity::TextLayout LineReaderActivity::computeTextLayout(const GfxRenderer& renderer, const int fontId,
+                                                                     const uint8_t screenMargin) {
+  TextLayout layout;
+  renderer.getOrientedViewableTRBL(&layout.marginTop, &layout.marginRight, &layout.marginBottom, &layout.marginLeft);
+  layout.marginTop += std::max(static_cast<int>(screenMargin), UITheme::getStatusBarTopHeight());
+  layout.marginLeft += screenMargin;
+  layout.marginRight += screenMargin;
+  layout.marginBottom += std::max(static_cast<int>(screenMargin), UITheme::getStatusBarBottomHeight());
+  layout.viewportWidth = renderer.getScreenWidth() - layout.marginLeft - layout.marginRight;
+  layout.viewportHeight = renderer.getScreenHeight() - layout.marginTop - layout.marginBottom;
+  layout.linesPerPage = std::max(1, layout.viewportHeight / renderer.getLineHeight(fontId));
+  return layout;
+}
+
+void LineReaderActivity::computeViewportLayout() {
+  // Store current settings for index-cache validation
+  cachedFontId = SETTINGS.getTxtReaderFontId();
+  cachedScreenMargin = SETTINGS.screenMargin;
+  cachedParagraphAlignment = SETTINGS.paragraphAlignment;
+
+  const TextLayout layout = computeTextLayout(renderer, cachedFontId, cachedScreenMargin);
+  cachedOrientedMarginTop = layout.marginTop;
+  cachedOrientedMarginRight = layout.marginRight;
+  cachedOrientedMarginBottom = layout.marginBottom;
+  cachedOrientedMarginLeft = layout.marginLeft;
+  viewportWidth = layout.viewportWidth;
+  linesPerPage = layout.linesPerPage;
+
+  LOG_DBG(logTag, "Viewport: %dx%d, lines per page: %d", viewportWidth, layout.viewportHeight, linesPerPage);
+}
+
+void LineReaderActivity::noteStatusBarRendered() const {
+  lastStatusBarPage = currentPage + 1;
+  lastStatusBarBattery = SETTINGS.statusBarBattery ? static_cast<int>(powerManager.getBatteryPercentage()) : -1;
+  if (SETTINGS.useClock && SETTINGS.statusBarClock && HalClock::isSynced()) {
+    const time_t now = HalClock::now();
+    lastStatusBarClockMinute = now > 0 ? static_cast<int>(now / 60) : -1;
+  } else {
+    lastStatusBarClockMinute = -1;
+  }
+}
+
+bool LineReaderActivity::shouldSkipPeriodicUpdate() const {
+  if (lastStatusBarPage < 0) return false;
+  if (currentPage + 1 != lastStatusBarPage) return false;
+  if (SETTINGS.statusBarBattery) {
+    if (static_cast<int>(powerManager.getBatteryPercentage()) != lastStatusBarBattery) return false;
+  }
+  if (SETTINGS.useClock && SETTINGS.statusBarClock && HalClock::isSynced()) {
+    const time_t now = HalClock::now();
+    const int minute = now > 0 ? static_cast<int>(now / 60) : -1;
+    if (minute != lastStatusBarClockMinute) return false;
+  }
+  return true;
+}
+
+void LineReaderActivity::saveProgress() const {
+  FsFile f;
+  if (Storage.openFileForWrite(logTag, txt->getCachePath() + "/progress.bin", f)) {
+    const size_t offset =
+        (currentPage >= 0 && currentPage < static_cast<int>(pageOffsets.size())) ? pageOffsets[currentPage] : 0;
+    const uint8_t percent = ReaderUtils::pageProgressPercentByte(currentPage, totalPages);
+    uint8_t data[7];
+    data[0] = currentPage & 0xFF;
+    data[1] = (currentPage >> 8) & 0xFF;
+    data[2] = offset & 0xFF;
+    data[3] = (offset >> 8) & 0xFF;
+    data[4] = (offset >> 16) & 0xFF;
+    data[5] = (offset >> 24) & 0xFF;
+    data[6] = percent;
+    f.write(data, 7);
+    f.close();
+    globalReadingSessionTracker().updateProgress(percent);
+  }
+}
+
+void LineReaderActivity::loadProgress() {
+  FsFile f;
+  if (Storage.openFileForRead(logTag, txt->getCachePath() + "/progress.bin", f)) {
+    // Page sits in bytes 0-1 in both the legacy 4-byte format and the current
+    // 7-byte format (page counts stay well under 65536).
+    uint8_t data[2];
+    if (f.read(data, 2) == 2) {
+      const int loadedPage = data[0] + (data[1] << 8);
+      if (totalPages <= 0) {
+        currentPage = 0;
+      } else {
+        currentPage = std::min(loadedPage, totalPages - 1);
+      }
+      LOG_DBG(logTag, "Loaded progress: page %d/%d", currentPage, totalPages);
+    }
+    f.close();
+  }
+}

--- a/src/activities/reader/LineReaderActivity.cpp
+++ b/src/activities/reader/LineReaderActivity.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 
 #include "CrossPointState.h"
+#include "FinishedBookActivity.h"
 #include "KOReaderDocumentId.h"
 #include "ReaderActivity.h"
 #include "ReadingSessionTracker.h"
@@ -66,6 +67,87 @@ void LineReaderActivity::onExit() {
   APP_STATE.saveToFile();
   UITheme::getInstance().getMutableTheme().onBookWillClose(txt ? txt->getPath() : "", nullptr, nullptr, txt.get());
   txt.reset();
+}
+
+void LineReaderActivity::loop() {
+  const bool drainActive = inputDrainGuard.shouldDrain(mappedInput);
+  if (!drainActive && drainWasActive) {
+    halTiltSensor.clearPendingEvents();
+  }
+  drainWasActive = drainActive;
+
+  if (drainActive) {
+    buttonEvents.drain();
+    return;
+  }
+
+  ButtonEventManager::ButtonEvent ev;
+  while (buttonEvents.consumeEvent(ev)) {
+    if (ev.button == MappedInputManager::Button::Back) {
+      if (ev.type == ButtonEventManager::PressType::Long) {
+        ReaderUtils::enforceExitFullRefresh(renderer);
+        onGoHome();
+        return;
+      }
+      if (ev.type == ButtonEventManager::PressType::Short) {
+        ReaderUtils::enforceExitFullRefresh(renderer);
+        finish();
+        return;
+      }
+    }
+
+    if (ev.button == MappedInputManager::Button::Confirm && ev.type == ButtonEventManager::PressType::Short) {
+      if (onConfirmShortPress()) {
+        return;
+      }
+      continue;
+    }
+
+    if ((ev.button == MappedInputManager::Button::PageBack || ev.button == MappedInputManager::Button::Left) &&
+        ev.type == ButtonEventManager::PressType::Short) {
+      goToPreviousPage();
+      return;
+    }
+
+    if ((ev.button == MappedInputManager::Button::PageForward || ev.button == MappedInputManager::Button::Right) &&
+        ev.type == ButtonEventManager::PressType::Short) {
+      goToNextPage();
+      return;
+    }
+  }
+
+  auto [prevTriggered, nextTriggered] = ReaderUtils::detectPageTurn(mappedInput);
+  if (prevTriggered) {
+    goToPreviousPage();
+  } else if (nextTriggered) {
+    goToNextPage();
+  }
+}
+
+void LineReaderActivity::goToPreviousPage() {
+  if (currentPage > 0) {
+    currentPage--;
+    onPageChanged();
+    globalReadingSessionTracker().onPageTurn();
+    requestUpdate();
+  }
+}
+
+void LineReaderActivity::goToNextPage() {
+  if (currentPage < totalPages - 1) {
+    currentPage++;
+    onPageChanged();
+    globalReadingSessionTracker().onPageTurn();
+    requestUpdate();
+  } else {
+    launchFinishedBookFlow();
+  }
+}
+
+void LineReaderActivity::launchFinishedBookFlow() {
+  saveProgress();
+  BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, txt ? txt->getPath() : std::string(),
+                                       std::string(), std::string());
 }
 
 LineReaderActivity::TextLayout LineReaderActivity::computeTextLayout(const GfxRenderer& renderer, const int fontId,

--- a/src/activities/reader/LineReaderActivity.h
+++ b/src/activities/reader/LineReaderActivity.h
@@ -12,10 +12,12 @@
 // Shared scaffolding for the line-oriented file readers (TXT, Markdown).
 // Owns the document handle, page-offset index, viewport layout, reading
 // progress persistence and status-bar freshness tracking, plus the common
-// enter/exit lifecycle (orientation, recents, reading-stats session).
-// Subclasses provide the format-specific parsing, page rendering and input
-// handling, and hook into onReaderEnter()/onReaderExit() for extras such as
-// bookmarks or headings.
+// enter/exit lifecycle (orientation, recents, reading-stats session) and the
+// loop() input handling (back/page buttons, tilt page turns, finished-book
+// flow). Subclasses provide the format-specific parsing and page rendering,
+// and hook in via onReaderEnter()/onReaderExit() for extras such as bookmarks
+// or headings, onConfirmShortPress() for their navigation overlay, and
+// onPageChanged() for per-page bookkeeping.
 class LineReaderActivity : public Activity {
  protected:
   std::unique_ptr<Txt> txt;
@@ -59,6 +61,19 @@ class LineReaderActivity : public Activity {
   // Called from onExit() after the stats session is flushed, before the
   // document is torn down (TXT syncs bookmarks, subclasses clear their lines).
   virtual void onReaderExit() {}
+  // Called from loop() on a Confirm short press. Return true when handled
+  // (TXT opens starred pages, MD opens the ToC); false lets the press fall
+  // through unhandled.
+  virtual bool onConfirmShortPress() { return false; }
+  // Called after currentPage changed through the shared page-turn handling
+  // (MD recomputes the current heading here).
+  virtual void onPageChanged() {}
+
+  // Page-turn helpers used by loop(); going forward past the last page
+  // launches the finished-book flow.
+  void goToPreviousPage();
+  void goToNextPage();
+  void launchFinishedBookFlow();
 
   // Reads the current font/margin/alignment settings and fills the cached
   // layout fields (oriented margins, viewportWidth, linesPerPage).
@@ -89,6 +104,7 @@ class LineReaderActivity : public Activity {
 
   void onEnter() override;
   void onExit() override;
+  void loop() override;
   bool isReaderActivity() const override { return true; }
   bool shouldSkipPeriodicUpdate() const override;
 };

--- a/src/activities/reader/LineReaderActivity.h
+++ b/src/activities/reader/LineReaderActivity.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <Txt.h>
+
+#include <memory>
+#include <vector>
+
+#include "CrossPointSettings.h"
+#include "ReaderUtils.h"
+#include "activities/Activity.h"
+
+// Shared scaffolding for the line-oriented file readers (TXT, Markdown).
+// Owns the document handle, page-offset index, viewport layout, reading
+// progress persistence and status-bar freshness tracking, plus the common
+// enter/exit lifecycle (orientation, recents, reading-stats session).
+// Subclasses provide the format-specific parsing, page rendering and input
+// handling, and hook into onReaderEnter()/onReaderExit() for extras such as
+// bookmarks or headings.
+class LineReaderActivity : public Activity {
+ protected:
+  std::unique_ptr<Txt> txt;
+  // Module tag used for storage/log calls so TXT and MD keep distinct logs.
+  const char* logTag;
+
+  int currentPage = 0;
+  int totalPages = 1;
+  int pagesUntilFullRefresh = 0;
+  ReaderUtils::InputDrainGuard inputDrainGuard;
+  bool drainWasActive = false;
+
+  // Streaming reader state: file offset for the start of each page.
+  std::vector<size_t> pageOffsets;
+  int linesPerPage = 0;
+  int viewportWidth = 0;
+  bool initialized = false;
+
+  // Cached settings for index-cache validation (font/margin/alignment changes
+  // require re-indexing) and oriented layout for rendering.
+  int cachedFontId = 0;
+  uint8_t cachedScreenMargin = 0;
+  uint8_t cachedParagraphAlignment = CrossPointSettings::LEFT_ALIGN;
+  int cachedOrientedMarginTop = 0;
+  int cachedOrientedMarginRight = 0;
+  int cachedOrientedMarginBottom = 0;
+  int cachedOrientedMarginLeft = 0;
+
+  // See EpubReaderActivity for rationale — suppresses no-op minute-tick re-renders.
+  mutable int lastStatusBarPage = -1;
+  mutable int lastStatusBarBattery = -1;
+  mutable int lastStatusBarClockMinute = -1;
+
+  LineReaderActivity(const char* name, const char* logTag, GfxRenderer& renderer, MappedInputManager& mappedInput,
+                     std::unique_ptr<Txt> txt)
+      : Activity(name, renderer, mappedInput), txt(std::move(txt)), logTag(logTag) {}
+
+  // Called from onEnter() after the cache dir is set up, before recents and
+  // the stats session are touched (TXT loads bookmarks here).
+  virtual void onReaderEnter() {}
+  // Called from onExit() after the stats session is flushed, before the
+  // document is torn down (TXT syncs bookmarks, subclasses clear their lines).
+  virtual void onReaderExit() {}
+
+  // Reads the current font/margin/alignment settings and fills the cached
+  // layout fields (oriented margins, viewportWidth, linesPerPage).
+  void computeViewportLayout();
+
+  // Records what the status bar showed so shouldSkipPeriodicUpdate() can
+  // suppress no-op minute-tick re-renders. Call at the end of renderStatusBar().
+  void noteStatusBarRendered() const;
+
+  // progress.bin, 7-byte format: page(2 LE) + file offset(4 LE) + percent(1).
+  // The offset lets drawCurrentPageToBuffer render without requiring index.bin.
+  void saveProgress() const;
+  void loadProgress();
+
+ public:
+  // Oriented text layout shared by the readers and their static sleep-overlay
+  // renderers, which must reproduce the exact same wrapping geometry.
+  struct TextLayout {
+    int marginTop = 0;
+    int marginRight = 0;
+    int marginBottom = 0;
+    int marginLeft = 0;
+    int viewportWidth = 0;
+    int viewportHeight = 0;
+    int linesPerPage = 1;
+  };
+  static TextLayout computeTextLayout(const GfxRenderer& renderer, int fontId, uint8_t screenMargin);
+
+  void onEnter() override;
+  void onExit() override;
+  bool isReaderActivity() const override { return true; }
+  bool shouldSkipPeriodicUpdate() const override;
+};

--- a/src/activities/reader/MdReaderActivity.cpp
+++ b/src/activities/reader/MdReaderActivity.cpp
@@ -292,43 +292,8 @@ void MdReaderActivity::loop() {
         requestUpdate();
       } else {
         saveProgress();
-        const std::string currentBookPath = txt ? txt->getPath() : std::string();
-        const std::string nextBookPath =
-            BookFinished::findNextBookInDirectory(currentBookPath, std::string(), std::string());
-        startActivityForResult(
-            std::make_unique<FinishedBookActivity>(renderer, mappedInput, currentBookPath, nextBookPath),
-            [this, currentBookPath, nextBookPath](const ActivityResult& result) {
-              if (result.isCancelled) {
-                requestUpdate();
-                return;
-              }
-              globalReadingSessionTracker().markFinished();
-              const auto& menuResult = std::get<MenuResult>(result.data);
-              if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::GoHome)) {
-                if (SETTINGS.moveFinishedBooksToCompleted) {
-                  std::string movedPath;
-                  BookFinished::moveFinishedBookToCompleted(currentBookPath, movedPath);
-                }
-                if (SETTINGS.removeFinishedBooksFromRecents) {
-                  RECENT_BOOKS.removeBook(currentBookPath);
-                }
-                activityManager.goHome();
-                return;
-              }
-              if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::OpenNextBook) &&
-                  !nextBookPath.empty()) {
-                if (SETTINGS.moveFinishedBooksToCompleted) {
-                  std::string movedPath;
-                  BookFinished::moveFinishedBookToCompleted(currentBookPath, movedPath);
-                }
-                if (SETTINGS.removeFinishedBooksFromRecents) {
-                  RECENT_BOOKS.removeBook(currentBookPath);
-                }
-                activityManager.goToReader(nextBookPath);
-                return;
-              }
-              requestUpdate();
-            });
+        BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, txt ? txt->getPath() : std::string(),
+                                             std::string(), std::string());
       }
       return;
     }

--- a/src/activities/reader/MdReaderActivity.cpp
+++ b/src/activities/reader/MdReaderActivity.cpp
@@ -2,8 +2,6 @@
 
 #include <FontCacheManager.h>
 #include <GfxRenderer.h>
-#include <HalClock.h>
-#include <HalPowerManager.h>
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Serialization.h>
@@ -14,15 +12,11 @@
 #include <numeric>
 
 #include "CrossPointSettings.h"
-#include "CrossPointState.h"
 #include "FinishedBookActivity.h"
-#include "KOReaderDocumentId.h"
 #include "MappedInputManager.h"
 #include "MdReaderTocSelectionActivity.h"
-#include "ReaderActivity.h"
 #include "ReaderUtils.h"
 #include "ReadingSessionTracker.h"
-#include "RecentBooksStore.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 
@@ -40,33 +34,6 @@ static std::string flattenHeadingText(const MdParser::ParsedLine& parsed) {
   return result;
 }
 }  // namespace
-
-void MdReaderActivity::onEnter() {
-  Activity::onEnter();
-
-  inputDrainGuard.arm();
-
-  if (!txt) {
-    return;
-  }
-
-  ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
-
-  txt->setupCacheDir();
-
-  auto filePath = txt->getPath();
-  auto fileName = filePath.substr(filePath.rfind('/') + 1);
-  APP_STATE.openEpubPath = filePath;
-  APP_STATE.saveToFile();
-  const std::string txtSidecar = ReaderActivity::sidecarCoverPath(filePath);
-  const std::string txtCover = txtSidecar.empty() ? txt->getThumbBmpPath() : txtSidecar;
-  RECENT_BOOKS.addBook(filePath, fileName, "", "", txtCover);
-
-  // Start the stats session.
-  globalReadingSessionTracker().begin(KOReaderDocumentId::calculateFromFilename(filePath), fileName, "");
-
-  requestUpdate();
-}
 
 void MdReaderActivity::assignHeadingPageNumbers() {
   if (pageOffsets.empty()) {
@@ -220,21 +187,9 @@ void MdReaderActivity::scanHeadings() {
   }
 }
 
-void MdReaderActivity::onExit() {
-  Activity::onExit();
-
-  // Flush the stats session before tearing down the reader.
-  globalReadingSessionTracker().end();
-
-  renderer.setOrientation(GfxRenderer::Orientation::Portrait);
-
-  pageOffsets.clear();
+void MdReaderActivity::onReaderExit() {
   pageCodeBlockState.clear();
   currentPageLines.clear();
-  APP_STATE.readerActivityLoadCount = 0;
-  APP_STATE.saveToFile();
-  UITheme::getInstance().getMutableTheme().onBookWillClose(txt ? txt->getPath() : "", nullptr, nullptr, txt.get());
-  txt.reset();
 }
 
 void MdReaderActivity::loop() {
@@ -305,28 +260,10 @@ void MdReaderActivity::initializeReader() {
     return;
   }
 
-  cachedFontId = SETTINGS.getTxtReaderFontId();
-  cachedScreenMargin = SETTINGS.screenMargin;
-  cachedParagraphAlignment = SETTINGS.paragraphAlignment;
-
-  renderer.getOrientedViewableTRBL(&cachedOrientedMarginTop, &cachedOrientedMarginRight, &cachedOrientedMarginBottom,
-                                   &cachedOrientedMarginLeft);
-  cachedOrientedMarginTop += std::max(static_cast<int>(cachedScreenMargin), UITheme::getStatusBarTopHeight());
-  cachedOrientedMarginLeft += cachedScreenMargin;
-  cachedOrientedMarginRight += cachedScreenMargin;
-  cachedOrientedMarginBottom += std::max(static_cast<int>(cachedScreenMargin), UITheme::getStatusBarBottomHeight());
-
-  viewportWidth = renderer.getScreenWidth() - cachedOrientedMarginLeft - cachedOrientedMarginRight;
-  const int viewportHeight = renderer.getScreenHeight() - cachedOrientedMarginTop - cachedOrientedMarginBottom;
-  const int lineHeight = renderer.getLineHeight(cachedFontId);
+  computeViewportLayout();
 
   pageBuffer.reserve(CHUNK_SIZE + 1);
   scanHeadings();
-
-  linesPerPage = viewportHeight / lineHeight;
-  if (linesPerPage < 1) linesPerPage = 1;
-
-  LOG_DBG("MDR", "Viewport: %dx%d, lines per page: %d", viewportWidth, viewportHeight, linesPerPage);
 
   if (!loadPageIndexCache()) {
     buildPageIndex();
@@ -857,71 +794,7 @@ void MdReaderActivity::renderStatusBar() const {
   }
   GUI.drawStatusBar(renderer, progress, currentPage + 1, totalPages, title);
 
-  lastStatusBarPage = currentPage + 1;
-  lastStatusBarBattery = SETTINGS.statusBarBattery ? static_cast<int>(powerManager.getBatteryPercentage()) : -1;
-  if (SETTINGS.useClock && SETTINGS.statusBarClock && HalClock::isSynced()) {
-    const time_t now = HalClock::now();
-    lastStatusBarClockMinute = now > 0 ? static_cast<int>(now / 60) : -1;
-  } else {
-    lastStatusBarClockMinute = -1;
-  }
-}
-
-bool MdReaderActivity::shouldSkipPeriodicUpdate() const {
-  if (lastStatusBarPage < 0) return false;
-  if (currentPage + 1 != lastStatusBarPage) return false;
-  if (SETTINGS.statusBarBattery) {
-    if (static_cast<int>(powerManager.getBatteryPercentage()) != lastStatusBarBattery) return false;
-  }
-  if (SETTINGS.useClock && SETTINGS.statusBarClock && HalClock::isSynced()) {
-    const time_t now = HalClock::now();
-    const int minute = now > 0 ? static_cast<int>(now / 60) : -1;
-    if (minute != lastStatusBarClockMinute) return false;
-  }
-  return true;
-}
-
-void MdReaderActivity::saveProgress() const {
-  FsFile f;
-  if (Storage.openFileForWrite("MDR", txt->getCachePath() + "/progress.bin", f)) {
-    // 7-byte format matching TxtReaderActivity: page(2 bytes LE) + file offset(4 bytes LE) + overallPercent(1 byte)
-    const size_t offset =
-        (currentPage >= 0 && currentPage < static_cast<int>(pageOffsets.size())) ? pageOffsets[currentPage] : 0;
-    const uint8_t percent = ReaderUtils::pageProgressPercentByte(currentPage, totalPages);
-    uint8_t data[7];
-    data[0] = currentPage & 0xFF;
-    data[1] = (currentPage >> 8) & 0xFF;
-    data[2] = offset & 0xFF;
-    data[3] = (offset >> 8) & 0xFF;
-    data[4] = (offset >> 16) & 0xFF;
-    data[5] = (offset >> 24) & 0xFF;
-    data[6] = percent;
-    f.write(data, 7);
-    f.close();
-    globalReadingSessionTracker().updateProgress(percent);
-  }
-}
-
-void MdReaderActivity::loadProgress() {
-  FsFile f;
-  if (Storage.openFileForRead("MDR", txt->getCachePath() + "/progress.bin", f)) {
-    uint8_t data[7];
-    const int dataSize = f.read(data, 7);
-    f.close();
-    if (dataSize >= 4) {
-      // Page sits in bytes 0-1 in both the old 4-byte uint32 format and the new 7-byte format
-      // (page counts stay well under 65536, so the upper bytes were always zero).
-      int loadedPage = data[0] + (data[1] << 8);
-      if (totalPages == 0) {
-        currentPage = 0;
-      } else if (loadedPage >= totalPages) {
-        currentPage = totalPages - 1;
-      } else {
-        currentPage = loadedPage;
-      }
-      LOG_DBG("MDR", "Loaded progress: page %d/%d", currentPage, totalPages);
-    }
-  }
+  noteStatusBarRendered();
 }
 
 bool MdReaderActivity::loadPageIndexCache() {

--- a/src/activities/reader/MdReaderActivity.cpp
+++ b/src/activities/reader/MdReaderActivity.cpp
@@ -12,7 +12,6 @@
 #include <numeric>
 
 #include "CrossPointSettings.h"
-#include "FinishedBookActivity.h"
 #include "MappedInputManager.h"
 #include "MdReaderTocSelectionActivity.h"
 #include "ReaderUtils.h"
@@ -192,67 +191,26 @@ void MdReaderActivity::onReaderExit() {
   currentPageLines.clear();
 }
 
-void MdReaderActivity::loop() {
-  if (inputDrainGuard.shouldDrain(mappedInput)) {
-    buttonEvents.drain();
-    return;
+bool MdReaderActivity::onConfirmShortPress() {
+  if (headings.empty()) {
+    return false;
   }
+  onPageChanged();
+  ReaderUtils::enforceExitFullRefresh(renderer);
+  startActivityForResult(
+      std::make_unique<MdReaderTocSelectionActivity>(renderer, mappedInput, headings, currentHeadingIndex),
+      [this](const ActivityResult& result) {
+        if (!result.isCancelled) {
+          currentPage = std::get<PageResult>(result.data).page;
+          onPageChanged();
+          requestUpdate();
+        }
+      });
+  return true;
+}
 
-  ButtonEventManager::ButtonEvent ev;
-  while (buttonEvents.consumeEvent(ev)) {
-    if (ev.button == MappedInputManager::Button::Back) {
-      if (ev.type == ButtonEventManager::PressType::Long) {
-        activityManager.goToFileBrowser(txt ? txt->getPath() : "");
-        return;
-      }
-      if (ev.type == ButtonEventManager::PressType::Short) {
-        onGoHome();
-        return;
-      }
-    }
-
-    if (!headings.empty() && ev.button == MappedInputManager::Button::Confirm &&
-        ev.type == ButtonEventManager::PressType::Short) {
-      currentHeadingIndex = getHeadingIndexForOffset(pageOffsets[currentPage]);
-      ReaderUtils::enforceExitFullRefresh(renderer);
-      startActivityForResult(
-          std::make_unique<MdReaderTocSelectionActivity>(renderer, mappedInput, headings, currentHeadingIndex),
-          [this](const ActivityResult& result) {
-            if (!result.isCancelled) {
-              currentPage = std::get<PageResult>(result.data).page;
-              currentHeadingIndex = getHeadingIndexForOffset(pageOffsets[currentPage]);
-              requestUpdate();
-            }
-          });
-      return;
-    }
-
-    if ((ev.button == MappedInputManager::Button::PageBack || ev.button == MappedInputManager::Button::Left) &&
-        ev.type == ButtonEventManager::PressType::Short) {
-      if (currentPage > 0) {
-        currentPage--;
-        currentHeadingIndex = getHeadingIndexForOffset(pageOffsets[currentPage]);
-        globalReadingSessionTracker().onPageTurn();
-        requestUpdate();
-      }
-      return;
-    }
-
-    if ((ev.button == MappedInputManager::Button::PageForward || ev.button == MappedInputManager::Button::Right) &&
-        ev.type == ButtonEventManager::PressType::Short) {
-      if (currentPage < totalPages - 1) {
-        currentPage++;
-        currentHeadingIndex = getHeadingIndexForOffset(pageOffsets[currentPage]);
-        globalReadingSessionTracker().onPageTurn();
-        requestUpdate();
-      } else {
-        saveProgress();
-        BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, txt ? txt->getPath() : std::string(),
-                                             std::string(), std::string());
-      }
-      return;
-    }
-  }
+void MdReaderActivity::onPageChanged() {
+  currentHeadingIndex = pageOffsets.empty() ? -1 : getHeadingIndexForOffset(pageOffsets[currentPage]);
 }
 
 void MdReaderActivity::initializeReader() {
@@ -929,7 +887,7 @@ void MdReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION ac
     case BA::BTN_PAGE_FORWARD:
       if (currentPage < totalPages - 1) {
         currentPage++;
-        currentHeadingIndex = pageOffsets.empty() ? -1 : getHeadingIndexForOffset(pageOffsets[currentPage]);
+        onPageChanged();
         globalReadingSessionTracker().onPageTurn();
         requestUpdate();
       }
@@ -937,7 +895,7 @@ void MdReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION ac
     case BA::BTN_PAGE_BACK:
       if (currentPage > 0) {
         currentPage--;
-        currentHeadingIndex = pageOffsets.empty() ? -1 : getHeadingIndexForOffset(pageOffsets[currentPage]);
+        onPageChanged();
         globalReadingSessionTracker().onPageTurn();
         requestUpdate();
       }
@@ -945,13 +903,13 @@ void MdReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION ac
     case BA::BTN_PAGE_FORWARD_10:
       currentPage += 10;
       clampPage();
-      currentHeadingIndex = pageOffsets.empty() ? -1 : getHeadingIndexForOffset(pageOffsets[currentPage]);
+      onPageChanged();
       requestUpdate();
       break;
     case BA::BTN_PAGE_BACK_10:
       currentPage -= 10;
       clampPage();
-      currentHeadingIndex = pageOffsets.empty() ? -1 : getHeadingIndexForOffset(pageOffsets[currentPage]);
+      onPageChanged();
       requestUpdate();
       break;
     case BA::BTN_NEXT_SECTION:
@@ -962,13 +920,13 @@ void MdReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION ac
       break;
     case BA::BTN_OPEN_TOC:
       if (!headings.empty()) {
-        currentHeadingIndex = pageOffsets.empty() ? -1 : getHeadingIndexForOffset(pageOffsets[currentPage]);
+        onPageChanged();
         startActivityForResult(
             std::make_unique<MdReaderTocSelectionActivity>(renderer, mappedInput, headings, currentHeadingIndex),
             [this](const ActivityResult& result) {
               if (!result.isCancelled) {
                 currentPage = std::get<PageResult>(result.data).page;
-                currentHeadingIndex = pageOffsets.empty() ? -1 : getHeadingIndexForOffset(pageOffsets[currentPage]);
+                onPageChanged();
                 requestUpdate();
               }
             });

--- a/src/activities/reader/MdReaderActivity.cpp
+++ b/src/activities/reader/MdReaderActivity.cpp
@@ -877,7 +877,10 @@ void MdReaderActivity::renderPage() {
   ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
 
   if (SETTINGS.textAntiAliasing) {
-    ReaderUtils::renderAntiAliased(renderer, [&]() { renderLines(); });
+    // Same AA pass as EpubReaderActivity — see TxtReaderActivity::renderPage()
+    // for why the legacy store/restore helper ghosted after swapBuffers().
+    renderer.setFastGrayscaleLut(SETTINGS.fastAntiAliasing);
+    renderer.renderGrayscalePlanesSequential([&](GfxRenderer::RenderMode) { renderLines(); });
   }
 }
 

--- a/src/activities/reader/MdReaderActivity.h
+++ b/src/activities/reader/MdReaderActivity.h
@@ -6,8 +6,7 @@
 #include <vector>
 
 #include "CrossPointSettings.h"
-#include "ReaderUtils.h"
-#include "activities/Activity.h"
+#include "LineReaderActivity.h"
 
 struct MdHeading {
   size_t offset = 0;
@@ -16,13 +15,7 @@ struct MdHeading {
   int pageIndex = -1;
 };
 
-class MdReaderActivity final : public Activity {
-  std::unique_ptr<Txt> txt;
-
-  int currentPage = 0;
-  int totalPages = 1;
-  int pagesUntilFullRefresh = 0;
-
+class MdReaderActivity final : public LineReaderActivity {
   // A single rendered line on screen (after word-wrapping)
   struct RenderedLine {
     std::vector<MdParser::Span> spans;
@@ -31,27 +24,12 @@ class MdReaderActivity final : public Activity {
     bool isCodeBlock = false;
   };
 
-  // Streaming reader state
-  std::vector<size_t> pageOffsets;
   std::vector<uint8_t> pageCodeBlockState;  // 1 if page starts inside a code block
   std::vector<RenderedLine> currentPageLines;
   std::vector<uint8_t> pageBuffer;
 
   std::vector<MdHeading> headings;
   int currentHeadingIndex = -1;
-
-  int linesPerPage = 0;
-  int viewportWidth = 0;
-  bool initialized = false;
-
-  // Cached settings for cache validation
-  int cachedFontId = 0;
-  uint8_t cachedScreenMargin = 0;
-  uint8_t cachedParagraphAlignment = CrossPointSettings::LEFT_ALIGN;
-  int cachedOrientedMarginTop = 0;
-  int cachedOrientedMarginRight = 0;
-  int cachedOrientedMarginBottom = 0;
-  int cachedOrientedMarginLeft = 0;
 
   // Indent constants (in pixels)
   static constexpr int LIST_INDENT = 20;
@@ -60,10 +38,6 @@ class MdReaderActivity final : public Activity {
 
   void renderPage();
   void renderStatusBar() const;
-  // See EpubReaderActivity for rationale — suppresses no-op minute-tick re-renders.
-  mutable int lastStatusBarPage = -1;
-  mutable int lastStatusBarBattery = -1;
-  mutable int lastStatusBarClockMinute = -1;
 
   void initializeReader();
   bool loadPageAtOffset(size_t offset, bool startInCodeBlock, std::vector<RenderedLine>& outLines, size_t& nextOffset,
@@ -71,13 +45,10 @@ class MdReaderActivity final : public Activity {
   void buildPageIndex();
   bool loadPageIndexCache();
   void savePageIndexCache() const;
-  void saveProgress() const;
-  void loadProgress();
   void scanHeadings();
   void assignHeadingPageNumbers();
   int getHeadingIndexForOffset(size_t offset) const;
   void jumpToHeading(bool next);
-  ReaderUtils::InputDrainGuard inputDrainGuard;
 
   // Word-wrap a parsed markdown line into one or more RenderedLines.
   // Returns true if all content was emitted, false if truncated by maxLines.
@@ -87,14 +58,13 @@ class MdReaderActivity final : public Activity {
   // Measure total pixel width of a span list
   int measureSpans(const std::vector<MdParser::Span>& spans) const;
 
+ protected:
+  void onReaderExit() override;
+
  public:
   explicit MdReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Txt> txt)
-      : Activity("MdReader", renderer, mappedInput), txt(std::move(txt)) {}
-  void onEnter() override;
-  void onExit() override;
+      : LineReaderActivity("MdReader", "MDR", renderer, mappedInput, std::move(txt)) {}
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
-  bool shouldSkipPeriodicUpdate() const override;
   void onButtonAction(CrossPointSettings::BUTTON_ACTION action) override;
 };

--- a/src/activities/reader/MdReaderActivity.h
+++ b/src/activities/reader/MdReaderActivity.h
@@ -60,11 +60,14 @@ class MdReaderActivity final : public LineReaderActivity {
 
  protected:
   void onReaderExit() override;
+  // Opens the ToC overlay when the document has headings.
+  bool onConfirmShortPress() override;
+  // Keeps currentHeadingIndex in sync with the page shown.
+  void onPageChanged() override;
 
  public:
   explicit MdReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Txt> txt)
       : LineReaderActivity("MdReader", "MDR", renderer, mappedInput, std::move(txt)) {}
-  void loop() override;
   void render(RenderLock&&) override;
   void onButtonAction(CrossPointSettings::BUTTON_ACTION action) override;
 };

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -3,7 +3,6 @@
 #include <CrossPointSettings.h>
 #include <GfxRenderer.h>
 #include <HalTiltSensor.h>
-#include <Logging.h>
 
 #include <cstdint>
 
@@ -174,33 +173,6 @@ inline void enforceExitFullRefresh(const GfxRenderer& renderer) {
   // Schedule the next displayed screen to use a half refresh, rather than refreshing
   // the current reader screen as it closes.
   renderer.setNextDisplayRefreshMode(HalDisplay::HALF_REFRESH);
-}
-
-// Grayscale anti-aliasing pass. Renders content twice (LSB + MSB) to build
-// the grayscale buffer. Only the content callback is re-rendered — status bars
-// and other overlays should be drawn before calling this.
-// Kept as a template to avoid std::function overhead; instantiated once per reader type.
-template <typename RenderFn>
-void renderAntiAliased(GfxRenderer& renderer, RenderFn&& renderFn) {
-  if (!renderer.storeBwBuffer()) {
-    LOG_ERR("READER", "Failed to store BW buffer for anti-aliasing");
-    return;
-  }
-
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-  renderFn();
-  renderer.copyGrayscaleLsbBuffers();
-
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-  renderFn();
-  renderer.copyGrayscaleMsbBuffers();
-
-  renderer.displayGrayBuffer();
-  renderer.setRenderMode(GfxRenderer::BW);
-
-  renderer.restoreBwBuffer();
 }
 
 }  // namespace ReaderUtils

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -2,8 +2,6 @@
 
 #include <FontCacheManager.h>
 #include <GfxRenderer.h>
-#include <HalClock.h>
-#include <HalPowerManager.h>
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Serialization.h>
@@ -15,12 +13,9 @@
 #include "CrossPointState.h"
 #include "FinishedBookActivity.h"
 #include "GlobalBookmarkIndex.h"
-#include "KOReaderDocumentId.h"
 #include "MappedInputManager.h"
-#include "ReaderActivity.h"
 #include "ReaderUtils.h"
 #include "ReadingSessionTracker.h"
-#include "RecentBooksStore.h"
 #include "StarredPagesActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -95,67 +90,17 @@ size_t parseAndWrapLines(const uint8_t* buffer, size_t chunkSize, size_t fileOff
 }
 }  // namespace
 
-void TxtReaderActivity::onEnter() {
-  Activity::onEnter();
-
-  // See ReaderUtils::InputDrainGuard — prevents wake-up power-button hold from leaking into
-  // the first detectPageTurn() call as a page turn or chapter skip.
-  inputDrainGuard.arm();
-
-  if (!txt) {
-    return;
-  }
-
-  {
-    RenderLock lock(*this);
-    ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
-  }
-
-  txt->setupCacheDir();
+void TxtReaderActivity::onReaderEnter() {
   applyPendingBookmarkJump();
-
-  // Load bookmarks for this file
   bookmarkStore.load(txt->getCachePath());
-
-  // Save current txt as last opened file and add to recent books
-  auto filePath = txt->getPath();
-  auto fileName = filePath.substr(filePath.rfind('/') + 1);
-  APP_STATE.openEpubPath = filePath;
-  APP_STATE.saveToFile();
-  const std::string txtSidecar = ReaderActivity::sidecarCoverPath(filePath);
-  const std::string txtCover = txtSidecar.empty() ? txt->getThumbBmpPath() : txtSidecar;
-  RECENT_BOOKS.addBook(filePath, fileName, "", "", txtCover);
-
-  // Start reading-stats session. Same filename-hash policy as EPUB so renamed
-  // files start fresh; author is unknown for plain TXT.
-  globalReadingSessionTracker().begin(KOReaderDocumentId::calculateFromFilename(filePath), fileName, "");
-
-  // Trigger first update
-  requestUpdate();
 }
 
-void TxtReaderActivity::onExit() {
-  Activity::onExit();
-
-  // Flush the stats session before tearing down the txt — same pattern as
-  // EpubReaderActivity::onExit().
-  globalReadingSessionTracker().end();
-
-  // Save bookmarks before exit
+void TxtReaderActivity::onReaderExit() {
   bookmarkStore.save();
   if (txt) {
     GLOBAL_BOOKMARKS.syncFromStore(bookmarkStore, txt->getPath(), txt->getCachePath(), txt->getTitle(), true);
   }
-
-  // Reset orientation back to portrait for the rest of the UI
-  renderer.setOrientation(GfxRenderer::Orientation::Portrait);
-
-  pageOffsets.clear();
   currentPageLines.clear();
-  APP_STATE.readerActivityLoadCount = 0;
-  APP_STATE.saveToFile();
-  UITheme::getInstance().getMutableTheme().onBookWillClose(txt ? txt->getPath() : "", nullptr, nullptr, txt.get());
-  txt.reset();
 }
 
 void TxtReaderActivity::loop() {
@@ -256,27 +201,7 @@ void TxtReaderActivity::initializeReader() {
     return;
   }
 
-  // Store current settings for cache validation
-  cachedFontId = SETTINGS.getTxtReaderFontId();
-  cachedScreenMargin = SETTINGS.screenMargin;
-  cachedParagraphAlignment = SETTINGS.paragraphAlignment;
-
-  // Calculate viewport dimensions
-  renderer.getOrientedViewableTRBL(&cachedOrientedMarginTop, &cachedOrientedMarginRight, &cachedOrientedMarginBottom,
-                                   &cachedOrientedMarginLeft);
-  cachedOrientedMarginTop += std::max(static_cast<int>(cachedScreenMargin), UITheme::getStatusBarTopHeight());
-  cachedOrientedMarginLeft += cachedScreenMargin;
-  cachedOrientedMarginRight += cachedScreenMargin;
-  cachedOrientedMarginBottom += std::max(static_cast<int>(cachedScreenMargin), UITheme::getStatusBarBottomHeight());
-
-  viewportWidth = renderer.getScreenWidth() - cachedOrientedMarginLeft - cachedOrientedMarginRight;
-  const int viewportHeight = renderer.getScreenHeight() - cachedOrientedMarginTop - cachedOrientedMarginBottom;
-  const int lineHeight = renderer.getLineHeight(cachedFontId);
-
-  linesPerPage = viewportHeight / lineHeight;
-  if (linesPerPage < 1) linesPerPage = 1;
-
-  LOG_DBG("TRS", "Viewport: %dx%d, lines per page: %d", viewportWidth, viewportHeight, linesPerPage);
+  computeViewportLayout();
 
   // Try to load cached page index first
   if (!loadPageIndexCache()) {
@@ -472,49 +397,7 @@ void TxtReaderActivity::renderStatusBar() const {
   const bool isStarred = bookmarkStore.has(0, static_cast<uint16_t>(currentPage));
   GUI.drawStatusBar(renderer, progress, currentPage + 1, totalPages, title, 0, isStarred);
 
-  lastStatusBarPage = currentPage + 1;
-  lastStatusBarBattery = SETTINGS.statusBarBattery ? static_cast<int>(powerManager.getBatteryPercentage()) : -1;
-  if (SETTINGS.useClock && SETTINGS.statusBarClock && HalClock::isSynced()) {
-    const time_t now = HalClock::now();
-    lastStatusBarClockMinute = now > 0 ? static_cast<int>(now / 60) : -1;
-  } else {
-    lastStatusBarClockMinute = -1;
-  }
-}
-
-bool TxtReaderActivity::shouldSkipPeriodicUpdate() const {
-  if (lastStatusBarPage < 0) return false;
-  if (currentPage + 1 != lastStatusBarPage) return false;
-  if (SETTINGS.statusBarBattery) {
-    if (static_cast<int>(powerManager.getBatteryPercentage()) != lastStatusBarBattery) return false;
-  }
-  if (SETTINGS.useClock && SETTINGS.statusBarClock && HalClock::isSynced()) {
-    const time_t now = HalClock::now();
-    const int minute = now > 0 ? static_cast<int>(now / 60) : -1;
-    if (minute != lastStatusBarClockMinute) return false;
-  }
-  return true;
-}
-
-void TxtReaderActivity::saveProgress() const {
-  FsFile f;
-  if (Storage.openFileForWrite("TRS", txt->getCachePath() + "/progress.bin", f)) {
-    // 7-byte format: page(2 bytes LE) + file offset(4 bytes LE) + overallPercent(1 byte)
-    // The offset lets drawCurrentPageToBuffer render without requiring index.bin.
-    const size_t offset = (currentPage < static_cast<int>(pageOffsets.size())) ? pageOffsets[currentPage] : 0;
-    const uint8_t percent = ReaderUtils::pageProgressPercentByte(currentPage, totalPages);
-    uint8_t data[7];
-    data[0] = currentPage & 0xFF;
-    data[1] = (currentPage >> 8) & 0xFF;
-    data[2] = offset & 0xFF;
-    data[3] = (offset >> 8) & 0xFF;
-    data[4] = (offset >> 16) & 0xFF;
-    data[5] = (offset >> 24) & 0xFF;
-    data[6] = percent;
-    f.write(data, 7);
-    f.close();
-    globalReadingSessionTracker().updateProgress(percent);
-  }
+  noteStatusBarRendered();
 }
 
 void TxtReaderActivity::applyPendingBookmarkJump() {
@@ -542,24 +425,6 @@ void TxtReaderActivity::applyPendingBookmarkJump() {
   if (persisted) {
     jump.clear();
     APP_STATE.saveToFile();
-  }
-}
-
-void TxtReaderActivity::loadProgress() {
-  FsFile f;
-  if (Storage.openFileForRead("TRS", txt->getCachePath() + "/progress.bin", f)) {
-    uint8_t data[4];
-    if (f.read(data, 4) == 4) {
-      currentPage = data[0] + (data[1] << 8);
-      if (currentPage >= totalPages) {
-        currentPage = totalPages - 1;
-      }
-      if (currentPage < 0) {
-        currentPage = 0;
-      }
-      LOG_DBG("TRS", "Loaded progress: page %d/%d", currentPage, totalPages);
-    }
-    f.close();
   }
 }
 
@@ -708,39 +573,17 @@ bool TxtReaderActivity::drawCurrentPageToBuffer(const std::string& filePath, Gfx
   }
 
   // Apply the reader orientation so margins match what the reader would produce
-  switch (SETTINGS.orientation) {
-    case CrossPointSettings::ORIENTATION::PORTRAIT:
-      renderer.setOrientation(GfxRenderer::Orientation::Portrait);
-      break;
-    case CrossPointSettings::ORIENTATION::LANDSCAPE_CW:
-      renderer.setOrientation(GfxRenderer::Orientation::LandscapeClockwise);
-      break;
-    case CrossPointSettings::ORIENTATION::INVERTED:
-      renderer.setOrientation(GfxRenderer::Orientation::PortraitInverted);
-      break;
-    case CrossPointSettings::ORIENTATION::LANDSCAPE_CCW:
-      renderer.setOrientation(GfxRenderer::Orientation::LandscapeCounterClockwise);
-      break;
-    default:
-      break;
-  }
+  ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
 
-  // Compute layout values that match what initializeReader() produces
+  // Compute layout values that match what computeViewportLayout() produces
   const int fontId = SETTINGS.getTxtReaderFontId();
   const uint8_t screenMargin = SETTINGS.screenMargin;
   const uint8_t paragraphAlignment = SETTINGS.paragraphAlignment;
 
-  int marginTop, marginRight, marginBottom, marginLeft;
-  renderer.getOrientedViewableTRBL(&marginTop, &marginRight, &marginBottom, &marginLeft);
-  marginTop += std::max(static_cast<int>(screenMargin), UITheme::getStatusBarTopHeight());
-  marginLeft += screenMargin;
-  marginRight += screenMargin;
-  marginBottom += std::max(static_cast<int>(screenMargin), UITheme::getStatusBarBottomHeight());
-
-  const int vw = renderer.getScreenWidth() - marginLeft - marginRight;
-  const int vh = renderer.getScreenHeight() - marginTop - marginBottom;
+  const TextLayout layout = computeTextLayout(renderer, fontId, screenMargin);
+  const int vw = layout.viewportWidth;
   const int lineHeight = renderer.getLineHeight(fontId);
-  const int linesPerPage = std::max(1, vh / lineHeight);
+  const int linesPerPage = layout.linesPerPage;
 
   // Step 1: Try to read the saved page and its file offset from progress.bin.
   // The 6-byte format (written by saveProgress) stores: page(2) + offset(4).
@@ -846,16 +689,16 @@ bool TxtReaderActivity::drawCurrentPageToBuffer(const std::string& filePath, Gfx
 
   // Render lines to frame buffer (no displayBuffer call)
   renderer.clearScreen();
-  int y = marginTop;
+  int y = layout.marginTop;
   for (const auto& line : pageLines) {
     if (!line.empty()) {
-      int x = marginLeft;
+      int x = layout.marginLeft;
       switch (paragraphAlignment) {
         case CrossPointSettings::CENTER_ALIGN:
-          x = marginLeft + (vw - renderer.getTextWidth(fontId, line.c_str())) / 2;
+          x = layout.marginLeft + (vw - renderer.getTextWidth(fontId, line.c_str())) / 2;
           break;
         case CrossPointSettings::RIGHT_ALIGN:
-          x = marginLeft + vw - renderer.getTextWidth(fontId, line.c_str());
+          x = layout.marginLeft + vw - renderer.getTextWidth(fontId, line.c_str());
           break;
         default:
           break;

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -486,7 +486,14 @@ void TxtReaderActivity::renderPage() {
   ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
 
   if (SETTINGS.textAntiAliasing) {
-    ReaderUtils::renderAntiAliased(renderer, [&renderLines]() { renderLines(); });
+    // Same AA pass as EpubReaderActivity: displayBuffer() above ended with
+    // swapBuffers(), so the write framebuffer now holds the stale previous
+    // frame. renderGrayscalePlanesSequential() reseeds the controller baseline
+    // from frameBufferActive (the just-displayed page); snapshotting/restoring
+    // the write framebuffer instead would diff the next fast refresh against
+    // the previous page and ghost heavily.
+    renderer.setFastGrayscaleLut(SETTINGS.fastAntiAliasing);
+    renderer.renderGrayscalePlanesSequential([&](GfxRenderer::RenderMode) { renderLines(); });
   }
   // scope destructor clears font cache via FontCacheManager
 }

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -11,7 +11,6 @@
 
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
-#include "FinishedBookActivity.h"
 #include "GlobalBookmarkIndex.h"
 #include "MappedInputManager.h"
 #include "ReaderUtils.h"
@@ -103,97 +102,22 @@ void TxtReaderActivity::onReaderExit() {
   currentPageLines.clear();
 }
 
-void TxtReaderActivity::loop() {
-  const bool drainActive = inputDrainGuard.shouldDrain(mappedInput);
-  if (!drainActive && drainWasActive) {
-    halTiltSensor.clearPendingEvents();
+bool TxtReaderActivity::onConfirmShortPress() {
+  if (bookmarkStore.isEmpty()) {
+    return false;
   }
-  drainWasActive = drainActive;
-
-  if (drainActive) {
-    buttonEvents.drain();
-    return;
-  }
-
-  ButtonEventManager::ButtonEvent ev;
-  while (buttonEvents.consumeEvent(ev)) {
-    if (ev.button == MappedInputManager::Button::Back) {
-      if (ev.type == ButtonEventManager::PressType::Long) {
-        ReaderUtils::enforceExitFullRefresh(renderer);
-        onGoHome();
-        return;
-      }
-      if (ev.type == ButtonEventManager::PressType::Short) {
-        ReaderUtils::enforceExitFullRefresh(renderer);
-        finish();
-        return;
-      }
-    }
-
-    if (!bookmarkStore.isEmpty() && ev.button == MappedInputManager::Button::Confirm &&
-        ev.type == ButtonEventManager::PressType::Short) {
-      ReaderUtils::enforceExitFullRefresh(renderer);
-      startActivityForResult(std::make_unique<StarredPagesActivity>(renderer, mappedInput, bookmarkStore),
-                             [this](const ActivityResult& result) {
-                               if (!result.isCancelled) {
-                                 const auto& starred = std::get<StarredPageResult>(result.data);
-                                 currentPage = starred.pageNumber;
-                                 if (currentPage >= totalPages) currentPage = totalPages - 1;
-                                 if (currentPage < 0) currentPage = 0;
-                               }
-                               requestUpdate();
-                             });
-      return;
-    }
-
-    if ((ev.button == MappedInputManager::Button::PageBack || ev.button == MappedInputManager::Button::Left) &&
-        ev.type == ButtonEventManager::PressType::Short) {
-      if (currentPage > 0) {
-        currentPage--;
-        globalReadingSessionTracker().onPageTurn();
-        requestUpdate();
-      }
-      return;
-    }
-
-    if ((ev.button == MappedInputManager::Button::PageForward || ev.button == MappedInputManager::Button::Right) &&
-        ev.type == ButtonEventManager::PressType::Short) {
-      if (currentPage < totalPages - 1) {
-        currentPage++;
-        globalReadingSessionTracker().onPageTurn();
-        requestUpdate();
-      } else {
-        launchFinishedBookFlow();
-      }
-      return;
-    }
-  }
-
-  auto [prevTriggered, nextTriggered] = ReaderUtils::detectPageTurn(mappedInput);
-  if (!prevTriggered && !nextTriggered) {
-    return;
-  }
-
-  if (prevTriggered) {
-    if (currentPage > 0) {
-      currentPage--;
-      globalReadingSessionTracker().onPageTurn();
-      requestUpdate();
-    }
-  } else if (nextTriggered) {
-    if (currentPage < totalPages - 1) {
-      currentPage++;
-      globalReadingSessionTracker().onPageTurn();
-      requestUpdate();
-    } else {
-      launchFinishedBookFlow();
-    }
-  }
-}
-
-void TxtReaderActivity::launchFinishedBookFlow() {
-  saveProgress();
-  BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, txt->getPath(), std::string(), std::string());
+  ReaderUtils::enforceExitFullRefresh(renderer);
+  startActivityForResult(std::make_unique<StarredPagesActivity>(renderer, mappedInput, bookmarkStore),
+                         [this](const ActivityResult& result) {
+                           if (!result.isCancelled) {
+                             const auto& starred = std::get<StarredPageResult>(result.data);
+                             currentPage = starred.pageNumber;
+                             if (currentPage >= totalPages) currentPage = totalPages - 1;
+                             if (currentPage < 0) currentPage = 0;
+                           }
+                           requestUpdate();
+                         });
+  return true;
 }
 
 void TxtReaderActivity::initializeReader() {

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -248,42 +248,7 @@ void TxtReaderActivity::loop() {
 
 void TxtReaderActivity::launchFinishedBookFlow() {
   saveProgress();
-  const std::string currentBookPath = txt->getPath();
-  const std::string nextBookPath = BookFinished::findNextBookInDirectory(currentBookPath, std::string(), std::string());
-
-  startActivityForResult(std::make_unique<FinishedBookActivity>(renderer, mappedInput, currentBookPath, nextBookPath),
-                         [this, currentBookPath, nextBookPath](const ActivityResult& result) {
-                           if (result.isCancelled) {
-                             requestUpdate();
-                             return;
-                           }
-                           globalReadingSessionTracker().markFinished();
-                           const auto& menuResult = std::get<MenuResult>(result.data);
-                           if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::GoHome)) {
-                             if (SETTINGS.moveFinishedBooksToCompleted) {
-                               std::string movedPath;
-                               BookFinished::moveFinishedBookToCompleted(currentBookPath, movedPath);
-                             }
-                             if (SETTINGS.removeFinishedBooksFromRecents) {
-                               RECENT_BOOKS.removeBook(currentBookPath);
-                             }
-                             activityManager.goHome();
-                             return;
-                           }
-                           if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::OpenNextBook) &&
-                               !nextBookPath.empty()) {
-                             if (SETTINGS.moveFinishedBooksToCompleted) {
-                               std::string movedPath;
-                               BookFinished::moveFinishedBookToCompleted(currentBookPath, movedPath);
-                             }
-                             if (SETTINGS.removeFinishedBooksFromRecents) {
-                               RECENT_BOOKS.removeBook(currentBookPath);
-                             }
-                             activityManager.goToReader(nextBookPath);
-                             return;
-                           }
-                           requestUpdate();
-                         });
+  BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, txt->getPath(), std::string(), std::string());
 }
 
 void TxtReaderActivity::initializeReader() {

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -6,65 +6,36 @@
 
 #include "BookmarkStore.h"
 #include "CrossPointSettings.h"
-#include "ReaderUtils.h"
-#include "activities/Activity.h"
+#include "LineReaderActivity.h"
 
-class TxtReaderActivity final : public Activity {
-  std::unique_ptr<Txt> txt;
-
-  int currentPage = 0;
-  int totalPages = 1;
-  int pagesUntilFullRefresh = 0;
-  ReaderUtils::InputDrainGuard inputDrainGuard;
-  bool drainWasActive = false;
-
+class TxtReaderActivity final : public LineReaderActivity {
   // Bookmarks (starred pages)
   BookmarkStore bookmarkStore;
 
-  // Streaming text reader - stores file offsets for each page
-  std::vector<size_t> pageOffsets;  // File offset for start of each page
   std::vector<std::string> currentPageLines;
-  int linesPerPage = 0;
-  int viewportWidth = 0;
-  bool initialized = false;
-
-  // Cached settings for cache validation (different fonts/margins require re-indexing)
-  int cachedFontId = 0;
-  uint8_t cachedScreenMargin = 0;
-  uint8_t cachedParagraphAlignment = CrossPointSettings::LEFT_ALIGN;
-  int cachedOrientedMarginTop = 0;
-  int cachedOrientedMarginRight = 0;
-  int cachedOrientedMarginBottom = 0;
-  int cachedOrientedMarginLeft = 0;
 
   void renderPage();
   void renderStatusBar() const;
-  // See EpubReaderActivity for rationale — suppresses no-op minute-tick re-renders.
-  mutable int lastStatusBarPage = -1;
-  mutable int lastStatusBarBattery = -1;
-  mutable int lastStatusBarClockMinute = -1;
 
   void initializeReader();
   bool loadPageAtOffset(size_t offset, std::vector<std::string>& outLines, size_t& nextOffset);
   void buildPageIndex();
   bool loadPageIndexCache();
   void savePageIndexCache() const;
-  void saveProgress() const;
-  void loadProgress();
   // Consume a persisted bookmark-jump request (from GlobalBookmarksActivity) for
   // this TXT file. Rewrites progress.bin before initializeReader() reads it.
   void applyPendingBookmarkJump();
   void launchFinishedBookFlow();
 
+ protected:
+  void onReaderEnter() override;
+  void onReaderExit() override;
+
  public:
   explicit TxtReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Txt> txt)
-      : Activity("TxtReader", renderer, mappedInput), txt(std::move(txt)) {}
-  void onEnter() override;
-  void onExit() override;
+      : LineReaderActivity("TxtReader", "TRS", renderer, mappedInput, std::move(txt)) {}
   void loop() override;
   void render(RenderLock&&) override;
-  bool isReaderActivity() const override { return true; }
-  bool shouldSkipPeriodicUpdate() const override;
   void onButtonAction(CrossPointSettings::BUTTON_ACTION action) override;
 
   // Renders the last saved page to the frame buffer without flushing to display.

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -25,16 +25,16 @@ class TxtReaderActivity final : public LineReaderActivity {
   // Consume a persisted bookmark-jump request (from GlobalBookmarksActivity) for
   // this TXT file. Rewrites progress.bin before initializeReader() reads it.
   void applyPendingBookmarkJump();
-  void launchFinishedBookFlow();
 
  protected:
   void onReaderEnter() override;
   void onReaderExit() override;
+  // Opens the starred-pages overlay when bookmarks exist.
+  bool onConfirmShortPress() override;
 
  public:
   explicit TxtReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Txt> txt)
       : LineReaderActivity("TxtReader", "TRS", renderer, mappedInput, std::move(txt)) {}
-  void loop() override;
   void render(RenderLock&&) override;
   void onButtonAction(CrossPointSettings::BUTTON_ACTION action) override;
 

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -147,43 +147,7 @@ void XtcReaderActivity::loop() {
   if (currentPage >= xtc->getPageCount()) {
     if (nextTriggered) {
       saveProgress();
-      const std::string currentBookPath = xtc->getPath();
-      const std::string nextBookPath =
-          BookFinished::findNextBookInDirectory(currentBookPath, std::string(), std::string());
-      startActivityForResult(
-          std::make_unique<FinishedBookActivity>(renderer, mappedInput, currentBookPath, nextBookPath),
-          [this, nextBookPath, currentBookPath](const ActivityResult& result) {
-            if (result.isCancelled) {
-              requestUpdate();
-              return;
-            }
-            globalReadingSessionTracker().markFinished();
-            const auto& menuResult = std::get<MenuResult>(result.data);
-            if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::GoHome)) {
-              if (SETTINGS.moveFinishedBooksToCompleted) {
-                std::string movedPath;
-                BookFinished::moveFinishedBookToCompleted(currentBookPath, movedPath);
-              }
-              if (SETTINGS.removeFinishedBooksFromRecents) {
-                RECENT_BOOKS.removeBook(currentBookPath);
-              }
-              activityManager.goHome();
-              return;
-            }
-            if (menuResult.action == static_cast<int>(BookFinished::FinishedBookAction::OpenNextBook) &&
-                !nextBookPath.empty()) {
-              if (SETTINGS.moveFinishedBooksToCompleted) {
-                std::string movedPath;
-                BookFinished::moveFinishedBookToCompleted(currentBookPath, movedPath);
-              }
-              if (SETTINGS.removeFinishedBooksFromRecents) {
-                RECENT_BOOKS.removeBook(currentBookPath);
-              }
-              activityManager.goToReader(nextBookPath);
-              return;
-            }
-            requestUpdate();
-          });
+      BookFinished::launchFinishedBookFlow(*this, renderer, mappedInput, xtc->getPath(), std::string(), std::string());
     } else {
       currentPage = xtc->getPageCount() - 1;
       requestUpdate();


### PR DESCRIPTION
## Summary

Extracts the duplicated scaffolding of `TxtReaderActivity` and `MdReaderActivity` into a shared `LineReaderActivity` base and unifies their input handling. Net **−533/+75** across the two readers plus the new ~290-line base; the readers now only carry their format-specific parsing, rendering, and navigation overlays.

Structured as single-concern commits, each buildable on its own:

1. **`44d52b91` — extract LineReaderActivity base** (behavior-preserving): enter/exit lifecycle (orientation, recents, stats session, theme close), viewport/margin layout, `progress.bin` save/load, status-bar freshness tracking behind `shouldSkipPeriodicUpdate()`. Format extras hook in via `onReaderEnter()`/`onReaderExit()`. `TxtReaderActivity::drawCurrentPageToBuffer` now reuses the shared `computeTextLayout()`/`applyOrientation()` instead of hand-rolled copies.
2. **`307a7b21` — move the shared input loop into the base** (behavior-identical for TXT): drain guard with tilt-event clearing, back-button handling, page buttons, `detectPageTurn()`, finished-book flow. Subclasses hook in via `onConfirmShortPress()` (TXT: starred pages, MD: ToC) and `onPageChanged()` (MD: current-heading tracking).
3. **`9794c82d` — MdReader adopts the shared loop** (⚠️ user-visible behavior change, deliberate — MD follows TXT's lead):
   - Back short **closes the reader**, Back long **goes home** (was: short=home, long=file browser), both now scheduling the exit half-refresh.
   - **Tilt page turns and default button-release turns now work in MD** — it never called `ReaderUtils::detectPageTurn()` before.
   - The finished-book flow also triggers from a tilt/release turn on the last page, and the wake drain clears pending tilt events.

Also carries two earlier commits on this branch: the AA-pass refresh-baseline fix (`6f8c06fc`) and the shared finished-book flow helper (`736cea25`).

## Verification

- `pio run` (default env) builds at every commit
- 130/130 host unit tests pass
- `pio check` (cppcheck, CI flags) clean
- clang-format clean
- RAM: base class adds no new members beyond what both readers already carried; no new allocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)