### PR TITLE
fix: Harden OTA release metadata fetch and parsing

### DIFF
--- a/lib/JsonParser/ReleaseJsonParser.cpp
+++ b/lib/JsonParser/ReleaseJsonParser.cpp
@@ -1,0 +1,222 @@
+#include "ReleaseJsonParser.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+void safeCopy(char* dst, size_t dstSize, const char* src, size_t srcLen) {
+  size_t n = srcLen < dstSize - 1 ? srcLen : dstSize - 1;
+  memcpy(dst, src, n);
+  dst[n] = '\0';
+}
+
+}  // namespace
+
+ReleaseJsonParser::ReleaseJsonParser()
+    : parser(JsonCallbacks{this, sOnKey, sOnString, sOnNumber, sOnBool, sOnNull, sOnObjectStart, sOnObjectEnd,
+                           sOnArrayStart, sOnArrayEnd}) {
+  reset();
+}
+
+void ReleaseJsonParser::reset() {
+  parser.reset();
+  position = Position::TOP_LEVEL;
+  lastKey = LastKey::NONE;
+  depth = 0;
+  assetDepth = 0;
+  tagName[0] = '\0';
+  firmwareUrl[0] = '\0';
+  firmwareSize = 0;
+  tagFound = false;
+  firmwareFound = false;
+  topLevelArray = false;
+  currentAssetName[0] = '\0';
+  currentAssetUrl[0] = '\0';
+  currentAssetSize = 0;
+}
+
+bool ReleaseJsonParser::inReleaseObject() const {
+  if (!topLevelArray) {
+    return depth == 1;
+  }
+  return depth == 2;
+}
+
+void ReleaseJsonParser::feed(const char* data, size_t len) { parser.feed(data, len); }
+
+bool ReleaseJsonParser::foundTag() const { return tagFound; }
+bool ReleaseJsonParser::foundFirmware() const { return firmwareFound; }
+const char* ReleaseJsonParser::getTagName() const { return tagName; }
+const char* ReleaseJsonParser::getFirmwareUrl() const { return firmwareUrl; }
+size_t ReleaseJsonParser::getFirmwareSize() const { return firmwareSize; }
+
+void ReleaseJsonParser::commitAsset() {
+  if (strcmp(currentAssetName, "firmware.bin") == 0) {
+    memcpy(firmwareUrl, currentAssetUrl, sizeof(firmwareUrl));
+    firmwareSize = currentAssetSize;
+    firmwareFound = true;
+  }
+  currentAssetName[0] = '\0';
+  currentAssetUrl[0] = '\0';
+  currentAssetSize = 0;
+}
+
+void ReleaseJsonParser::sOnKey(void* ctx, const char* key, size_t len) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->inReleaseObject()) {
+        if (len == 8 && memcmp(key, "tag_name", 8) == 0)
+          self->lastKey = LastKey::TAG_NAME;
+        else if (len == 6 && memcmp(key, "assets", 6) == 0)
+          self->lastKey = LastKey::ASSETS;
+        else
+          self->lastKey = LastKey::NONE;
+      }
+      break;
+    case Position::IN_ASSET_OBJECT:
+      if (self->assetDepth == 1) {
+        if (len == 4 && memcmp(key, "name", 4) == 0)
+          self->lastKey = LastKey::ASSET_NAME;
+        else if (len == 20 && memcmp(key, "browser_download_url", 20) == 0)
+          self->lastKey = LastKey::ASSET_URL;
+        else if (len == 4 && memcmp(key, "size", 4) == 0)
+          self->lastKey = LastKey::ASSET_SIZE;
+        else
+          self->lastKey = LastKey::NONE;
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnString(void* ctx, const char* value, size_t len) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->lastKey) {
+    case LastKey::TAG_NAME:
+      if (self->position == Position::TOP_LEVEL && self->inReleaseObject()) {
+        safeCopy(self->tagName, sizeof(self->tagName), value, len);
+        self->tagFound = true;
+      }
+      break;
+    case LastKey::ASSET_NAME:
+      if (self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1)
+        safeCopy(self->currentAssetName, sizeof(self->currentAssetName), value, len);
+      break;
+    case LastKey::ASSET_URL:
+      if (self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1)
+        safeCopy(self->currentAssetUrl, sizeof(self->currentAssetUrl), value, len);
+      break;
+    default:
+      break;
+  }
+  self->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnNumber(void* ctx, const char* value, size_t /*len*/) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  if (self->lastKey == LastKey::ASSET_SIZE && self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1) {
+    self->currentAssetSize = static_cast<size_t>(strtoul(value, nullptr, 10));
+  }
+  self->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnBool(void* ctx, bool /*value*/) {
+  static_cast<ReleaseJsonParser*>(ctx)->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnNull(void* ctx) { static_cast<ReleaseJsonParser*>(ctx)->lastKey = LastKey::NONE; }
+
+void ReleaseJsonParser::sOnObjectStart(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      self->depth++;
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSETS_ARRAY:
+      self->position = Position::IN_ASSET_OBJECT;
+      self->assetDepth = 1;
+      self->currentAssetName[0] = '\0';
+      self->currentAssetUrl[0] = '\0';
+      self->currentAssetSize = 0;
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth++;
+      self->lastKey = LastKey::NONE;
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnObjectEnd(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth > 0) self->depth--;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth--;
+      if (self->assetDepth == 0) {
+        self->commitAsset();
+        self->position = Position::IN_ASSETS_ARRAY;
+      }
+      self->lastKey = LastKey::NONE;
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnArrayStart(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth == 0) {
+        self->topLevelArray = true;
+        self->depth++;
+      } else if (self->lastKey == LastKey::ASSETS && self->inReleaseObject()) {
+        self->position = Position::IN_ASSETS_ARRAY;
+      } else {
+        self->depth++;
+      }
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth++;
+      self->lastKey = LastKey::NONE;
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnArrayEnd(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth > 0) {
+        self->depth--;
+      }
+      if (self->topLevelArray && self->depth == 0) {
+        self->topLevelArray = false;
+      }
+      break;
+    case Position::IN_ASSETS_ARRAY:
+      self->position = Position::TOP_LEVEL;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth--;
+      self->lastKey = LastKey::NONE;
+      break;
+  }
+}

--- a/lib/JsonParser/ReleaseJsonParser.h
+++ b/lib/JsonParser/ReleaseJsonParser.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "StreamingJsonParser.h"
+
+// Ported from crosspoint-reader/crosspoint-reader (MIT),
+// initially authored in PR #1810 by znelson and contributors.
+class ReleaseJsonParser {
+ public:
+  ReleaseJsonParser();
+
+  ReleaseJsonParser(const ReleaseJsonParser&) = delete;
+  ReleaseJsonParser& operator=(const ReleaseJsonParser&) = delete;
+
+  void reset();
+  void feed(const char* data, size_t len);
+
+  bool foundTag() const;
+  bool foundFirmware() const;
+  const char* getTagName() const;
+  const char* getFirmwareUrl() const;
+  size_t getFirmwareSize() const;
+
+ private:
+  bool inReleaseObject() const;
+
+  enum class Position : uint8_t {
+    TOP_LEVEL,
+    IN_ASSETS_ARRAY,
+    IN_ASSET_OBJECT,
+  };
+
+  enum class LastKey : uint8_t {
+    NONE,
+    TAG_NAME,
+    ASSETS,
+    ASSET_NAME,
+    ASSET_URL,
+    ASSET_SIZE,
+  };
+
+  static void sOnKey(void* ctx, const char* key, size_t len);
+  static void sOnString(void* ctx, const char* value, size_t len);
+  static void sOnNumber(void* ctx, const char* value, size_t len);
+  static void sOnBool(void* ctx, bool value);
+  static void sOnNull(void* ctx);
+  static void sOnObjectStart(void* ctx);
+  static void sOnObjectEnd(void* ctx);
+  static void sOnArrayStart(void* ctx);
+  static void sOnArrayEnd(void* ctx);
+
+  void commitAsset();
+
+  StreamingJsonParser parser;
+
+  Position position;
+  LastKey lastKey;
+  uint8_t depth;
+  uint8_t assetDepth;
+
+  char tagName[32];
+  char firmwareUrl[512];
+  size_t firmwareSize;
+  bool tagFound;
+  bool firmwareFound;
+
+  char currentAssetName[32];
+  char currentAssetUrl[512];
+  bool topLevelArray;
+  size_t currentAssetSize;
+};

--- a/lib/JsonParser/StreamingJsonParser.cpp
+++ b/lib/JsonParser/StreamingJsonParser.cpp
@@ -1,0 +1,248 @@
+#include "StreamingJsonParser.h"
+
+#include <cstring>
+
+StreamingJsonParser::StreamingJsonParser(const JsonCallbacks& callbacks) : cb(callbacks) { reset(); }
+
+void StreamingJsonParser::reset() {
+  tokenLen = 0;
+  state = State::SCANNING;
+  expectingValue = false;
+  escaped = false;
+  tokenOverflow = false;
+  error = false;
+  nestingDepth = 0;
+  literalLen = 0;
+  literalPos = 0;
+}
+
+void StreamingJsonParser::feed(const char* data, size_t len) {
+  for (size_t i = 0; i < len && !error; ++i) {
+    char c = data[i];
+    switch (state) {
+      case State::SCANNING:
+        handleScanning(c);
+        break;
+      case State::IN_STRING_KEY:
+      case State::IN_STRING_VALUE:
+        handleStringChar(c);
+        break;
+      case State::IN_NUMBER:
+        handleNumber(c);
+        break;
+      case State::IN_LITERAL:
+        handleLiteral(c);
+        break;
+      case State::SKIP_STRING:
+        handleSkipString(c);
+        break;
+    }
+  }
+}
+
+void StreamingJsonParser::handleScanning(char c) {
+  switch (c) {
+    case '"':
+      tokenLen = 0;
+      tokenOverflow = false;
+      if (expectingValue || inArray()) {
+        state = State::IN_STRING_VALUE;
+      } else {
+        state = State::IN_STRING_KEY;
+      }
+      break;
+    case '{':
+      if (nestingDepth < MAX_NESTING) {
+        nestingStack[nestingDepth++] = Container::OBJECT;
+      } else {
+        error = true;
+        return;
+      }
+      if (cb.onObjectStart) cb.onObjectStart(cb.ctx);
+      expectingValue = false;
+      break;
+    case '}':
+      if (cb.onObjectEnd) cb.onObjectEnd(cb.ctx);
+      if (nestingDepth > 0) --nestingDepth;
+      expectingValue = false;
+      break;
+    case '[':
+      if (nestingDepth < MAX_NESTING) {
+        nestingStack[nestingDepth++] = Container::ARRAY;
+      } else {
+        error = true;
+        return;
+      }
+      if (cb.onArrayStart) cb.onArrayStart(cb.ctx);
+      expectingValue = false;
+      break;
+    case ']':
+      if (cb.onArrayEnd) cb.onArrayEnd(cb.ctx);
+      if (nestingDepth > 0) --nestingDepth;
+      expectingValue = false;
+      break;
+    case ':':
+      expectingValue = true;
+      break;
+    case ',':
+      expectingValue = false;
+      break;
+    case 't':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "true", 4);
+        literalLen = 4;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    case 'f':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "false", 5);
+        literalLen = 5;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    case 'n':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "null", 4);
+        literalLen = 4;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    default:
+      if ((expectingValue || inArray()) && (c == '-' || (c >= '0' && c <= '9'))) {
+        tokenLen = 0;
+        tokenOverflow = false;
+        appendToken(c);
+        state = State::IN_NUMBER;
+      }
+      break;
+  }
+}
+
+void StreamingJsonParser::handleStringChar(char c) {
+  if (escaped) {
+    escaped = false;
+    switch (c) {
+      case '"':
+      case '\\':
+      case '/':
+        appendToken(c);
+        break;
+      case 'b':
+        appendToken('\b');
+        break;
+      case 'f':
+        appendToken('\f');
+        break;
+      case 'n':
+        appendToken('\n');
+        break;
+      case 'r':
+        appendToken('\r');
+        break;
+      case 't':
+        appendToken('\t');
+        break;
+      case 'u':
+        // Pass \uXXXX through as literal chars. Field matching here is ASCII-only.
+        appendToken('\\');
+        appendToken('u');
+        break;
+      default:
+        appendToken('\\');
+        appendToken(c);
+        break;
+    }
+    return;
+  }
+
+  if (c == '\\') {
+    escaped = true;
+    return;
+  }
+
+  if (c == '"') {
+    emitToken();
+    return;
+  }
+
+  appendToken(c);
+}
+
+void StreamingJsonParser::handleNumber(char c) {
+  if ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E') {
+    appendToken(c);
+    return;
+  }
+
+  if (!tokenOverflow && cb.onNumber) {
+    tokenBuf[tokenLen] = '\0';
+    cb.onNumber(cb.ctx, tokenBuf, tokenLen);
+  }
+  state = State::SCANNING;
+  expectingValue = false;
+
+  handleScanning(c);
+}
+
+void StreamingJsonParser::handleLiteral(char c) {
+  if (c == literalExpected[literalPos]) {
+    ++literalPos;
+    if (literalPos == literalLen) {
+      if (literalExpected[0] == 't') {
+        if (cb.onBool) cb.onBool(cb.ctx, true);
+      } else if (literalExpected[0] == 'f') {
+        if (cb.onBool) cb.onBool(cb.ctx, false);
+      } else {
+        if (cb.onNull) cb.onNull(cb.ctx);
+      }
+      state = State::SCANNING;
+      expectingValue = false;
+    }
+  } else {
+    error = true;
+  }
+}
+
+void StreamingJsonParser::handleSkipString(char c) {
+  if (escaped) {
+    escaped = false;
+    return;
+  }
+  if (c == '\\') {
+    escaped = true;
+    return;
+  }
+  if (c == '"') {
+    state = State::SCANNING;
+    expectingValue = false;
+  }
+}
+
+void StreamingJsonParser::appendToken(char c) {
+  if (tokenLen < TOKEN_BUF_SIZE - 1) {
+    tokenBuf[tokenLen++] = c;
+  } else {
+    tokenOverflow = true;
+  }
+}
+
+void StreamingJsonParser::emitToken() {
+  if (state == State::IN_STRING_KEY) {
+    if (!tokenOverflow && cb.onKey) {
+      tokenBuf[tokenLen] = '\0';
+      cb.onKey(cb.ctx, tokenBuf, tokenLen);
+    }
+    state = State::SCANNING;
+  } else {
+    if (!tokenOverflow && cb.onString) {
+      tokenBuf[tokenLen] = '\0';
+      cb.onString(cb.ctx, tokenBuf, tokenLen);
+    }
+    state = State::SCANNING;
+    expectingValue = false;
+  }
+}

--- a/lib/JsonParser/StreamingJsonParser.h
+++ b/lib/JsonParser/StreamingJsonParser.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Ported from crosspoint-reader/crosspoint-reader (MIT),
+// initially authored in PR #1810 by znelson and contributors.
+struct JsonCallbacks {
+  void* ctx;
+  void (*onKey)(void* ctx, const char* key, size_t len);
+  void (*onString)(void* ctx, const char* value, size_t len);
+  void (*onNumber)(void* ctx, const char* value, size_t len);
+  void (*onBool)(void* ctx, bool value);
+  void (*onNull)(void* ctx);
+  void (*onObjectStart)(void* ctx);
+  void (*onObjectEnd)(void* ctx);
+  void (*onArrayStart)(void* ctx);
+  void (*onArrayEnd)(void* ctx);
+};
+
+class StreamingJsonParser {
+ public:
+  static constexpr size_t TOKEN_BUF_SIZE = 512;
+  static constexpr size_t MAX_NESTING = 32;
+
+  explicit StreamingJsonParser(const JsonCallbacks& callbacks);
+
+  void reset();
+  void feed(const char* data, size_t len);
+
+  bool hasError() const { return error; }
+
+ private:
+  enum class State : uint8_t {
+    SCANNING,
+    IN_STRING_KEY,
+    IN_STRING_VALUE,
+    IN_NUMBER,
+    IN_LITERAL,
+    SKIP_STRING,
+  };
+
+  enum class Container : uint8_t {
+    NONE,
+    OBJECT,
+    ARRAY,
+  };
+
+  void handleScanning(char c);
+  void handleStringChar(char c);
+  void handleNumber(char c);
+  void handleLiteral(char c);
+  void handleSkipString(char c);
+
+  void appendToken(char c);
+  void emitToken();
+
+  bool inArray() const { return nestingDepth > 0 && nestingStack[nestingDepth - 1] == Container::ARRAY; }
+
+  JsonCallbacks cb;
+  char tokenBuf[TOKEN_BUF_SIZE];
+  size_t tokenLen;
+  State state;
+  bool expectingValue;
+  bool escaped;
+  bool tokenOverflow;
+  bool error;
+
+  Container nestingStack[MAX_NESTING];
+  uint8_t nestingDepth;
+
+  char literalExpected[6];
+  uint8_t literalLen;
+  uint8_t literalPos;
+};

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -1,5 +1,6 @@
 #include "OtaUpdateActivity.h"
 
+#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <WiFi.h>
@@ -10,6 +11,20 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "network/OtaUpdater.h"
+
+namespace {
+// Ported from crosspoint-reader/crosspoint-reader: release large allocations
+// before TLS so mbedTLS can get contiguous buffers on constrained heaps.
+void trimMemoryBeforeTls(GfxRenderer& renderer) {
+  if (auto* cache = renderer.getFontCacheManager()) {
+    cache->clearCache();
+  }
+  if (renderer.hasSecondaryBuffer() && renderer.releaseSecondaryBuffer()) {
+    LOG_DBG("OTA", "Released secondary framebuffer before TLS (~52 KB contiguous)");
+    renderer.setSingleBufferFastDiff(true);
+  }
+}
+}  // namespace
 
 void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
   if (!success) {
@@ -26,6 +41,8 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
   }
   requestUpdateAndWait();
 
+  trimMemoryBeforeTls(renderer);
+
   const auto res = updater.checkForUpdate();
   if (res != OtaUpdater::OK) {
     LOG_DBG("OTA", "Update check failed: %d", res);
@@ -38,7 +55,8 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
   }
 
   if (!updater.isUpdateNewer()) {
-    LOG_DBG("OTA", "No new update available");
+    LOG_DBG("OTA", "No new update available (latest=%s, current=%s)", updater.getLatestVersion().c_str(),
+            CROSSPOINT_VERSION);
     {
       RenderLock lock(*this);
       state = NO_UPDATE;
@@ -127,6 +145,11 @@ void OtaUpdateActivity::render(RenderLock&&) {
         (std::to_string(updater.getProcessedSize()) + " / " + std::to_string(updater.getTotalSize())).c_str());
   } else if (state == NO_UPDATE) {
     renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_NO_UPDATE), true, EpdFontFamily::BOLD);
+    renderer.drawText(UI_10_FONT_ID, contentRect.x + metrics.contentSidePadding, top + height + metrics.verticalSpacing,
+                      (std::string(tr(STR_CURRENT_VERSION)) + CROSSPOINT_VERSION).c_str());
+    renderer.drawText(UI_10_FONT_ID, contentRect.x + metrics.contentSidePadding,
+                      top + height * 2 + metrics.verticalSpacing * 2,
+                      (std::string(tr(STR_NEW_VERSION)) + updater.getLatestVersion()).c_str());
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   } else if (state == FAILED) {

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -25,9 +25,8 @@ namespace {
 // crt_bundle's Subject-DN lookup can pick the wrong "ISRG Root X1" entry on
 // cross-signed bundles and fail signature verification ("PK verify failed
 // with error 0x4290" → MBEDTLS_ERR_X509_FATAL_ERROR -0x3000). We use this
-// pin for raw.githubusercontent.com (Let's Encrypt-issued), and fall back to
-// the default crt_bundle for all other hosts (DigiCert chain on
-// github.com/api.github.com, etc.).
+// pin for raw.githubusercontent.com (Let's Encrypt-issued), and use a separate
+// pin for github.com/api.github.com (Sectigo/USERTrust chain).
 //
 // Not-after: 2035-06-04. Update when Let's Encrypt rotates the root.
 // Source: https://letsencrypt.org/certs/isrgrootx1.pem
@@ -64,6 +63,36 @@ constexpr const char ISRG_ROOT_X1_PEM[] =
     "emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n"
     "-----END CERTIFICATE-----\n";
 
+// USERTrust ECC self-signed root (trust anchor for GitHub's Sectigo chain).
+// Used as GitHub fallback trust anchor after crt_bundle failure.
+// Not-after: 2038-01-18.
+// Source: system CA bundle (/etc/ssl/certs/USERTrust_ECC_Certification_Authority.pem).
+constexpr const char SECTIGO_GITHUB_DV_E36_PEM[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICjzCCAhWgAwIBAgIQXIuZxVqUxdJxVt7NiYDMJjAKBggqhkjOPQQDAzCBiDEL\n"
+    "MAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNl\n"
+    "eSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMT\n"
+    "JVVTRVJUcnVzdCBFQ0MgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTAwMjAx\n"
+    "MDAwMDAwWhcNMzgwMTE4MjM1OTU5WjCBiDELMAkGA1UEBhMCVVMxEzARBgNVBAgT\n"
+    "Ck5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNleSBDaXR5MR4wHAYDVQQKExVUaGUg\n"
+    "VVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMTJVVTRVJUcnVzdCBFQ0MgQ2VydGlm\n"
+    "aWNhdGlvbiBBdXRob3JpdHkwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQarFRaqflo\n"
+    "I+d61SRvU8Za2EurxtW20eZzca7dnNYMYf3boIkDuAUU7FfO7l0/4iGzzvfUinng\n"
+    "o4N+LZfQYcTxmdwlkWOrfzCjtHDix6EznPO/LlxTsV+zfTJ/ijTjeXmjQjBAMB0G\n"
+    "A1UdDgQWBBQ64QmG1M8ZwpZ2dEl23OA1xmNjmjAOBgNVHQ8BAf8EBAMCAQYwDwYD\n"
+    "VR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjA2Z6EWCNzklwBBHU6+4WMB\n"
+    "zzuqQhFkoJ2UOQIReVx7Hfpkue4WQrO/isIJxOzksU0CMQDpKmFHjFJKS04YcPbW\n"
+    "RNZu9YO6bVi9JNlWSOrvxKJGgYhqOkbRqZtNyWHa0V1Xahg=\n"
+    "-----END CERTIFICATE-----\n";
+
+std::string extractHostFromUrl(const std::string& url) {
+  size_t schemeEnd = url.find("://");
+  size_t hostStart = schemeEnd == std::string::npos ? 0 : schemeEnd + 3;
+  size_t hostEnd = url.find('/', hostStart);
+  if (hostEnd == std::string::npos) hostEnd = url.size();
+  return url.substr(hostStart, hostEnd - hostStart);
+}
+
 // mbedtls rejects certs whose notBefore lies in the future of the device
 // clock, returning MBEDTLS_ERR_X509_CERT_VERIFY_FAILED (-0x2700). The
 // ESP32-C3 has no battery-backed RTC, so cold-boot clocks default to 1970
@@ -91,19 +120,34 @@ bool ensureClockForTls() {
   return true;
 }
 
+bool forceSyncClockForTls() {
+  char err[64] = {0};
+  if (!HalClock::syncNtp(err, sizeof(err))) {
+    LOG_ERR("HTTP", "Forced SNTP sync failed: %s", err);
+    return false;
+  }
+  LOG_INF("HTTP", "Forced SNTP sync complete; epoch now %ld", static_cast<long>(time(nullptr)));
+  return true;
+}
+
 // True if the URL's host is a *.githubusercontent.com host that's served by
 // Let's Encrypt — needs the ISRG pin to dodge the crt_bundle Subject-collision
 // bug. Adjust if more hosts hit the same issue.
 bool needsLetsEncryptPin(const std::string& url) {
-  // Strip scheme://, then everything from the first / onward.
-  size_t schemeEnd = url.find("://");
-  size_t hostStart = schemeEnd == std::string::npos ? 0 : schemeEnd + 3;
-  size_t hostEnd = url.find('/', hostStart);
-  if (hostEnd == std::string::npos) hostEnd = url.size();
-  const std::string host = url.substr(hostStart, hostEnd - hostStart);
+  const std::string host = extractHostFromUrl(url);
   // raw.githubusercontent.com is the only one we've seen fail today. Match
   // the suffix so codeload.githubusercontent.com / etc. get the same fix.
   static constexpr const char* kSuffix = ".githubusercontent.com";
+  const size_t suffixLen = strlen(kSuffix);
+  return host.size() >= suffixLen && host.compare(host.size() - suffixLen, suffixLen, kSuffix) == 0;
+}
+
+bool needsGithubComPin(const std::string& url) {
+  const std::string host = extractHostFromUrl(url);
+  if (host == "github.com" || host == "api.github.com") {
+    return true;
+  }
+  static constexpr const char* kSuffix = ".github.com";
   const size_t suffixLen = strlen(kSuffix);
   return host.size() >= suffixLen && host.compare(host.size() - suffixLen, suffixLen, kSuffix) == 0;
 }
@@ -116,11 +160,15 @@ bool needsLetsEncryptPin(const std::string& url) {
 // upstream PR #2075 (port of OtaUpdater's PR #2074 sizing).
 constexpr int HTTP_RX_BUF = 4096;
 constexpr int HTTP_TX_BUF = 1024;
+constexpr int HTTP_RX_BUF_LEAN = 2048;
+constexpr int HTTP_TX_BUF_LEAN = 512;
 // Per-socket-op timeout. esp_http_client's timeout_ms is uint32, so unlike
 // Arduino HTTPClient's uint16 setTimeout it doesn't silently truncate. 60s
 // gives slow servers room to send their first headers.
 constexpr int HTTP_TIMEOUT_MS = 60000;
+constexpr int HTTP_TIMEOUT_MS_LEAN = 15000;
 constexpr size_t READ_CHUNK = 2048;
+constexpr size_t READ_CHUNK_LEAN = 1024;
 
 struct Sink {
   // Returns false to abort the transfer (e.g. SD write failure or user cancel).
@@ -128,6 +176,7 @@ struct Sink {
   HttpDownloader::ProgressCallback progress;
   size_t total = 0;
   size_t downloaded = 0;
+  size_t readChunk = READ_CHUNK;
 };
 
 bool isRedirect(int status) {
@@ -138,9 +187,12 @@ bool isRedirect(int status) {
 // TLS root strategy (pinned ISRG vs default crt_bundle) based on the host.
 void configureClient(const std::string& url, esp_http_client_config_t& config) {
   config.url = url.c_str();
-  config.buffer_size = HTTP_RX_BUF;
-  config.buffer_size_tx = HTTP_TX_BUF;
-  config.timeout_ms = HTTP_TIMEOUT_MS;
+  const bool leanTlsProfile = needsGithubComPin(url);
+  // GitHub OTA checks run very close to heap limits on this device; use
+  // smaller HTTP buffers on those hosts to preserve TLS headroom.
+  config.buffer_size = leanTlsProfile ? HTTP_RX_BUF_LEAN : HTTP_RX_BUF;
+  config.buffer_size_tx = leanTlsProfile ? HTTP_TX_BUF_LEAN : HTTP_TX_BUF;
+  config.timeout_ms = leanTlsProfile ? HTTP_TIMEOUT_MS_LEAN : HTTP_TIMEOUT_MS;
   if (needsLetsEncryptPin(url)) {
     config.cert_pem = ISRG_ROOT_X1_PEM;
     config.cert_len = sizeof(ISRG_ROOT_X1_PEM);
@@ -164,17 +216,49 @@ void applyRequestHeaders(esp_http_client_handle_t client, const std::string& use
 // connection on subsequent calls per HTTP keep-alive), read headers, follow
 // redirects, then stream the body. Used by both the standalone runGet and the
 // Session-based path.
-HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& sink) {
+HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& sink, int* lastTlsCode = nullptr) {
+  const unsigned long startMs = millis();
+  size_t minFree = esp_get_free_heap_size();
+  size_t minLargest = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT);
+  auto sampleHeap = [&minFree, &minLargest]() {
+    const size_t freeNow = esp_get_free_heap_size();
+    const size_t largestNow = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT);
+    if (freeNow < minFree) {
+      minFree = freeNow;
+    }
+    if (largestNow < minLargest) {
+      minLargest = largestNow;
+    }
+  };
+  auto logPhase = [&sampleHeap, startMs](const char* phase) {
+    sampleHeap();
+    LOG_DBG("HTTP", "Phase %s @%lums heap=%u largest=%u", phase, millis() - startMs, esp_get_free_heap_size(),
+            heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT));
+  };
+
+  logPhase("start");
   esp_err_t err = esp_http_client_open(client, 0);
   if (err != ESP_OK) {
     int tlsCode = 0;
     int tlsFlags = 0;
     esp_http_client_get_and_clear_last_tls_error(client, &tlsCode, &tlsFlags);
-    LOG_ERR("HTTP", "open failed: %s (tls_code=-0x%04x, tls_flags=0x%08x)", esp_err_to_name(err), -tlsCode, tlsFlags);
+    if (lastTlsCode) {
+      *lastTlsCode = tlsCode;
+    }
+    sampleHeap();
+    LOG_ERR(
+        "HTTP",
+        "open failed: %s (tls_code=-0x%04x, tls_flags=0x%08x, t=%lums, heap=%u, largest=%u, minHeap=%u, minLargest=%u)",
+        esp_err_to_name(err), -tlsCode, tlsFlags, millis() - startMs, esp_get_free_heap_size(),
+        heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT), minFree, minLargest);
     return HttpDownloader::HTTP_ERROR;
   }
+  logPhase("open_ok");
   int64_t contentLength = esp_http_client_fetch_headers(client);
   int status = esp_http_client_get_status_code(client);
+  LOG_DBG("HTTP", "Phase headers @%lums status=%d content_length=%lld", millis() - startMs, status,
+          static_cast<long long>(contentLength));
+  sampleHeap();
   for (int hop = 0; isRedirect(status) && hop < 5; ++hop) {
     if (esp_http_client_set_redirection(client) != ESP_OK) break;
     err = esp_http_client_open(client, 0);
@@ -193,15 +277,16 @@ HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& 
 
   sink.total = contentLength > 0 ? static_cast<size_t>(contentLength) : 0;
 
-  std::unique_ptr<char[]> buf(new (std::nothrow) char[READ_CHUNK]);
+  std::unique_ptr<char[]> buf(new (std::nothrow) char[sink.readChunk]);
   if (!buf) {
-    LOG_ERR("HTTP", "OOM: %u byte read buffer", (unsigned)READ_CHUNK);
+    LOG_ERR("HTTP", "OOM: %u byte read buffer", static_cast<unsigned>(sink.readChunk));
     return HttpDownloader::HTTP_ERROR;
   }
 
   bool aborted = false;
   while (true) {
-    const int read = esp_http_client_read(client, buf.get(), READ_CHUNK);
+    const int read = esp_http_client_read(client, buf.get(), static_cast<int>(sink.readChunk));
+    sampleHeap();
     if (read < 0) {
       LOG_ERR("HTTP", "read error after %zu bytes", sink.downloaded);
       return HttpDownloader::HTTP_ERROR;
@@ -227,6 +312,8 @@ HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& 
     LOG_ERR("HTTP", "incomplete: got %zu of %zu bytes", sink.downloaded, sink.total);
     return HttpDownloader::HTTP_ERROR;
   }
+  LOG_DBG("HTTP", "Phase complete @%lums downloaded=%zu minHeap=%u minLargest=%u", millis() - startMs, sink.downloaded,
+          minFree, minLargest);
   return HttpDownloader::OK;
 }
 
@@ -248,6 +335,10 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
                                      Sink& sink) {
   logPreCallContext(url);
 
+  if (needsGithubComPin(url)) {
+    sink.readChunk = READ_CHUNK_LEAN;
+  }
+
   esp_http_client_config_t config = {};
   configureClient(url, config);
 
@@ -257,8 +348,27 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
     return HttpDownloader::HTTP_ERROR;
   }
   applyRequestHeaders(client, username, password);
-  HttpDownloader::DownloadError result = performGet(client, sink);
+  int tlsCode = 0;
+  HttpDownloader::DownloadError result = performGet(client, sink, &tlsCode);
   esp_http_client_cleanup(client);
+
+  // 0x2700 / -0x2700 is cert verification failure (sign depends on backend
+  // reporting path). If the device clock drifted but
+  // still looked "plausible", force one SNTP refresh and retry once.
+  if (result == HttpDownloader::HTTP_ERROR && sink.downloaded == 0 && (tlsCode == 0x2700 || tlsCode == -0x2700) &&
+      url.compare(0, 8, "https://") == 0) {
+    LOG_INF("HTTP", "TLS verify failed (-0x2700); forcing SNTP sync and retrying once");
+    if (forceSyncClockForTls()) {
+      esp_http_client_config_t retryConfig = {};
+      configureClient(url, retryConfig);
+      client = esp_http_client_init(&retryConfig);
+      if (client) {
+        applyRequestHeaders(client, username, password);
+        result = performGet(client, sink);
+        esp_http_client_cleanup(client);
+      }
+    }
+  }
 
   // The crt_bundle has a Subject-DN collision bug that picks the wrong ISRG
   // Root X1 on some Let's Encrypt cross-signed chains (PK verify error
@@ -267,22 +377,39 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
   // and the URL is https, retry once with the pinned ISRG cert to catch any
   // LE-signed host — not just *.githubusercontent.com which is already covered
   // by needsLetsEncryptPin().
-  if (result == HttpDownloader::HTTP_ERROR && sink.downloaded == 0 && url.compare(0, 8, "https://") == 0 &&
-      !needsLetsEncryptPin(url)) {
-    LOG_INF("HTTP", "Retrying with ISRG pin (crt_bundle may have failed Let's Encrypt chain)");
-    esp_http_client_config_t isrgConfig = {};
-    isrgConfig.url = url.c_str();
-    isrgConfig.buffer_size = HTTP_RX_BUF;
-    isrgConfig.buffer_size_tx = HTTP_TX_BUF;
-    isrgConfig.timeout_ms = HTTP_TIMEOUT_MS;
-    isrgConfig.cert_pem = ISRG_ROOT_X1_PEM;
-    isrgConfig.cert_len = sizeof(ISRG_ROOT_X1_PEM);
-    isrgConfig.keep_alive_enable = true;
-    client = esp_http_client_init(&isrgConfig);
-    if (client) {
-      applyRequestHeaders(client, username, password);
-      result = performGet(client, sink);
-      esp_http_client_cleanup(client);
+  if (result == HttpDownloader::HTTP_ERROR && sink.downloaded == 0 && url.compare(0, 8, "https://") == 0) {
+    if (needsGithubComPin(url)) {
+      LOG_INF("HTTP", "Retrying with GitHub Sectigo pin after handshake failure");
+      esp_http_client_config_t githubConfig = {};
+      githubConfig.url = url.c_str();
+      githubConfig.buffer_size = HTTP_RX_BUF;
+      githubConfig.buffer_size_tx = HTTP_TX_BUF;
+      githubConfig.timeout_ms = HTTP_TIMEOUT_MS;
+      githubConfig.cert_pem = SECTIGO_GITHUB_DV_E36_PEM;
+      githubConfig.cert_len = sizeof(SECTIGO_GITHUB_DV_E36_PEM);
+      githubConfig.keep_alive_enable = true;
+      client = esp_http_client_init(&githubConfig);
+      if (client) {
+        applyRequestHeaders(client, username, password);
+        result = performGet(client, sink);
+        esp_http_client_cleanup(client);
+      }
+    } else if (!needsLetsEncryptPin(url)) {
+      LOG_INF("HTTP", "Retrying with ISRG pin (crt_bundle may have failed Let's Encrypt chain)");
+      esp_http_client_config_t isrgConfig = {};
+      isrgConfig.url = url.c_str();
+      isrgConfig.buffer_size = HTTP_RX_BUF;
+      isrgConfig.buffer_size_tx = HTTP_TX_BUF;
+      isrgConfig.timeout_ms = HTTP_TIMEOUT_MS;
+      isrgConfig.cert_pem = ISRG_ROOT_X1_PEM;
+      isrgConfig.cert_len = sizeof(ISRG_ROOT_X1_PEM);
+      isrgConfig.keep_alive_enable = true;
+      client = esp_http_client_init(&isrgConfig);
+      if (client) {
+        applyRequestHeaders(client, username, password);
+        result = performGet(client, sink);
+        esp_http_client_cleanup(client);
+      }
     }
   }
 
@@ -380,6 +507,29 @@ bool HttpDownloader::fetchUrl(const std::string& url, Stream& outContent, const 
   Sink sink;
   sink.write = [&outContent](const uint8_t* data, size_t len) { return outContent.write(data, len) == len; };
   return runGet(url, username, password, sink) == OK;
+}
+
+bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username,
+                              const std::string& password) {
+  // Preserve historic semantics: callback abort => failure.
+  return fetchUrl(url, onData, false, username, password);
+}
+
+bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData, bool treatAbortAsSuccess,
+                              const std::string& username, const std::string& password) {
+  LOG_DBG("HTTP", "Fetching (stream): %s", url.c_str());
+  if (!onData) {
+    return false;
+  }
+  Sink sink;
+  sink.write = [&onData](const uint8_t* data, size_t len) { return onData(data, len); };
+  const DownloadError result = runGet(url, username, password, sink);
+  if (result == OK) {
+    return true;
+  }
+  // Optional mode for parsers that intentionally stop early once they have
+  // extracted all required fields from the stream.
+  return treatAbortAsSuccess && result == ABORTED;
 }
 
 bool HttpDownloader::fetchUrl(const std::string& url, std::string& outContent, const std::string& username,

--- a/src/network/HttpDownloader.h
+++ b/src/network/HttpDownloader.h
@@ -15,6 +15,8 @@ class HttpDownloader {
  public:
   // Progress callback. Return false to abort the transfer.
   using ProgressCallback = std::function<bool(unsigned int downloaded, unsigned int total)>;
+  // Called with each response chunk as it arrives; return false to abort.
+  using DataCallback = std::function<bool(const uint8_t* data, size_t len)>;
 
   enum DownloadError {
     OK = 0,
@@ -58,6 +60,22 @@ class HttpDownloader {
 
   static bool fetchUrl(const std::string& url, Stream& stream, const std::string& username = "",
                        const std::string& password = "");
+
+  static bool fetchUrl(const std::string& url, const DataCallback& onData, const std::string& username = "",
+                       const std::string& password = "");
+
+  /**
+   * Streaming fetch variant with explicit abort semantics.
+   *
+   * When treatAbortAsSuccess is false (default behavior), a callback abort
+   * (onData returns false) is treated as failure.
+   *
+   * When treatAbortAsSuccess is true, a callback abort maps to success.
+   * This is used by metadata parsers that intentionally stop once required
+   * fields are found, to avoid depending on full-body tail reads.
+   */
+  static bool fetchUrl(const std::string& url, const DataCallback& onData, bool treatAbortAsSuccess,
+                       const std::string& username = "", const std::string& password = "");
 
   /**
    * Download a file to the SD card with optional credentials.

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -1,14 +1,14 @@
 #include "OtaUpdater.h"
 
 #include <Arduino.h>
-#include <ArduinoJson.h>
 #include <Logging.h>
+#include <ReleaseJsonParser.h>
 
 #include <cstdio>
 #include <cstring>
 
 #include "CrossPointSettings.h"
-#include "HttpClientStream.h"
+#include "HttpDownloader.h"
 #include "bootloader_common.h"
 #include "esp_flash_partitions.h"
 #include "esp_heap_caps.h"
@@ -21,8 +21,6 @@
 namespace {
 constexpr char latestReleaseUrl[] = "https://api.github.com/repos/" CROSSPOINT_GIT_REPOSITORY "/releases/latest";
 constexpr char releaseListUrl[] = "https://api.github.com/repos/" CROSSPOINT_GIT_REPOSITORY "/releases?per_page=1";
-constexpr int httpRxBufferSize = 2048;
-constexpr int httpTxBufferSize = 512;
 constexpr int otaHttpMaxAttempts = 3;
 constexpr unsigned long otaInitialRetryDelayMs = 1000;
 constexpr size_t releaseMetadataMaxBytes = 128 * 1024;
@@ -40,15 +38,6 @@ esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
   return esp_http_client_set_header(http_client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
 }
 
-struct HttpClientCleaner {
-  esp_http_client_handle_t client;
-  ~HttpClientCleaner() {
-    if (client) {
-      esp_http_client_cleanup(client);
-    }
-  }
-};
-
 const char* getReleaseApiUrl() { return SETTINGS.includeBetaUpdates ? releaseListUrl : latestReleaseUrl; }
 
 void delayBeforeRetry(const char* operation, int attempt) {
@@ -57,30 +46,14 @@ void delayBeforeRetry(const char* operation, int attempt) {
   delay(delayMs);
 }
 
-JsonVariantConst selectRelease(const JsonDocument& doc) {
-  if (doc.is<JsonArrayConst>()) {
-    for (JsonObjectConst release : doc.as<JsonArrayConst>()) {
-      if (release["draft"] | false) {
-        continue;
-      }
-      return release;
-    }
-    return JsonVariantConst();
-  }
+struct WifiPowerSaveGuard {
+  WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_NONE); }
+  ~WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_MIN_MODEM); }
+};
 
-  if (doc.is<JsonObjectConst>()) {
-    return doc.as<JsonObjectConst>();
-  }
-
-  return JsonVariantConst();
-}
 } /* namespace */
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
-  JsonDocument filter;
-  esp_err_t esp_err;
-  JsonDocument doc;
-
   updateAvailable = false;
   latestVersion.clear();
   otaUrl.clear();
@@ -91,154 +64,70 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
 
   const char* releaseApiUrl = getReleaseApiUrl();
 
-  esp_http_client_config_t client_config = {
-      .url = releaseApiUrl,
-      .timeout_ms = 10000,
-      /* Default HTTP client buffer size 512 byte only */
-      .buffer_size = httpRxBufferSize,
-      .buffer_size_tx = httpTxBufferSize,
-      .crt_bundle_attach = esp_crt_bundle_attach,
-      .keep_alive_enable = true,
-  };
+  // Keep WiFi out of modem-sleep while doing release metadata HTTPS I/O.
+  // This mirrors installUpdate() and reduces intermittent TLS read stalls.
+  WifiPowerSaveGuard wifiPowerSaveGuard;
 
-  if (SETTINGS.includeBetaUpdates) {
-    filter[0]["tag_name"] = true;
-    filter[0]["draft"] = true;
-    filter[0]["assets"][0]["name"] = true;
-    filter[0]["assets"][0]["browser_download_url"] = true;
-    filter[0]["assets"][0]["size"] = true;
-  } else {
-    filter["tag_name"] = true;
-    filter["assets"][0]["name"] = true;
-    filter["assets"][0]["browser_download_url"] = true;
-    filter["assets"][0]["size"] = true;
-  }
-
+  // Use one streaming parser path for both stable and beta update checks to
+  // avoid holding full GitHub release JSON in memory.
+  // Adapted from crosspoint-reader/crosspoint-reader (MIT),
+  // PR #1810 by znelson and contributors.
+  LOG_DBG("OTA", "Checking for %s update at %s", SETTINGS.includeBetaUpdates ? "beta" : "stable", releaseApiUrl);
   for (int attempt = 1; attempt <= otaHttpMaxAttempts; ++attempt) {
-    doc.clear();
+    ReleaseJsonParser releaseParser;
+    size_t bytesSeen = 0;
+    const bool ok = HttpDownloader::fetchUrl(
+        releaseApiUrl,
+        [&releaseParser, &bytesSeen](const uint8_t* data, size_t len) {
+          bytesSeen += len;
+          if (bytesSeen > releaseMetadataMaxBytes) {
+            return false;
+          }
+          releaseParser.feed(reinterpret_cast<const char*>(data), len);
+          // For OTA metadata we only need tag_name and firmware.bin fields.
+          // Stop early once both are found to avoid fragile tail reads.
+          if (releaseParser.foundTag() && releaseParser.foundFirmware()) {
+            return false;
+          }
+          return true;
+        },
+        true);
 
-    esp_http_client_handle_t client_handle = esp_http_client_init(&client_config);
-    if (!client_handle) {
-      LOG_ERR("OTA", "HTTP Client Handle Failed");
-      return INTERNAL_UPDATE_ERROR;
-    }
-    HttpClientCleaner clientCleaner = {client_handle};
-
-    esp_err = esp_http_client_set_header(client_handle, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
-    if (esp_err != ESP_OK) {
-      LOG_ERR("OTA", "esp_http_client_set_header Failed : %s", esp_err_to_name(esp_err));
-      return INTERNAL_UPDATE_ERROR;
-    }
-
-    esp_err = esp_http_client_set_header(client_handle, "Accept", "application/vnd.github+json");
-    if (esp_err != ESP_OK) {
-      LOG_ERR("OTA", "esp_http_client_set_header Failed : %s", esp_err_to_name(esp_err));
-      return INTERNAL_UPDATE_ERROR;
-    }
-
-    esp_err = esp_http_client_open(client_handle, 0);
-    if (esp_err != ESP_OK) {
-      LOG_ERR("OTA", "esp_http_client_open Failed on attempt %d/%d: %s", attempt, otaHttpMaxAttempts,
-              esp_err_to_name(esp_err));
-      if (attempt < otaHttpMaxAttempts) {
-        delayBeforeRetry("Release metadata connection", attempt);
-        continue;
-      }
-      return HTTP_ERROR;
-    }
-
-    const int64_t headerContentLength = esp_http_client_fetch_headers(client_handle);
-    if (headerContentLength < 0) {
-      LOG_ERR("OTA", "esp_http_client_fetch_headers Failed on attempt %d/%d: %lld", attempt, otaHttpMaxAttempts,
-              headerContentLength);
-      if (attempt < otaHttpMaxAttempts) {
-        delayBeforeRetry("Release metadata headers", attempt);
-        continue;
-      }
-      return HTTP_ERROR;
-    }
-
-    const int statusCode = esp_http_client_get_status_code(client_handle);
-    if (statusCode != 200) {
-      LOG_ERR("OTA", "Release metadata request failed on attempt %d/%d: HTTP %d", attempt, otaHttpMaxAttempts,
-              statusCode);
-      if (statusCode >= 500 && attempt < otaHttpMaxAttempts) {
-        delayBeforeRetry("Release metadata HTTP status", attempt);
-        continue;
-      }
-      return HTTP_ERROR;
-    }
-
-    const bool chunked = esp_http_client_is_chunked_response(client_handle);
-    const int64_t contentLength = chunked ? -1 : esp_http_client_get_content_length(client_handle);
-    LOG_DBG("OTA", "Release metadata headers: content_length=%lld chunked=%s heap=%u largest=%u", contentLength,
-            chunked ? "yes" : "no", heap_caps_get_free_size(MALLOC_CAP_8BIT),
-            heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
-
-    if (contentLength > static_cast<int64_t>(releaseMetadataMaxBytes)) {
-      LOG_ERR("OTA", "Release metadata too large: %lld bytes", contentLength);
-      return METADATA_TOO_LARGE_ERROR;
-    }
-
-    HttpClientStream responseStream(client_handle, contentLength, releaseMetadataMaxBytes);
-    const DeserializationError error = deserializeJson(doc, responseStream, DeserializationOption::Filter(filter));
-    if (error) {
-      if (responseStream.isLimitExceeded() || error == DeserializationError::NoMemory) {
-        LOG_ERR("OTA", "Release metadata too large after %zu bytes: %s", responseStream.bytesReadCount(),
-                error.c_str());
+    if (!ok) {
+      if (bytesSeen > releaseMetadataMaxBytes) {
+        LOG_ERR("OTA", "Release metadata too large after %zu bytes", bytesSeen);
         return METADATA_TOO_LARGE_ERROR;
       }
-      if (responseStream.hasError()) {
-        LOG_ERR("OTA", "HTTP stream read failed on attempt %d/%d after %zu bytes: %d", attempt, otaHttpMaxAttempts,
-                responseStream.bytesReadCount(), responseStream.lastError());
-        if (attempt < otaHttpMaxAttempts) {
-          delayBeforeRetry("Release metadata stream", attempt);
-          continue;
-        }
-        return HTTP_ERROR;
+
+      LOG_ERR("OTA", "Release metadata stream failed on attempt %d/%d", attempt, otaHttpMaxAttempts);
+      if (attempt < otaHttpMaxAttempts) {
+        delayBeforeRetry("Release metadata stream", attempt);
+        continue;
       }
-      LOG_ERR("OTA", "JSON parse failed after %zu bytes: %s", responseStream.bytesReadCount(), error.c_str());
+      return HTTP_ERROR;
+    }
+
+    if (!releaseParser.foundTag()) {
+      LOG_ERR("OTA", "No tag_name found in release metadata");
       return JSON_PARSE_ERROR;
     }
 
-    break;
-  }
-
-  const JsonVariantConst release = selectRelease(doc);
-  if (release.isNull()) {
-    LOG_ERR("OTA", "No release found in response");
-    return NO_UPDATE;
-  }
-
-  if (!release["tag_name"].is<std::string>()) {
-    LOG_ERR("OTA", "No tag_name found");
-    return JSON_PARSE_ERROR;
-  }
-
-  if (!release["assets"].is<JsonArrayConst>()) {
-    LOG_ERR("OTA", "No assets found");
-    return JSON_PARSE_ERROR;
-  }
-
-  latestVersion = release["tag_name"].as<std::string>();
-
-  for (JsonObjectConst asset : release["assets"].as<JsonArrayConst>()) {
-    if (asset["name"] == "firmware.bin") {
-      otaUrl = asset["browser_download_url"].as<std::string>();
-      otaSize = asset["size"].as<size_t>();
-      totalSize = otaSize;
-      updateAvailable = true;
-      break;
+    if (!releaseParser.foundFirmware()) {
+      LOG_ERR("OTA", "No firmware.bin asset found");
+      return NO_UPDATE;
     }
+
+    latestVersion = releaseParser.getTagName();
+    otaUrl = releaseParser.getFirmwareUrl();
+    otaSize = releaseParser.getFirmwareSize();
+    totalSize = otaSize;
+    updateAvailable = true;
+
+    LOG_DBG("OTA", "Found %s update: %s", SETTINGS.includeBetaUpdates ? "beta" : "stable", latestVersion.c_str());
+    return OK;
   }
 
-  if (!updateAvailable) {
-    LOG_ERR("OTA", "No firmware.bin asset found");
-    return NO_UPDATE;
-  }
-
-  LOG_DBG("OTA", "Found %s update: %s", SETTINGS.includeBetaUpdates ? "beta" : "stable", latestVersion.c_str());
-  return OK;
+  return HTTP_ERROR;
 }
 
 bool OtaUpdater::isUpdateNewer() const {


### PR DESCRIPTION
Adopt streaming JSON release parsing, improve low-memory OTA reliability, and add clearer no-update version reporting.

Acknowledges upstream work from ngxson and contributors.
