### PR TITLE
fix: Resolve stale highlights in the recent-books grid partial repaint

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -151,6 +151,12 @@ class GfxRenderer {
   int getScreenHeight() const;
   void displayBuffer(HalDisplay::RefreshMode refreshMode = HalDisplay::FAST_REFRESH) const;
   void setNextDisplayRefreshMode(HalDisplay::RefreshMode refreshMode) const;
+  // Make the write framebuffer match the currently displayed frame. Call before
+  // a partial repaint that patches a few regions and re-displays without
+  // re-rendering the full frame: displayBuffer() ends with swapBuffers(), so
+  // the write buffer otherwise holds the frame from two refreshes ago. No-op in
+  // single-buffer mode, where the write buffer is already the displayed frame.
+  void syncWriteBufferFromDisplayed() const { display.syncWriteBufferFromActive(); }
 
   // Temporarily free the secondary (previous-frame) buffer (~52 KB) during
   // operations that don't need it (e.g. chapter compilation). BW rendering

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -106,6 +106,8 @@ void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
 
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
+void HalDisplay::syncWriteBufferFromActive() const { einkDisplay.syncWriteBufferFromActive(); }
+
 void HalDisplay::releaseBuffers() { einkDisplay.releaseBuffers(); }
 
 bool HalDisplay::releaseSecondaryBuffer() { return einkDisplay.releaseSecondaryBuffer(); }

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -61,6 +61,12 @@ class HalDisplay {
   // Access to frame buffer
   uint8_t* getFrameBuffer() const;
 
+  // Copy the just-displayed frame back into the write framebuffer. The display
+  // path ends with a buffer swap, so the write buffer otherwise holds the frame
+  // from two refreshes ago — partial repaints that patch a few regions and
+  // re-display must call this first. No-op in single-buffer mode.
+  void syncWriteBufferFromActive() const;
+
   // Release both frame buffers back to the heap (~52KB on X3, ~48KB on X4 each,
   // so ~104KB / ~96KB total). Call only after the final displayBuffer(); the
   // e-ink controller retains the image in its own RAM. No display operations

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -455,6 +455,11 @@ void RecentBooksActivity::renderGridView(RenderLock&&) {
   const int prevPage = prevSelectorIndex >= 0 ? (prevSelectorIndex / GRID_COLS / visibleRows) : -1;
   const int curPage = selectedRow / visibleRows;
   if (!fullRedrawNeeded && prevSelectorIndex >= 0 && prevSelectorIndex != selectorIndex && prevPage == curPage) {
+    // The write framebuffer holds the frame from two refreshes ago (displayBuffer()
+    // swaps buffers), which still shows an older selection. Resync it to the
+    // displayed frame before patching just the two affected cells; without this,
+    // the stale highlight ships back to the panel and multiple cells appear selected.
+    renderer.syncWriteBufferFromDisplayed();
     int cx, cy;
     cellPos(prevSelectorIndex, cx, cy);
     renderGridCell(prevSelectorIndex, false, cx, cy, tw, th, labelW);


### PR DESCRIPTION
## Summary

Fixes the 3x3 recent-books grid showing **multiple highlighted entries** when navigating.

**Root cause:** the grid's selection fast path repaints only two cells (deselect previous, select current) and re-displays, assuming the write framebuffer still holds what's on screen. It doesn't — `displayBuffer()` ends with `swapBuffers()`, so the write buffer holds the frame from **two refreshes ago**, including an older selection highlight the two-cell patch never clears. Each selection move leapfrogs that stale highlight between the two buffer slots, producing the multi-highlight artifact. The same staleness could briefly revert a freshly generated cover thumbnail to its "Loading…" placeholder.

**Fix:** resync the write buffer to the displayed frame at the top of the partial fast path:

- New `EInkDisplay::syncWriteBufferFromActive()` in the SDK (submodule bump → jpirnay/crosspoint-xdk#2): a guarded ≤52KB RAM-to-RAM memcpy, no-op in single-buffer mode where the write buffer is already the displayed frame.
- Exposed through the HAL (`HalDisplay`) and `GfxRenderer::syncWriteBufferFromDisplayed()`, per the layering rules.
- One call site in `RecentBooksActivity::renderGridView()`'s partial path; the full-redraw path is unaffected (it `clearScreen()`s and repaints everything).

⚠️ **Depends on jpirnay/crosspoint-xdk#2** — the submodule pointer references that PR's head commit. Merge the SDK PR first (with a merge commit, not squash, so the pinned commit stays branch-reachable — or re-bump the pointer after merging).

## Verification

- `pio run` (default env) builds
- `pio check` (cppcheck, CI flags) clean, clang-format clean
- 130/130 host unit tests unaffected (display stack isn't compiled host-side)
- No new allocations; cost per selection move is one ≤52KB memcpy, negligible next to the e-ink refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)