### PR TITLE
perf: Background-C build-while-you-read for uncached sections, X3 build-mode + popup fixes

### DIFF
--- a/docs/background-b-handoff.md
+++ b/docs/background-b-handoff.md
@@ -1,5 +1,10 @@
 # Background B (section pre-analysis) — handoff for another PC
 
+> **Historical.** Background B (and now A and C) is implemented and live. For the current
+> architecture of all three background mechanisms see
+> [background-rendering.md](background-rendering.md). This file is kept as the original
+> implementation handoff.
+
 Self-contained pickup note. Pairs with the full design in
 [epubreader-control-flow-refactor.md](epubreader-control-flow-refactor.md) §2.6–2.7.
 This file is the "where we are, what's verified, exactly what to do next."

--- a/docs/background-rendering.md
+++ b/docs/background-rendering.md
@@ -1,0 +1,160 @@
+# Background work in the EPUB reader (A / B / C)
+
+How the reader hides latency behind three cooperative background mechanisms. This is the
+**current-state reference**; the historical design/handoff lives in
+[epubreader-control-flow-refactor.md](epubreader-control-flow-refactor.md) and
+[background-b-handoff.md](background-b-handoff.md). All code is in
+`src/activities/reader/EpubReaderActivity.cpp`.
+
+## Task model
+
+Two FreeRTOS tasks, serialised by one `RenderLock` (the `renderingMutex`):
+
+- **Render task** (`ActivityManager::renderTaskLoop`) — the *only* task that draws. It is
+  notification-driven: it takes the `RenderLock`, calls `Activity::render()`, releases the lock,
+  and waits for the next `requestUpdate()`. `render()` dispatches to one pass per call via
+  `classifyRenderPass()` (`FinishedBook`, `SectionBuilding`, `PreRender`, `BufferDisplay`,
+  `BuildSection`, `Normal`).
+- **Loop task** (the main Arduino `loopTask`) — input handling, plus idle-time background work
+  via `serviceBackgroundWork()` when no input/page-turn is pending.
+
+`renderContents()` releases the lock *before* the (blocking) e-ink waveform wait, so the loop
+task gets the CPU during the ~0.5 s refresh — that window is when background work actually runs.
+
+## The three mechanisms at a glance
+
+| | What it hides | Runs on | Builds with buffer | When |
+|---|---|---|---|---|
+| **A** — next-page pre-render | per-page-turn render compute (~90 ms) | render task (`PreRender` pass) | resident | next page is text-only & heap ok |
+| **B** — next-section pre-build | the "Indexing…" parse when you cross a chapter | loop task | **resident** (can't release — it's displaying) | idle, lookahead window |
+| **C** — current-section build | the freeze when you *land* on an uncached section | loop task (build) + render task (draw only) | released or resident, device-dependent | on entry to an uncached section |
+
+A and B are *look-ahead* for a section that's already on screen. C is for the section you just
+navigated to and have nothing to read yet — so it has the highest priority.
+
+## Priority — `serviceBackgroundWork()`
+
+```
+runDeferredGrayscalePass();                 // 1. AA of the page just shown (visible quality)
+if (pendingGrayscale_.active) return;        //    AA still owed → nothing else runs
+if (section && section->hasActiveBuild())    // 2. Background C: build the section you're waiting on
+  { stepCurrentSectionBuild(); return; }
+stepBackgroundSectionBuild();                // 3. Background A re-arm, then Background B
+```
+
+Rationale: deferred AA finishes the current page's quality; **C** unblocks reading (you can't
+read until it produces pages); **A**/**B** are speculative look-ahead that only matter once the
+current page/section is settled.
+
+---
+
+## A — next-page pre-render
+
+Renders the *next* logical page into the inactive framebuffer so a forward turn is a near-instant
+`BufferDisplay` instead of a fresh render.
+
+- **Scheduled** in `renderContents()` (`pendingPreRender = true` + `requestUpdate()`) and **re-armed**
+  once per `(spine, page)` by `stepBackgroundSectionBuild()` after the deferred-AA frees its memory.
+- **Runs** as the `PreRender` pass (`renderPreRenderPass`) on the render task.
+- **Gate:** free heap ≥ `PRE_RENDER_MIN_FREE_HEAP_BYTES` (56 KB); **text-only** pages only (image
+  pages are excluded — their decode is too heap-hungry and deep).
+- **Note on X3:** a page turn is *waveform-bound* (~0.5 s), so A only saves the ~90 ms of
+  prewarm+BW compute. Its benefit is modest on X3; the panel, not the CPU, sets page-turn speed.
+
+## B — next-section pre-build (look-ahead)
+
+Builds the **next consecutive** sections' caches during idle so crossing a chapter boundary is a
+cache hit, not a blocking parse. `stepBackgroundSectionBuild()`, one bounded slice per idle tick.
+
+- **Lookahead:** up to `BG_BUILD_LOOKAHEAD` (3) spines ahead of the reading position; the cursor
+  walks forward as each settles and re-anchors on any navigation.
+- **State machine:** `Probe` (cache check) → `WaitHeap` (gates) → `Building` (`BG_BUILD_BUDGET_MS`
+  = 40 ms slices) → `Settled`.
+- **Builds resident.** B runs while a page is displayed, so it *cannot* release the secondary
+  buffer (that would drop the current page's AA / fast-refresh baseline). This is the key
+  constraint that shapes its gates.
+- **Heap gates (resident):** free ≥ max(`BG_BUILD_PARSE_MIN_FREE_HEAP_BYTES` 48 KB,
+  `BG_BUILD_EXTRACT_BASE_HEAP_BYTES` 30 KB + inflate-ring); contig ≥ max(`BG_BUILD_MIN_CONTIG_HEAP_BYTES`
+  24 KB, ring + 8 KB).
+- **CSS refuse gate:** a CSS section built resident reliably drops below the runtime CSS-resolve
+  floor (~40 KB free) mid-parse → styles silently skipped → a *css-degraded* cache the foreground
+  must rebuild. So B refuses CSS sections unless free ≥ `BG_BUILD_CSS_MIN_FREE_HEAP_BYTES` (72 KB);
+  below that it parks in `WaitHeap` and lets **C** build the section released on arrival. It also
+  **early-aborts** (`Section::activeBuildCssDegraded()`) the instant a slice starts skipping, rather
+  than finishing a build it will discard.
+- **Discards** truncated or css-degraded results (`clearCache()`); those rebuild clean in the
+  foreground/C with the buffer released.
+- **Adoption:** when you cross into a B section, `buildSection()` adopts `backgroundSection_` — a
+  completed build is a cache hit; a still-partial build is finished by C.
+
+## C — current-section build (build-while-you-read)
+
+For the section you just entered that has **no cache** (first open, a jump / TOC / percent target,
+a settings/orientation change that invalidated caches, or one B was heap-gated off). Closes the
+gap B doesn't cover. The render task **only draws**; the build runs on the loop task.
+
+- **Start:** `buildSection()` detects the cache miss, picks a mode (below), draws the "Indexing"
+  popup, kicks off the build so `hasActiveBuild()` is true, and returns — handing off.
+- **Build:** `stepCurrentSectionBuild()` on the loop task, 40 ms slices, highest reader-build
+  priority. On a newly-written target page it `requestUpdate()`s so the render task draws it.
+- **Draw:** the `SectionBuilding` pass (`renderSectionBuildingPass`) shows the requested page from
+  the in-progress LUT (`Section::loadPageFromActiveBuild`, text-only) or the "Indexing" popup until
+  it's built. Page reads flush the writer first so a second handle sees committed bytes.
+- **Navigation during the build:** only for an explicit `Page` target — forward advances
+  optimistically (shows the page once C reaches it, popup until then), back works, back past page 0
+  leaves the chapter. Paragraph/anchor/percent/last-page targets resolve only at completion.
+- **Finalize (`Done`):** the on-disk LUT is written, the nav target is resolved (a Page target's
+  running position is kept; past-the-end crosses to the next spine), then `READING` resumes and the
+  `Normal` pass renders the page with AA.
+- **Failure (failed / truncated / css-degraded):** discard, latch `forceBlockingBuildSpine_`, and
+  fall back to the **blocking** path (which builds with the buffer released for ~52 KB headroom).
+
+### Build mode — `chooseSectionBuildMode()`
+
+| Mode | When | Buffer |
+|---|---|---|
+| `IncrementalReleased` | **X3** (any), or **X4 + CSS** | released; restored after via `recoverSecondaryBufferIfNeeded()` |
+| `IncrementalResident` | **X4 + non-CSS** that fits the in-place floors (`IN_PLACE_BUILD_MIN_FREE` 60 KB / `…_CONTIG` 28 KB) | kept resident |
+| `Blocking` | `forceBlockingBuildSpine_` latch, no secondary buffer, or a CSS-fallback rebuild | released → rebuilt → realloc'd |
+
+Device rationale (see [contributing/eink-controllers.md](contributing/eink-controllers.md)):
+
+- **X3** keeps the differential baseline in the controller's **DTM1**, so releasing the RAM buffer
+  costs no display benefit (fast refresh still works) and frees ~52 KB — and keeps CSS parses above
+  the resolve floor. So X3 **always** builds released. Mid-build draws are plain BW off the DTM1
+  baseline; AA returns once the buffer is restored.
+- **X4** re-seeds its fast-refresh baseline from the RAM buffer, so non-CSS builds keep it resident.
+  CSS builds release anyway (resident reliably css-degrades), at the cost of half-refresh mid-build
+  draws until restored.
+
+The released path sets `secondaryBufferDegraded_`; `recoverSecondaryBufferIfNeeded()` (top of every
+`render()`, guarded to skip while a build is active) reallocates + (X4) reseeds the buffer on the
+first render after the build ends. `onExit()` restores it too if the reader is left mid-build.
+
+---
+
+## Diagnostics
+
+- **Per-page** (`DBG`): `Page summary: … refresh=<fast|half|full> mode=0x.. renderMs=… …`. The
+  refresh mode/byte are captured at the page's own `triggerDisplay` (before the deferred-AA display
+  call would overwrite the renderer's live last-mode), so they reflect the page, not the AA pass.
+- **Background work** (`INF`, every ~5 s under `DEBUG_BACKGROUND_WORK`): `BG work: A runs/completes |
+  B runs/completes state=<probe|waitheap|building|settled> spine=… css=… | preReady=… buildPct=…
+  free=… contig=…`. A CSS book on a tight heap shows B parked in `waitheap` (the refuse gate) rather
+  than building-and-discarding.
+- **C lifecycle** (`INF`): `Background-C: building spine N … (buffer resident | secondary buffer
+  RELEASED …)`, `Background-C spine=N complete: M pages`, and on failure
+  `Background-C spine=N … falling back to blocking rebuild` / `… declined … blocking build`.
+- **Render-task stack** (`ERR`, always on): `Render task stack LOW: N bytes free` if the high-water
+  margin drops below 1536 B — the render task runs the deepest chains (build parse + image decode +
+  dither) and its stack abuts the heap, so an overflow corrupts the heap.
+
+## On X3 specifically (the common device)
+
+- B effectively steps aside for CSS books at steady reading heap (~57–65 KB free < 72 KB), so
+  forward chapter crosses into CSS sections are handled by **C released** (clean, responsive,
+  ~1–1.5 s to page 0) rather than B cache hits.
+- Page turns are fast (`refresh=fast`) except the scheduled anti-ghost **half** every
+  `getRefreshFrequency()` (15) turns. On X3 a "fast" request is never silently turned into a half —
+  it's honoured, or escalated to a *full* only when the differential baseline isn't synced (which
+  the clean build/restore paths avoid).

--- a/docs/epubreader-control-flow-refactor.md
+++ b/docs/epubreader-control-flow-refactor.md
@@ -1,5 +1,9 @@
 # EpubReader control-flow refactor & Background-B design
 
+> **Historical design doc.** The refactor and Background-B are implemented, and Background-C
+> (current-section build) has since been added. For the current architecture of all three
+> background mechanisms see [background-rendering.md](background-rendering.md).
+
 This document is a concrete, executable plan. Part 1 is a pure-restructuring
 cleanup that makes the reader's control flow read as the state machine it
 already is. Part 2 is a *design* for the new "Background B" capability

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -1087,6 +1087,35 @@ std::unique_ptr<Page> Section::loadPageFromSectionFile() {
   // File is intentionally NOT closed; stays open for the next page load
 }
 
+uint16_t Section::activeBuildPageCount() const {
+  if (!buildState_) return 0;
+  return pageCount;  // pageCount is incremented by onPageComplete() as each page is written
+}
+
+std::unique_ptr<Page> Section::loadPageFromActiveBuild(const uint16_t pageIndex) {
+  if (!buildState_ || pageIndex >= pageCount) {
+    LOG_ERR("SCT", "loadPageFromActiveBuild: page %u out of range (built=%u)", pageIndex, pageCount);
+    return nullptr;
+  }
+  const uint32_t offset = buildState_->lut[pageIndex];
+  if (offset == 0 || offset == UINT32_MAX) {
+    LOG_ERR("SCT", "loadPageFromActiveBuild: bad LUT entry %u for page %u", offset, pageIndex);
+    return nullptr;
+  }
+  FsFile readHandle;
+  if (!Storage.openFileForRead("SCT", filePath, readHandle)) {
+    LOG_ERR("SCT", "loadPageFromActiveBuild: cannot open %s for reading", filePath.c_str());
+    return nullptr;
+  }
+  if (!readHandle.seek(offset)) {
+    LOG_ERR("SCT", "loadPageFromActiveBuild: seek to %u failed", offset);
+    return nullptr;
+  }
+  auto page = Page::deserialize(readHandle);
+  readHandle.close();
+  return page;
+}
+
 void Section::warmAllImageCaches(const int xOffset, const int yOffset, const bool forceLoad,
                                  const bool monochromeOutput) {
   if (pageCount == 0) return;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -1092,6 +1092,13 @@ uint16_t Section::activeBuildPageCount() const {
   return pageCount;  // pageCount is incremented by onPageComplete() as each page is written
 }
 
+bool Section::activeBuildCssDegraded() const {
+  // Read the live CSS resolver's running stats: lowHeapSkips is incremented the moment the
+  // resolver drops a disk lookup under heap pressure (see CssParser), so it flags a degrading
+  // build mid-parse — before runBuildParse latches cssLowHeapDegraded_ at the parse end.
+  return buildState_ && buildState_->cssParser && buildState_->cssParser->getResolveStats().lowHeapSkips > 0;
+}
+
 std::unique_ptr<Page> Section::loadPageFromActiveBuild(const uint16_t pageIndex) {
   if (!buildState_ || pageIndex >= pageCount) {
     LOG_ERR("SCT", "loadPageFromActiveBuild: page %u out of range (built=%u)", pageIndex, pageCount);

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -1102,6 +1102,11 @@ std::unique_ptr<Page> Section::loadPageFromActiveBuild(const uint16_t pageIndex)
     LOG_ERR("SCT", "loadPageFromActiveBuild: bad LUT entry %u for page %u", offset, pageIndex);
     return nullptr;
   }
+  // The build writes pages to `file` without syncing per page, so its most recently written
+  // sector — and the directory-entry size — may not be on the card yet. A separate read handle
+  // only sees committed data, so flush the writer first; otherwise the read could seek past a
+  // stale EOF or deserialize a half-written sector.
+  if (file) file.flush();  // SdFat flush() == sync(): commits the cached sector + dir entry
   FsFile readHandle;
   if (!Storage.openFileForRead("SCT", filePath, readHandle)) {
     LOG_ERR("SCT", "loadPageFromActiveBuild: cannot open %s for reading", filePath.c_str());

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -198,6 +198,11 @@ class Section {
   // True when the last build's CSS resolution hit low-heap skips (styles silently
   // missing from the cached pages). Only meaningful right after a build.
   bool isCssLowHeapDegraded() const { return cssLowHeapDegraded_; }
+  // True while an incremental build is in flight and its CSS resolver has ALREADY hit a
+  // low-heap skip — i.e. the in-progress result is going to be css-degraded. Lets a sliced
+  // caller (Background-B) abort early instead of finishing a build it will discard. False when
+  // no build is live or no skips have occurred yet.
+  bool activeBuildCssDegraded() const;
 
   // Given a page in this section, return the TOC index for that page.
   int getTocIndexForPage(int page) const;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -181,10 +181,11 @@ class Section {
   // Pages [0, activeBuildPageCount()) are safe to read via loadPageFromActiveBuild().
   uint16_t activeBuildPageCount() const;
   // Load any page that has already been written during an active build, using the
-  // in-memory LUT that grows with every onPageComplete(). Opens a temporary read
-  // handle on the same file the build is writing to; safe because both handles are
-  // used only between build slices (never concurrently). Returns nullptr on error.
-  // pageIndex must be < activeBuildPageCount().
+  // in-memory LUT that grows with every onPageComplete(). Opens a temporary read handle
+  // on the same file the build is writing to, syncing the writer first so the read handle
+  // sees the latest committed pages (the writer is not synced per page). Must be called
+  // between build slices, never concurrently with a slice on another task. Returns nullptr
+  // on error. pageIndex must be < activeBuildPageCount().
   std::unique_ptr<Page> loadPageFromActiveBuild(uint16_t pageIndex);
   // Pre-decode every image in the section into its .pxc cache while heap is
   // maximally contiguous (secondary display buffer still released). Skips images

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -176,6 +176,16 @@ class Section {
   // log refusals at whatever cadence suits them.
   static bool heapAllowsEmbeddedStyle(size_t cssRuleCount);
   std::unique_ptr<Page> loadPageFromSectionFile();
+  // Number of pages fully written to the section file during an active build.
+  // Increases monotonically as the build progresses; 0 when no build is live.
+  // Pages [0, activeBuildPageCount()) are safe to read via loadPageFromActiveBuild().
+  uint16_t activeBuildPageCount() const;
+  // Load any page that has already been written during an active build, using the
+  // in-memory LUT that grows with every onPageComplete(). Opens a temporary read
+  // handle on the same file the build is writing to; safe because both handles are
+  // used only between build slices (never concurrently). Returns nullptr on error.
+  // pageIndex must be < activeBuildPageCount().
+  std::unique_ptr<Page> loadPageFromActiveBuild(uint16_t pageIndex);
   // Pre-decode every image in the section into its .pxc cache while heap is
   // maximally contiguous (secondary display buffer still released). Skips images
   // that are already cached or would show as a placeholder. The decode writes

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -40,8 +40,14 @@ void ActivityManager::begin() {
   renderingMutex = xSemaphoreCreateMutex();
   assert(renderingMutex != nullptr && "Failed to create rendering mutex");
 
+  // 10 KB: the render task runs the firmware's deepest call chains — page build/parse, CSS
+  // resolve, image decode (JPEG/PNG) + dither — and its stack abuts the heap top, so an
+  // overflow spills into the heap and surfaces as a corruption assert elsewhere (see the
+  // documented hazard in EpubReaderActivity). Field high-water dipped to ~1.7 KB free of the
+  // former 8 KB on a parse-on-render-task pass; +2 KB restores a safer margin. renderTaskLoop()
+  // also warns (RENDER_STACK_WARN_BYTES) if the live margin ever gets thin again.
   xTaskCreate(&renderTaskTrampoline, "ActivityManagerRender",
-              8192,              // Stack size
+              10240,             // Stack size (bytes)
               this,              // Parameters
               1,                 // Priority
               &renderTaskHandle  // Task handle
@@ -87,6 +93,22 @@ void ActivityManager::renderTaskLoop() {
     if (currentActivity) {
       HalPowerManager::Lock powerLock;  // Ensure we don't go into low-power mode while rendering
       currentActivity->render(std::move(lock));
+      // Always-on guard (cheap; one read): warn once if the render task's stack high-water gets
+      // dangerously thin. The render task's stack abuts the heap top — an overflow spills into
+      // the heap and shows up as an unrelated corruption assert. Tracks the running minimum so
+      // it only logs when a new low crosses the threshold (no per-pass spam). uxTaskGetStack...
+      // returns bytes on the C3 (StackType_t == uint8_t).
+      {
+        static constexpr unsigned RENDER_STACK_WARN_BYTES = 1536;
+        static unsigned lowestRenderStackFree = UINT_MAX;
+        const unsigned stackFree = static_cast<unsigned>(uxTaskGetStackHighWaterMark(nullptr));
+        if (stackFree < lowestRenderStackFree) {
+          lowestRenderStackFree = stackFree;
+          if (stackFree < RENDER_STACK_WARN_BYTES) {
+            LOG_ERR("MEM", "Render task stack LOW: %u bytes free (new min) — stack-into-heap overflow risk", stackFree);
+          }
+        }
+      }
 #ifdef ENABLE_BOOT_HEAP_DIAGNOSTICS
       // Render runs the deepest call chains in the firmware (page build + image
       // decode + dither) on this task's fixed 8 KB stack, which is heap-allocated

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -777,8 +777,9 @@ void FileBrowserActivity::doSetAsSleepCover(const std::string& fullPath) {
     {
       RenderLock lock(*this);
       const char* msg = success ? tr(STR_SLEEP_SCREEN_SET) : tr(STR_FAILED_TO_SET_SLEEP_SCREEN);
+      // drawPopup ships the frame; preseed its refresh mode to HALF instead of shipping twice.
+      renderer.setNextDisplayRefreshMode(HalDisplay::HALF_REFRESH);
       GUI.drawPopup(renderer, msg);
-      renderer.displayBuffer(HalDisplay::HALF_REFRESH);
     }
     requestUpdate();
   } else {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -609,7 +609,14 @@ void EpubReaderActivity::serviceBackgroundWork() {
   // self-gates on A having finished, since A drives perceived page-turn speed.
   runDeferredGrayscalePass();
   if (pendingGrayscale_.active) {
-    return;  // AA still owed (display bus busy); it keeps priority over B
+    return;  // AA still owed (display bus busy); it keeps priority over B/C
+  }
+  // Background C (build of the section the reader is waiting on) takes priority over A and B:
+  // the user has nothing to read until it produces pages. A/B are look-ahead work for a section
+  // that is already displayed, so they only matter once the current section is built.
+  if (section && section->hasActiveBuild()) {
+    stepCurrentSectionBuild();
+    return;
   }
   stepBackgroundSectionBuild();
 }
@@ -874,6 +881,103 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
       return;
     }
   }
+}
+
+void EpubReaderActivity::stepCurrentSectionBuild() {
+  if (!epub || !section || !section->hasActiveBuild()) {
+    return;
+  }
+  // Don't contend with the render task for the lock while a refresh/render is in flight: a
+  // blocked loop task can't service input. peek() is true when the mutex is HELD (busy).
+  if (renderer.isRefreshPending() || RenderLock::peek()) {
+    return;
+  }
+  RenderLock lock;
+  // Re-check under the lock: the render task may have started a refresh, turned a page, or
+  // finished/aborted the build between the unlocked test above and acquiring the lock.
+  if (!section || !section->hasActiveBuild() || renderer.isRefreshPending()) {
+    return;
+  }
+
+  // Layout needs glyph metrics only; reset accumulation so the next prewarm re-wires the
+  // flash-resident metric tables rather than the page-scoped bitmap cache (see
+  // stepBackgroundSectionBuild for the full rationale).
+  renderer.clearFontAccumulation();
+#if DEBUG_BACKGROUND_WORK
+  bgCounters_.bRuns++;
+#endif
+  const Section::BuildStep step = section->stepSectionBuild(makeSectionBuildParams(), BG_BUILD_BUDGET_MS);
+  checkHeapIntegrity("after_c_slice");
+
+  if (step == Section::BuildStep::More) {
+    backgroundBuildPercent_ = static_cast<int8_t>(section->activeBuildPercent());
+    // If the page the user is waiting on just became readable, ask the render task to draw it.
+    const int want = section->currentPage;
+    if (navTarget.kind == NavigationTarget::Kind::Page && want >= 0 &&
+        want < static_cast<int>(section->activeBuildPageCount()) && want != buildDisplayedPage_) {
+      requestUpdate();
+    }
+    return;
+  }
+
+  backgroundBuildPercent_ = -1;
+
+  // Failed, or finished but truncated / CSS-degraded: discard and retry on the blocking path,
+  // which builds with the secondary buffer released (~52 KB more headroom). The latch stops
+  // buildSection from re-entering Background-C for this spine.
+  if (step == Section::BuildStep::Failed || section->isTruncatedCache() || section->isCssLowHeapDegraded()) {
+    LOG_ERR("ERS", "Background-C spine=%d %s; falling back to blocking rebuild", currentSpineIndex,
+            step == Section::BuildStep::Failed ? "failed" : "incomplete");
+    section->clearCache();
+    section.reset();
+    forceBlockingBuildSpine_ = currentSpineIndex;
+    readerPhase_ = ReaderPhase::READING;
+    buildingPopupShown_ = false;
+    buildDisplayedPage_ = -1;
+    requestUpdate();  // -> BuildSection -> blocking build
+    return;
+  }
+
+  // Done & clean: the on-disk LUT is written and `section` is now a complete cache. Resolve the
+  // navigation target now that the final page count is known, then transition to reading.
+#if DEBUG_BACKGROUND_WORK
+  bgCounters_.bCompletes++;
+#endif
+  LOG_INF("ERS", "Background-C spine=%d complete: %u pages", currentSpineIndex, section->pageCount);
+  epub->persistImageManifest();
+  readerPhase_ = ReaderPhase::READING;
+
+  // Resolve the display position. For a Page target, section->currentPage already tracked the
+  // user's position through any mid-build page turns, so DON'T resolveInto (it would reset to the
+  // original page). Clamp it; if they ran past the end while building, cross into the next spine.
+  const int spineCount = epub->getSpineItemsCount();
+  if (navTarget.kind == NavigationTarget::Kind::Page) {
+    if (section->currentPage >= section->pageCount) {
+      if (currentSpineIndex + 1 < spineCount) {
+        navTarget = NavigationTarget::makePage(0);
+        currentSpineIndex++;
+        section.reset();
+      } else if (currentSpineIndex + 1 == spineCount) {
+        navTarget = NavigationTarget::makeLastPage();
+        currentSpineIndex++;
+        section.reset();
+      } else {
+        section->currentPage = std::max(0, section->pageCount - 1);
+      }
+    } else if (section->currentPage < 0) {
+      section->currentPage = 0;
+    }
+  } else {
+    navTarget.resolveInto(*section, currentSpineIndex);
+  }
+  if (section) {
+    navTarget = NavigationTarget::makePage(section->currentPage);
+  }
+  forceLoadLargeImages = false;
+  pageHasPlaceholders = false;
+  buildingPopupShown_ = false;
+  buildDisplayedPage_ = -1;
+  requestUpdate();  // -> Normal pass renders the resolved page (with AA)
 }
 
 // Translate an absolute percent into a spine index plus a normalized position
@@ -1955,6 +2059,36 @@ bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
     return false;
   }
 
+  // Background-C in progress: the final page count isn't known yet, so navigate optimistically.
+  // Only an explicit Page target has a meaningful position before completion (other targets are
+  // resolved when the build finishes); for those, swallow the turn. Forward advances the display
+  // cursor (the SectionBuilding pass shows the page once C builds it, or the popup until then);
+  // running past the real end is reconciled at completion (clamp / cross to the next spine). Back
+  // past page 0 leaves the chapter, aborting the in-flight build via ~Section.
+  if (section->hasActiveBuild()) {
+    if (navTarget.kind != NavigationTarget::Kind::Page) {
+      return false;
+    }
+    if (isForwardTurn) {
+      RenderLock lock(*this);
+      section->currentPage++;
+    } else if (section->currentPage > 0) {
+      RenderLock lock(*this);
+      section->currentPage--;
+    } else if (currentSpineIndex > 0) {
+      RenderLock lock(*this);
+      navTarget = NavigationTarget::makeLastPage();
+      currentSpineIndex--;
+      section.reset();
+    } else {
+      return false;
+    }
+    lastPageTurnTime = millis();
+    forceLoadLargeImages = false;
+    pageHasPlaceholders = false;
+    return true;
+  }
+
   // A 0-page section (permanently unparse-able chapter) has no within-chapter navigation,
   // but the user must still be able to cross spine boundaries to escape it.
   const bool hasPages = section->pageCount > 0;
@@ -2159,6 +2293,12 @@ EpubReaderActivity::RenderPass EpubReaderActivity::classifyRenderPass() const {
   if (currentSpineIndex == epub->getSpineItemsCount()) {
     return RenderPass::FinishedBook;
   }
+  // Background-C owns the screen while the current section is being built: draw the requested
+  // page from the in-progress LUT, or the indexing popup. Checked ahead of the pre-render /
+  // buffer-display passes (which never arm during a build) so a build can never be pre-empted.
+  if (section && section->hasActiveBuild()) {
+    return RenderPass::SectionBuilding;
+  }
   // BufferDisplay is checked before PreRender to preserve the former in-line order
   // (the buffer-display block ran ahead of the pre-render block). It applies only when
   // the prior waveform + post-waveform SPI work has settled; otherwise we fall through
@@ -2275,7 +2415,37 @@ bool EpubReaderActivity::heapAllowsInPlaceBuild(const bool embeddedStyle) const 
   return freeHeap >= IN_PLACE_BUILD_MIN_FREE_HEAP_BYTES && contigHeap >= IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES;
 }
 
-EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(RenderLock& lock, const RenderLayout& layout,
+bool EpubReaderActivity::currentSectionBuildEligible(const bool embeddedStyle) const {
+  // Background-C builds with the secondary buffer resident: on X4 to keep the fast-refresh
+  // baseline + grayscale AA, on X3 only for AA (the differential baseline lives in the
+  // controller's DTM1, so mid-build BW draws don't need it — see docs/contributing/
+  // eink-controllers.md). The blocking-fallback latch forces the old path after a failed attempt.
+  if (forceBlockingBuildSpine_ == currentSpineIndex) return false;
+  if (!renderer.hasSecondaryBuffer()) return false;
+
+  // CSS books need their selector index to fit alongside the resident buffer (same gate B uses).
+  if (embeddedStyle) {
+    const CssParser* css = epub->getCssParser();
+    if (!Section::heapAllowsEmbeddedStyle(css ? css->ruleCount() : 0)) return false;
+  }
+
+  if (renderer.isX3()) {
+    // X3 holds the differential baseline in-controller, so building with the buffer resident
+    // costs no display benefit — it's the exact regime Background-B already builds in on X3.
+    // Gate on B's proven floors (both defer image decode, so neither needs the foreground
+    // released path's image-decode headroom). The two-phase build self-aborts (→ blocking
+    // fallback) if a large entry's extract ring won't fit, so no ring pre-check is needed here.
+    const uint32_t freeHeap = esp_get_free_heap_size();
+    const uint32_t contigHeap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
+    return freeHeap >= BG_BUILD_PARSE_MIN_FREE_HEAP_BYTES && contigHeap >= BG_BUILD_MIN_CONTIG_HEAP_BYTES;
+  }
+
+  // X4: keep the secondary buffer resident to preserve the fast-refresh baseline (RED RAM is
+  // re-seeded from it) and AA, so require the stricter in-place headroom.
+  return heapAllowsInPlaceBuild(embeddedStyle);
+}
+
+EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const RenderLayout& layout,
                                                                          const bool embeddedStyle,
                                                                          const uint8_t imageRendering) {
   // Use a cleaner waveform for the indexing popup right after image pages; a FAST popup refresh
@@ -2323,93 +2493,39 @@ EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(RenderL
     LOG_INF("ERS", "Index start mem (after fb release): free=%lu", esp_get_free_heap_size());
   }
 
+  // Blocking build (the fallback path: X3, tight heap, a failed Background-C attempt, or a
+  // CSS-fallback rebuild). Background-C owns the responsive, build-while-you-read case; here we
+  // just build to completion. A resumed partial build continues via the same stepSectionBuild
+  // state inside createSectionFile.
+  const auto runCreate = [&]() {
+    return section->createSectionFile(buildParams.fontId, buildParams.lineCompression,
+                                      buildParams.extraParagraphSpacing, buildParams.paragraphAlignment,
+                                      buildParams.viewportWidth, buildParams.viewportHeight,
+                                      buildParams.hyphenationEnabled, buildParams.embeddedStyle,
+                                      buildParams.bionicReadingEnabled, buildParams.imageRendering, nullptr,
+                                      /*skipEviction=*/false, buildParams.headingFonts);
+  };
+
   const uint32_t createStart = millis();
-  bool createOk = false;
-
-  if (inPlace) {
-    // Sliced build: pump one budget slice at a time. Between slices, render any page that
-    // has been written to the section file but not yet shown to the user. This lets the
-    // reader see page 0 (and subsequent pages) as soon as they are built — typically within
-    // the first few hundred milliseconds — rather than waiting for the full chapter.
-    // Per-slice budget matches the background build cadence (40 ms) so the loop stays
-    // responsive. The render between slices is optional: if the target page is not yet built
-    // we simply continue without showing anything new.
-    constexpr uint32_t FG_SLICE_BUDGET_MS = 40;
-    bool pageRenderedDuringBuild = false;
-    uint16_t lastRenderedBuildPage = UINT16_MAX;
-    // Only stream mid-build pages when the nav target is an explicit page number — that's
-    // the only case where showing pages 0..N as they're built is meaningful progress toward
-    // the destination. All other targets (LastPage, Paragraph, ListItem, Anchor, TocIndex,
-    // Percent) can only be resolved after the full build + LUT are written; streaming
-    // unrelated pages would mislead the user (e.g. KOReader sync to p[142] mid-chapter
-    // would flash pages 0..N before jumping to the right page on completion).
-    const bool midBuildRenderEnabled = (navTarget.kind == NavigationTarget::Kind::Page);
-
-    while (true) {
-      const Section::BuildStep step = section->stepSectionBuild(buildParams, FG_SLICE_BUDGET_MS);
-
-      // After each slice, check if there are newly built pages available to show.
-      if (midBuildRenderEnabled) {
-        const uint16_t builtPages = section->activeBuildPageCount();
-        if (builtPages > 0 && builtPages > lastRenderedBuildPage + 1) {
-          // Pages [lastRenderedBuildPage+1 .. builtPages-1] are new. We only show the first
-          // available one per slice to keep the loop responsive; the user sees incremental progress.
-          const uint16_t showPage = (lastRenderedBuildPage == UINT16_MAX) ? 0 : lastRenderedBuildPage + 1;
-          if (showPage < builtPages) {
-            auto page = section->loadPageFromActiveBuild(showPage);
-            if (page) {
-              renderer.clearScreen();
-              section->currentPage = showPage;
-              renderContents(lock, std::move(page), layout.marginTop, layout.marginRight, layout.marginBottom,
-                             layout.marginLeft);
-              pageRenderedDuringBuild = true;
-              lastRenderedBuildPage = showPage;
-              LOG_INF("ERS", "Mid-build render: page %u available after %ums", showPage, millis() - createStart);
-            }
-          }
-        }
-      }
-
-      if (step == Section::BuildStep::Done) {
-        createOk = true;
-        break;
-      }
-      if (step == Section::BuildStep::Failed) {
-        break;
-      }
-      // step == More: continue slicing
-    }
-
-    if (!createOk) {
-      // In-place build failed — retry with secondary buffer released.
-      LOG_INF("ERS", "In-place section build failed; retrying with secondary buffer released (free=%lu)",
-              esp_get_free_heap_size());
-      renderer.releaseSecondaryBuffer();
-      released = true;
-      const uint32_t retryStart = millis();
-      createOk = section->createSectionFile(buildParams.fontId, buildParams.lineCompression,
-                                            buildParams.extraParagraphSpacing, buildParams.paragraphAlignment,
-                                            buildParams.viewportWidth, buildParams.viewportHeight,
-                                            buildParams.hyphenationEnabled, buildParams.embeddedStyle,
-                                            buildParams.bionicReadingEnabled, buildParams.imageRendering, nullptr,
-                                            /*skipEviction=*/false, buildParams.headingFonts);
-      LOG_INF("ERS", "createSectionFile retry returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - retryStart,
-              esp_get_free_heap_size());
-      checkHeapIntegrity("after_createSectionFile_retry");
-    }
-  } else {
-    // Released path: run to completion in one call (no secondary buffer for mid-build rendering).
-    createOk = section->createSectionFile(buildParams.fontId, buildParams.lineCompression,
-                                          buildParams.extraParagraphSpacing, buildParams.paragraphAlignment,
-                                          buildParams.viewportWidth, buildParams.viewportHeight,
-                                          buildParams.hyphenationEnabled, buildParams.embeddedStyle,
-                                          buildParams.bionicReadingEnabled, buildParams.imageRendering, nullptr,
-                                          /*skipEviction=*/false, buildParams.headingFonts);
-    LOG_INF("ERS", "createSectionFile returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - createStart,
-            esp_get_free_heap_size());
-  }
-
+  bool createOk = runCreate();
+  LOG_INF("ERS", "createSectionFile returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - createStart,
+          esp_get_free_heap_size());
   checkHeapIntegrity("after_createSectionFile");
+
+  if (!createOk && inPlace) {
+    // The conservative in-place gate was too optimistic. createSectionFile already reset its
+    // build state on failure, so the retry starts clean; free the buffer for the headroom the
+    // blocking foreground path has always relied on.
+    LOG_INF("ERS", "In-place section build failed; retrying with secondary buffer released (free=%lu)",
+            esp_get_free_heap_size());
+    renderer.releaseSecondaryBuffer();
+    released = true;
+    const uint32_t retryStart = millis();
+    createOk = runCreate();
+    LOG_INF("ERS", "createSectionFile retry returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - retryStart,
+            esp_get_free_heap_size());
+    checkHeapIntegrity("after_createSectionFile_retry");
+  }
 
   // Eager image pre-decode only on the released path (it needs the freed headroom).
   // warmAllImageCaches writes pixels into the framebuffer as a side effect; clearScreen()
@@ -2452,7 +2568,7 @@ EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(RenderL
   return outcome;
 }
 
-bool EpubReaderActivity::buildSection(RenderLock& lock, const RenderLayout& layout) {
+bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
   const int spineCount = epub->getSpineItemsCount();
   if (currentSpineIndex < 0 || currentSpineIndex >= spineCount) {
     LOG_ERR("ERS", "Render rejected invalid spine index %d (valid 0..%d)", currentSpineIndex, spineCount - 1);
@@ -2486,44 +2602,81 @@ bool EpubReaderActivity::buildSection(RenderLock& lock, const RenderLayout& layo
   resetBackgroundBuild();
   const unsigned long sectionStart = millis();
 
-  if (resumeBackgroundBuild ||
-      !section->loadSectionFile(getEffectiveReaderFontId(), getEffectiveReaderLineCompression(),
-                                SETTINGS.extraParagraphSpacing, getEffectiveParagraphAlignment(), viewportWidth,
-                                viewportHeight, getEffectiveHyphenation(), embeddedStyle, getEffectiveBionicReading(),
-                                imageRendering)) {
-    LOG_DBG("ERS", "Cache not found, building...");
+  // A resumed partial Background-B build has no on-disk LUT yet, so skip loadSectionFile (it
+  // would clobber the live write handle); it always needs building. Otherwise probe the cache.
+  const bool cacheHit = !resumeBackgroundBuild &&
+                        section->loadSectionFile(getEffectiveReaderFontId(), getEffectiveReaderLineCompression(),
+                                                 SETTINGS.extraParagraphSpacing, getEffectiveParagraphAlignment(),
+                                                 viewportWidth, viewportHeight, getEffectiveHyphenation(),
+                                                 embeddedStyle, getEffectiveBionicReading(), imageRendering);
+  const bool cssFallbackRebuild = cacheHit && section->isEmbeddedStyleFallback();
+  const bool needBuild = resumeBackgroundBuild || !cacheHit || cssFallbackRebuild;
+
+  if (needBuild) {
     lastRenderStats.cacheRebuilt = true;
 
-    const BuildOutcome outcome = compileSectionCache(lock, layout, embeddedStyle, imageRendering);
-    if (outcome == BuildOutcome::Restarting) {
-      return false;  // fragmented-heap recovery reboot in progress
-    }
-    renderer.restoreFontMetadata();
-    readerPhase_ = ReaderPhase::READING;
-    if (outcome == BuildOutcome::Failed) {
-      LOG_ERR("ERS", "Failed to build section; showing empty chapter");
-      // Do NOT reset section: leave it alive with pageCount=0 so getRenderPass()
-      // returns Normal on the next cycle (not BuildSection), breaking the retry loop.
-      // renderNormalPass handles pageCount==0 gracefully with an "empty chapter" screen.
-      requestUpdate();
-      return false;
-    }
-  } else if (section->isEmbeddedStyleFallback()) {
-    LOG_INF("ERS", "No-CSS fallback loaded; rebuilding with embedded CSS...");
-    lastRenderStats.cacheRebuilt = true;
+    // Background-C: build the current section incrementally on the loop task so input stays
+    // responsive and pages appear as they are written. Used for the clean cases — a cache miss
+    // or a resumed partial B build — when heap allows building in place. The CSS-fallback
+    // rebuild keeps the blocking path: the section already shows usable fallback content.
+    const bool incremental =
+        (resumeBackgroundBuild || !cacheHit) && !cssFallbackRebuild && currentSectionBuildEligible(embeddedStyle);
+    bool runBlocking = !incremental;
 
-    const BuildOutcome outcome = compileSectionCache(lock, layout, embeddedStyle, imageRendering);
-    if (outcome == BuildOutcome::Restarting) {
-      return false;  // fragmented-heap recovery reboot in progress
+    if (incremental) {
+      LOG_INF("ERS", "Background-C: building spine %d incrementally (free=%lu)", currentSpineIndex,
+              esp_get_free_heap_size());
+      GUI.drawPopup(renderer, tr(STR_INDEXING));  // immediate feedback before the first page lands
+      renderer.clearFontAccumulation();
+      readerPhase_ = ReaderPhase::PRECOMPILING;
+      // Seed the display cursor so the SectionBuilding pass knows which page to show first. For a
+      // Page target it's the requested page (usually 0); other targets show the popup until the
+      // build completes and the position is resolved, so the exact value doesn't matter there.
+      section->currentPage = (navTarget.kind == NavigationTarget::Kind::Page) ? navTarget.page : 0;
+      buildDisplayedPage_ = -1;
+      buildingPopupShown_ = true;
+      // Kick the build off so hasActiveBuild() is true (a resumed B build already is). One slice
+      // may already finish a tiny section, in which case we fall through to a normal render.
+      Section::BuildStep step = Section::BuildStep::More;
+      if (!section->hasActiveBuild()) {
+        step = section->stepSectionBuild(makeSectionBuildParams(), BG_BUILD_BUDGET_MS);
+      }
+      if (step == Section::BuildStep::More) {
+        requestUpdate();  // SectionBuilding pass + stepCurrentSectionBuild() take over
+        return false;
+      }
+      readerPhase_ = ReaderPhase::READING;
+      if (step == Section::BuildStep::Failed) {
+        LOG_ERR("ERS", "Background-C kickoff failed for spine %d; using blocking path", currentSpineIndex);
+        forceBlockingBuildSpine_ = currentSpineIndex;
+        runBlocking = true;
+      }
+      // step == Done: tiny section finished in one slice — fall through to resolveInto/return true.
     }
-    renderer.restoreFontMetadata();
-    readerPhase_ = ReaderPhase::READING;
-    if (outcome == BuildOutcome::Failed) {
-      LOG_ERR("ERS", "Failed to rebuild CSS section cache; keeping fallback");
-      section->loadSectionFile(getEffectiveReaderFontId(), getEffectiveReaderLineCompression(),
-                               SETTINGS.extraParagraphSpacing, getEffectiveParagraphAlignment(), viewportWidth,
-                               viewportHeight, getEffectiveHyphenation(), embeddedStyle, getEffectiveBionicReading(),
-                               imageRendering);
+
+    if (runBlocking) {
+      const BuildOutcome outcome = compileSectionCache(layout, embeddedStyle, imageRendering);
+      if (outcome == BuildOutcome::Restarting) {
+        return false;  // fragmented-heap recovery reboot in progress
+      }
+      renderer.restoreFontMetadata();
+      readerPhase_ = ReaderPhase::READING;
+      if (outcome == BuildOutcome::Failed) {
+        if (cssFallbackRebuild) {
+          LOG_ERR("ERS", "Failed to rebuild CSS section cache; keeping fallback");
+          section->loadSectionFile(getEffectiveReaderFontId(), getEffectiveReaderLineCompression(),
+                                   SETTINGS.extraParagraphSpacing, getEffectiveParagraphAlignment(), viewportWidth,
+                                   viewportHeight, getEffectiveHyphenation(), embeddedStyle,
+                                   getEffectiveBionicReading(), imageRendering);
+        } else {
+          LOG_ERR("ERS", "Failed to build section; showing empty chapter");
+          // Do NOT reset section: leave it alive with pageCount=0 so getRenderPass()
+          // returns Normal on the next cycle (not BuildSection), breaking the retry loop.
+          // renderNormalPass handles pageCount==0 gracefully with an "empty chapter" screen.
+          requestUpdate();
+          return false;
+        }
+      }
     }
   } else {
     LOG_DBG("ERS", "Cache found, skipping build...");
@@ -2535,6 +2688,10 @@ bool EpubReaderActivity::buildSection(RenderLock& lock, const RenderLayout& layo
     truncatedSectionHintRendersRemaining = TRUNCATED_SECTION_HINT_RENDER_COUNT;
     LOG_INF("ERS", "Section %d is truncated; showing mitigation hint", currentSpineIndex);
   }
+
+  // Section is ready (cache hit, blocking build, or a tiny C build that finished in one slice):
+  // the Background-C fallback latch for this spine has served its purpose.
+  forceBlockingBuildSpine_ = -1;
 
   LOG_DBG("ERS", "resolveInto: navTarget.kind=%d pageCount=%d", (int)navTarget.kind, (int)section->pageCount);
   navTarget.resolveInto(*section, currentSpineIndex);
@@ -2651,6 +2808,45 @@ void EpubReaderActivity::renderNormalPass(RenderLock& lock, const RenderLayout& 
   }
 }
 
+void EpubReaderActivity::renderSectionBuildingPass(RenderLock& lock, const RenderLayout& layout) {
+  if (!section || !section->hasActiveBuild()) {
+    // Build finished or was aborted between classifyRenderPass() and here — re-dispatch so the
+    // correct pass (Normal, or a fresh BuildSection after a cross/fallback) runs.
+    requestUpdate();
+    return;
+  }
+
+  // Draw the requested page if Background-C has already written it. Only for an explicit Page
+  // target (other targets resolve at completion). buildDisplayedPage_ records the target we've
+  // already acted on so we neither redraw it every tick nor (via the C step's nudge gate) get
+  // pinged every slice.
+  const int target = section->currentPage;
+  const int built = static_cast<int>(section->activeBuildPageCount());
+  if (navTarget.kind == NavigationTarget::Kind::Page && target >= 0 && target < built) {
+    if (target == buildDisplayedPage_) {
+      return;  // already handled this target (drawn, or an image page we're waiting out)
+    }
+    // Text-only pages render cleanly without the image decode / secondary-buffer dance that the
+    // lock-light build path avoids; an image target waits for the final Normal render but is
+    // still marked handled so the C step stops nudging us about it.
+    auto page = section->loadPageFromActiveBuild(static_cast<uint16_t>(target));
+    buildDisplayedPage_ = target;
+    if (page && !page->hasImages()) {
+      buildingPopupShown_ = false;
+      displayBuildPage(lock, *page, layout);  // releases the lock before the waveform wait
+      return;
+    }
+    // Image page or load failure: fall through to the popup until the build completes.
+  }
+
+  // Requested page not built yet (or it's an image page / non-Page target): show the indexing
+  // popup once, leaving any already-displayed page underneath it.
+  if (!buildingPopupShown_) {
+    GUI.drawPopup(renderer, tr(STR_INDEXING));
+    buildingPopupShown_ = true;
+  }
+}
+
 // TODO: Failure handling
 void EpubReaderActivity::render(RenderLock&& lock) {
   if (!epub) {
@@ -2726,12 +2922,15 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       renderNormalPass(lock, layout);
       return;
     case RenderPass::BuildSection:
-      if (!buildSection(lock, layout)) {
+      if (!buildSection(layout)) {
         return;
       }
       // Flush any image dimensions this build just resolved (foreground path).
       epub->persistImageManifest();
       renderNormalPass(lock, layout);
+      return;
+    case RenderPass::SectionBuilding:
+      renderSectionBuildingPass(lock, layout);
       return;
     case RenderPass::Normal:
       renderNormalPass(lock, layout);
@@ -2982,6 +3181,33 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   // Sleep until BUSY deasserts, then do post-waveform SPI work (DTM1 resync
   // on X3, conditioning passes, flag updates). SPI ownership transfers back
   // to this task only after completeDisplay() returns.
+  renderer.completeDisplay();
+}
+
+void EpubReaderActivity::displayBuildPage(RenderLock& lock, const Page& page, const RenderLayout& layout) {
+  // Draws one text-only page from an in-progress Background-C build: a plain BW render + status
+  // bar, no AA and no pre-render arming (those belong to the steady reading state set up by
+  // renderNormalPass() once the build completes). Caller guarantees the page is text-only, so
+  // no image decode / secondary-buffer release is needed. The lock is released before the
+  // waveform wait — exactly like renderContents() — so a C build slice can run on the loop task
+  // during the refresh.
+  const int viewportHeight = std::max(0, renderer.getScreenHeight() - layout.marginTop - layout.marginBottom);
+  const int contentTop = layout.marginTop + getImageOnlyPageYOffset(page, viewportHeight);
+
+  auto* fcm = renderer.getFontCacheManager();
+  auto scope = fcm->createPrewarmScope();
+  page.renderTextOnly(renderer, getEffectiveReaderFontId(), layout.marginLeft, contentTop);  // scan pass
+  scope.endScanAndPrewarm();
+
+  renderer.clearScreen();
+  page.render(renderer, getEffectiveReaderFontId(), layout.marginLeft, contentTop, /*forceLoadLargeImages=*/false,
+              /*monochromeOutput=*/true);
+  renderStatusBar();
+  ReaderUtils::triggerWithRefreshCycle(renderer, pagesUntilFullRefresh);
+  // Release the lock before the (blocking) waveform wait so stepCurrentSectionBuild() can run a
+  // build slice on the loop task while the panel refreshes — the same hand-off renderContents()
+  // uses for Background-A.
+  lock.unlock();
   renderer.completeDisplay();
 }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -122,6 +122,17 @@ constexpr uint32_t PRE_RENDER_MIN_FREE_HEAP_BYTES = 56 * 1024;
 #ifndef BG_BUILD_MIN_CONTIG_HEAP_BYTES
 #define BG_BUILD_MIN_CONTIG_HEAP_BYTES (24 * 1024)  // parse-phase floor; raised to ring+8 KB while extracting
 #endif
+// Extra free-heap floor for a CSS section built with the secondary buffer RESIDENT (which B
+// always is — it can't release while displaying). The runtime CSS resolver self-protects below
+// ~40 KB free (MIN_FREE_HEAP_FOR_CSS) by skipping disk lookups, producing a css-degraded cache
+// the foreground must rebuild — so B grinds for seconds then discards. The parse working set
+// peaks at ~25-28 KB, so B must start a CSS build with ≥ ~68 KB free to stay above the resolver
+// floor mid-parse. Below this, B refuses (stays in WaitHeap) and lets Background-C build the
+// section released — with ~120 KB free — when the reader navigates into it. (X3 docs note CSS
+// builds are "impossible" resident below ~68 KB free; this is that line, with a small margin.)
+#ifndef BG_BUILD_CSS_MIN_FREE_HEAP_BYTES
+#define BG_BUILD_CSS_MIN_FREE_HEAP_BYTES (72 * 1024)
+#endif
 // Per-slice time budget for a Background-B parse step. Conservative start (handoff plan
 // suggests 30–50 ms); tune from the DEBUG_BACKGROUND_WORK serial counters.
 constexpr uint32_t BG_BUILD_BUDGET_MS = 40;
@@ -832,6 +843,12 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
         if (!Section::heapAllowsEmbeddedStyle(css ? css->ruleCount() : 0)) {
           return;
         }
+        // B builds resident, so a CSS parse below ~68 KB free would dip under the runtime
+        // CSS-resolve floor mid-parse and come out css-degraded — seconds of work B then
+        // discards. Refuse here and let Background-C build it released (clean) on navigation.
+        if (freeHeap < BG_BUILD_CSS_MIN_FREE_HEAP_BYTES) {
+          return;
+        }
       }
       backgroundBuildState_ = BackgroundBuildState::Building;
       return;
@@ -857,6 +874,19 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
           backgroundSection_->stepSectionBuild(makeSectionBuildParams(), BG_BUILD_BUDGET_MS);
       checkHeapIntegrity("after_b_slice");
       if (step == Section::BuildStep::More) {
+        // Heap can drop after the WaitHeap gate passed (an interleaved page render allocates).
+        // The moment the CSS resolver starts skipping lookups the result is doomed to be
+        // css-degraded and discarded — bail now instead of grinding through the rest of the
+        // build. Background-C will rebuild it released (clean) when the reader navigates in.
+        if (backgroundSection_->activeBuildCssDegraded()) {
+          LOG_INF("ERS", "Background build spine=%d css-degrading mid-build; aborting early for foreground rebuild",
+                  targetSpine);
+          backgroundSection_->abortSectionBuild();
+          backgroundSection_.reset();
+          backgroundBuildPercent_ = -1;
+          backgroundBuildState_ = BackgroundBuildState::Settled;
+          return;
+        }
         backgroundBuildPercent_ = static_cast<int8_t>(backgroundSection_->activeBuildPercent());
         return;
       }
@@ -2371,8 +2401,7 @@ bool EpubReaderActivity::renderBufferDisplayPass(const RenderLayout& layout) {
     requestUpdate();
   }
   LOG_DBG("ERS", "Page summary: spine=%d page=%d/%d prerendered=1 refresh=%s mode=0x%02X", currentSpineIndex,
-          section->currentPage, section->pageCount, refreshModeName(renderer.getLastRefreshMode()),
-          renderer.getLastDisplayModeByte());
+          section->currentPage, section->pageCount, refreshModeName(lastPageRefreshMode_), lastPageDisplayModeByte_);
   return true;
 }
 
@@ -2605,9 +2634,14 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
   bool resumeBackgroundBuild = false;
   if (backgroundSection_ && backgroundBuildSpineIndex_ == currentSpineIndex) {
     resumeBackgroundBuild = backgroundSection_->hasActiveBuild();
+    // Distinguish the three adopt cases for an accurate log: a live partial build (resume), a
+    // B-completed section with pages (cache hit follows), or a section B only probed and parked
+    // in WaitHeap (no pages — loadSectionFile will miss and a foreground/C build follows).
+    const char* adoptKind = resumeBackgroundBuild                 ? "resuming partial build"
+                            : (backgroundSection_->pageCount > 0) ? "build complete"
+                                                                  : "probed only, will build";
     section = std::move(backgroundSection_);
-    LOG_INF("ERS", "Adopting background section for spine %d (%s)", currentSpineIndex,
-            resumeBackgroundBuild ? "resuming partial build" : "build complete");
+    LOG_INF("ERS", "Adopting background section for spine %d (%s)", currentSpineIndex, adoptKind);
   } else {
     section = std::make_unique<Section>(epub, currentSpineIndex, renderer);
   }
@@ -2820,14 +2854,15 @@ void EpubReaderActivity::renderNormalPass(RenderLock& lock, const RenderLayout& 
     const uint32_t totalFontLookups = lastRenderStats.fontCacheHits + lastRenderStats.fontCacheMisses;
     const uint32_t fontHitRatePct =
         totalFontLookups > 0 ? (lastRenderStats.fontCacheHits * 100UL) / totalFontLookups : 0UL;
-    LOG_DBG("ERS",
-            "Page summary: spine=%d page=%d/%d prerendered=0 refresh=%s mode=0x%02X renderMs=%lu prewarmMs=%lu "
-            "bwMs=%lu displayMs=%lu fontHits=%lu fontMisses=%lu fontHitPct=%lu glyphCalls=%lu glyphUs=%lu",
-            currentSpineIndex, section->currentPage, section->pageCount, refreshModeName(renderer.getLastRefreshMode()),
-            renderer.getLastDisplayModeByte(), lastRenderStats.requestRenderMs, lastRenderStats.phases.prewarmMs,
-            lastRenderStats.phases.bwRenderMs, lastRenderStats.phases.displayMs, lastRenderStats.fontCacheHits,
-            lastRenderStats.fontCacheMisses, fontHitRatePct, lastRenderStats.fontGetBitmapCalls,
-            lastRenderStats.fontGetBitmapTimeUs);
+    LOG_DBG(
+        "ERS",
+        "Page summary: spine=%d page=%d/%d prerendered=0 refresh=%s mode=0x%02X renderMs=%lu "
+        "prewarmMs=%lu bwMs=%lu displayMs=%lu fontHits=%lu fontMisses=%lu fontHitPct=%lu glyphCalls=%lu glyphUs=%lu",
+        currentSpineIndex, section->currentPage, section->pageCount, refreshModeName(lastPageRefreshMode_),
+        lastPageDisplayModeByte_, lastRenderStats.requestRenderMs, lastRenderStats.phases.prewarmMs,
+        lastRenderStats.phases.bwRenderMs, lastRenderStats.phases.displayMs, lastRenderStats.fontCacheHits,
+        lastRenderStats.fontCacheMisses, fontHitRatePct, lastRenderStats.fontGetBitmapCalls,
+        lastRenderStats.fontGetBitmapTimeUs);
 
     if (pendingScreenshot) {
       // No restoreCurrentPageToBufferIfPreRendered() needed here: we are inside renderContents()
@@ -3158,6 +3193,11 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   } else {
     ReaderUtils::triggerWithRefreshCycle(renderer, pagesUntilFullRefresh);
   }
+  // Capture this page's refresh mode/byte NOW, before the lock is released and the deferred-AA
+  // grayscale display overwrites the renderer's last-mode (which would otherwise mislabel the
+  // page summary logged afterwards).
+  lastPageRefreshMode_ = renderer.getLastRefreshMode();
+  lastPageDisplayModeByte_ = renderer.getLastDisplayModeByte();
   const auto tDisplay = millis();
 
   // Schedule a half-refresh on the next page turn after an image page to reduce ghosting.
@@ -3292,6 +3332,9 @@ void EpubReaderActivity::displayPreRenderedPage(const Page& page, const int orie
   } else {
     ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
   }
+  // Capture before the AA replay below overwrites the renderer's last-mode (see renderContents).
+  lastPageRefreshMode_ = renderer.getLastRefreshMode();
+  lastPageDisplayModeByte_ = renderer.getLastDisplayModeByte();
 
   if (getEffectiveTextAntiAliasing() && renderer.hasSecondaryBuffer() && !secondaryBufferDegraded_) {
     const int fontId = getEffectiveReaderFontId();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -933,6 +933,7 @@ void EpubReaderActivity::stepCurrentSectionBuild() {
   RenderLock lock;
   // Re-check under the lock: the render task may have started a refresh, turned a page, or
   // finished/aborted the build between the unlocked test above and acquiring the lock.
+  // cppcheck-suppress knownConditionTrueFalse ; render task mutates these concurrently
   if (!section || !section->hasActiveBuild() || renderer.isRefreshPending()) {
     return;
   }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2225,7 +2225,12 @@ void EpubReaderActivity::renderPreRenderPass(const RenderLayout& layout) {
     return;
   }
   const int nextPage = section->currentPage + 1;
-  if (nextPage >= section->pageCount) {
+  // During an active build use the in-memory LUT via loadPageFromActiveBuild; the on-disk
+  // LUT is not written until finalisation so loadPageFromSectionFile would always miss.
+  const bool buildActive = section->hasActiveBuild();
+  const int availablePages =
+      buildActive ? static_cast<int>(section->activeBuildPageCount()) : static_cast<int>(section->pageCount);
+  if (nextPage >= availablePages) {
     return;
   }
   if (esp_get_free_heap_size() < PRE_RENDER_MIN_FREE_HEAP_BYTES) {
@@ -2236,7 +2241,8 @@ void EpubReaderActivity::renderPreRenderPass(const RenderLayout& layout) {
 #endif
   const int savedPage = section->currentPage;
   section->currentPage = nextPage;
-  auto p = section->loadPageFromSectionFile();
+  auto p = buildActive ? section->loadPageFromActiveBuild(static_cast<uint16_t>(nextPage))
+                       : section->loadPageFromSectionFile();
   section->currentPage = savedPage;
   if (p && !p->hasImages()) {
     const unsigned long preRenderStart = millis();
@@ -2269,7 +2275,7 @@ bool EpubReaderActivity::heapAllowsInPlaceBuild(const bool embeddedStyle) const 
   return freeHeap >= IN_PLACE_BUILD_MIN_FREE_HEAP_BYTES && contigHeap >= IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES;
 }
 
-EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const RenderLayout& layout,
+EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(RenderLock& lock, const RenderLayout& layout,
                                                                          const bool embeddedStyle,
                                                                          const uint8_t imageRendering) {
   // Use a cleaner waveform for the indexing popup right after image pages; a FAST popup refresh
@@ -2291,13 +2297,14 @@ EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const R
   readerPhase_ = ReaderPhase::PRECOMPILING;
   renderer.dropFontMetadata();
 
-  const auto runCreate = [&]() {
-    return section->createSectionFile(getEffectiveReaderFontId(), getEffectiveReaderLineCompression(),
-                                      SETTINGS.extraParagraphSpacing, getEffectiveParagraphAlignment(),
-                                      layout.viewportWidth, layout.viewportHeight, getEffectiveHyphenation(),
-                                      embeddedStyle, getEffectiveBionicReading(), imageRendering, nullptr,
-                                      /*skipEviction=*/false, buildHeadingFonts());
-  };
+  // Build params from the current reader state. embeddedStyle and imageRendering come from
+  // the caller (may differ from lastRenderStats on the CSS-retry path); viewport comes from
+  // the layout already resolved by the caller.
+  Section::BuildParams buildParams = makeSectionBuildParams();
+  buildParams.embeddedStyle = embeddedStyle;
+  buildParams.imageRendering = imageRendering;
+  buildParams.viewportWidth = layout.viewportWidth;
+  buildParams.viewportHeight = layout.viewportHeight;
 
   // Prefer to build WITHOUT releasing the secondary buffer when heap is ample, so the chapter's
   // first page keeps a valid fast-refresh baseline. The in-place attempt defers image decode to
@@ -2317,25 +2324,92 @@ EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const R
   }
 
   const uint32_t createStart = millis();
-  bool createOk = runCreate();
-  LOG_INF("ERS", "createSectionFile returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - createStart,
-          esp_get_free_heap_size());
-  checkHeapIntegrity("after_createSectionFile");
+  bool createOk = false;
 
-  if (!createOk && inPlace) {
-    // The conservative in-place gate was too optimistic. createSectionFile already reset its
-    // build state on failure (Section::stepSectionBuild), so the retry starts clean; free the
-    // buffer for the headroom the blocking foreground path has always relied on.
-    LOG_INF("ERS", "In-place section build failed; retrying with secondary buffer released (free=%lu)",
+  if (inPlace) {
+    // Sliced build: pump one budget slice at a time. Between slices, render any page that
+    // has been written to the section file but not yet shown to the user. This lets the
+    // reader see page 0 (and subsequent pages) as soon as they are built — typically within
+    // the first few hundred milliseconds — rather than waiting for the full chapter.
+    // Per-slice budget matches the background build cadence (40 ms) so the loop stays
+    // responsive. The render between slices is optional: if the target page is not yet built
+    // we simply continue without showing anything new.
+    constexpr uint32_t FG_SLICE_BUDGET_MS = 40;
+    bool pageRenderedDuringBuild = false;
+    uint16_t lastRenderedBuildPage = UINT16_MAX;
+    // Only stream mid-build pages when the nav target is an explicit page number — that's
+    // the only case where showing pages 0..N as they're built is meaningful progress toward
+    // the destination. All other targets (LastPage, Paragraph, ListItem, Anchor, TocIndex,
+    // Percent) can only be resolved after the full build + LUT are written; streaming
+    // unrelated pages would mislead the user (e.g. KOReader sync to p[142] mid-chapter
+    // would flash pages 0..N before jumping to the right page on completion).
+    const bool midBuildRenderEnabled = (navTarget.kind == NavigationTarget::Kind::Page);
+
+    while (true) {
+      const Section::BuildStep step = section->stepSectionBuild(buildParams, FG_SLICE_BUDGET_MS);
+
+      // After each slice, check if there are newly built pages available to show.
+      if (midBuildRenderEnabled) {
+        const uint16_t builtPages = section->activeBuildPageCount();
+        if (builtPages > 0 && builtPages > lastRenderedBuildPage + 1) {
+          // Pages [lastRenderedBuildPage+1 .. builtPages-1] are new. We only show the first
+          // available one per slice to keep the loop responsive; the user sees incremental progress.
+          const uint16_t showPage = (lastRenderedBuildPage == UINT16_MAX) ? 0 : lastRenderedBuildPage + 1;
+          if (showPage < builtPages) {
+            auto page = section->loadPageFromActiveBuild(showPage);
+            if (page) {
+              renderer.clearScreen();
+              section->currentPage = showPage;
+              renderContents(lock, std::move(page), layout.marginTop, layout.marginRight, layout.marginBottom,
+                             layout.marginLeft);
+              pageRenderedDuringBuild = true;
+              lastRenderedBuildPage = showPage;
+              LOG_INF("ERS", "Mid-build render: page %u available after %ums", showPage, millis() - createStart);
+            }
+          }
+        }
+      }
+
+      if (step == Section::BuildStep::Done) {
+        createOk = true;
+        break;
+      }
+      if (step == Section::BuildStep::Failed) {
+        break;
+      }
+      // step == More: continue slicing
+    }
+
+    if (!createOk) {
+      // In-place build failed — retry with secondary buffer released.
+      LOG_INF("ERS", "In-place section build failed; retrying with secondary buffer released (free=%lu)",
+              esp_get_free_heap_size());
+      renderer.releaseSecondaryBuffer();
+      released = true;
+      const uint32_t retryStart = millis();
+      createOk = section->createSectionFile(buildParams.fontId, buildParams.lineCompression,
+                                            buildParams.extraParagraphSpacing, buildParams.paragraphAlignment,
+                                            buildParams.viewportWidth, buildParams.viewportHeight,
+                                            buildParams.hyphenationEnabled, buildParams.embeddedStyle,
+                                            buildParams.bionicReadingEnabled, buildParams.imageRendering, nullptr,
+                                            /*skipEviction=*/false, buildParams.headingFonts);
+      LOG_INF("ERS", "createSectionFile retry returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - retryStart,
+              esp_get_free_heap_size());
+      checkHeapIntegrity("after_createSectionFile_retry");
+    }
+  } else {
+    // Released path: run to completion in one call (no secondary buffer for mid-build rendering).
+    createOk = section->createSectionFile(buildParams.fontId, buildParams.lineCompression,
+                                          buildParams.extraParagraphSpacing, buildParams.paragraphAlignment,
+                                          buildParams.viewportWidth, buildParams.viewportHeight,
+                                          buildParams.hyphenationEnabled, buildParams.embeddedStyle,
+                                          buildParams.bionicReadingEnabled, buildParams.imageRendering, nullptr,
+                                          /*skipEviction=*/false, buildParams.headingFonts);
+    LOG_INF("ERS", "createSectionFile returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - createStart,
             esp_get_free_heap_size());
-    renderer.releaseSecondaryBuffer();
-    released = true;
-    const uint32_t retryStart = millis();
-    createOk = runCreate();
-    LOG_INF("ERS", "createSectionFile retry returned %d in %ums (free=%lu)", createOk ? 1 : 0, millis() - retryStart,
-            esp_get_free_heap_size());
-    checkHeapIntegrity("after_createSectionFile_retry");
   }
+
+  checkHeapIntegrity("after_createSectionFile");
 
   // Eager image pre-decode only on the released path (it needs the freed headroom).
   // warmAllImageCaches writes pixels into the framebuffer as a side effect; clearScreen()
@@ -2378,7 +2452,7 @@ EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const R
   return outcome;
 }
 
-bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
+bool EpubReaderActivity::buildSection(RenderLock& lock, const RenderLayout& layout) {
   const int spineCount = epub->getSpineItemsCount();
   if (currentSpineIndex < 0 || currentSpineIndex >= spineCount) {
     LOG_ERR("ERS", "Render rejected invalid spine index %d (valid 0..%d)", currentSpineIndex, spineCount - 1);
@@ -2420,7 +2494,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
     LOG_DBG("ERS", "Cache not found, building...");
     lastRenderStats.cacheRebuilt = true;
 
-    const BuildOutcome outcome = compileSectionCache(layout, embeddedStyle, imageRendering);
+    const BuildOutcome outcome = compileSectionCache(lock, layout, embeddedStyle, imageRendering);
     if (outcome == BuildOutcome::Restarting) {
       return false;  // fragmented-heap recovery reboot in progress
     }
@@ -2438,7 +2512,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
     LOG_INF("ERS", "No-CSS fallback loaded; rebuilding with embedded CSS...");
     lastRenderStats.cacheRebuilt = true;
 
-    const BuildOutcome outcome = compileSectionCache(layout, embeddedStyle, imageRendering);
+    const BuildOutcome outcome = compileSectionCache(lock, layout, embeddedStyle, imageRendering);
     if (outcome == BuildOutcome::Restarting) {
       return false;  // fragmented-heap recovery reboot in progress
     }
@@ -2652,7 +2726,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       renderNormalPass(lock, layout);
       return;
     case RenderPass::BuildSection:
-      if (!buildSection(layout)) {
+      if (!buildSection(lock, layout)) {
         return;
       }
       // Flush any image dimensions this build just resolved (foreground path).
@@ -3007,9 +3081,11 @@ void EpubReaderActivity::restoreCurrentPageToBufferIfPreRendered() {
 }
 
 void EpubReaderActivity::renderStatusBar() const {
-  // Calculate progress in book
+  // Calculate progress in book. During an active section build pageCount only reflects pages
+  // built so far, not the final chapter length — pass 0 to suppress the fraction and book
+  // progress rather than showing a misleading "3/3" when the chapter has 40 pages total.
   const int currentPage = section->currentPage + 1;
-  const float pageCount = section->pageCount;
+  const float pageCount = (section->hasActiveBuild()) ? 0.0f : static_cast<float>(section->pageCount);
   const float sectionChapterProg = (pageCount > 0) ? (static_cast<float>(currentPage) / pageCount) : 0;
   const float bookProgress = epub->calculateProgress(currentSpineIndex, sectionChapterProg) * 100;
 
@@ -3286,7 +3362,9 @@ bool EpubReaderActivity::drawCurrentPageToBuffer(const std::string& filePath, Gf
   if (pageNumber < 0 || pageNumber >= section->pageCount) pageNumber = 0;
   section->currentPage = pageNumber;
 
-  auto page = section->loadPageFromSectionFile();
+  // During an active build the on-disk LUT is not yet written; load from the in-memory LUT.
+  auto page = section->hasActiveBuild() ? section->loadPageFromActiveBuild(static_cast<uint16_t>(pageNumber))
+                                        : section->loadPageFromSectionFile();
   if (!page) {
     LOG_DBG("SLP", "EPUB: failed to load page %d", pageNumber);
     return false;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -415,7 +415,15 @@ void EpubReaderActivity::onExit() {
   // Abort any in-flight Background-B build (deletes its partial cache file) before the
   // epub it references goes away.
   resetBackgroundBuild();
-  section.reset();
+  section.reset();  // also aborts an in-flight Background-C build of the current section
+  // Background-C may have released the secondary buffer for headroom; the build is now aborted,
+  // so restore the global "buffer resident" invariant before the next activity renders.
+  if (secondaryBufferDegraded_ && !renderer.hasSecondaryBuffer()) {
+    if (renderer.reallocSecondaryBuffer()) {
+      LOG_INF("ERS", "onExit: restored secondary buffer released by Background-C");
+    }
+    secondaryBufferDegraded_ = false;
+  }
   UITheme::getInstance().getMutableTheme().onBookWillClose(epub ? epub->getPath() : "", epub.get(), nullptr, nullptr);
   epub.reset();
   currentPageFootnotes.clear();
@@ -2242,13 +2250,22 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
 }
 
 void EpubReaderActivity::recoverSecondaryBufferIfNeeded() {
-  // Opportunistic recovery: after an OOM during chapter indexing, try to
-  // restore the secondary buffer on subsequent renders when heap may be healthier.
+  // While Background-C is building with the buffer released for headroom, leave it released —
+  // reallocating now would reclaim the ~48–52 KB the build is using. The buffer is restored here
+  // on the first render after the build ends (hasActiveBuild() goes false).
+  if (section && section->hasActiveBuild()) {
+    return;
+  }
+  // Opportunistic recovery: after an OOM during chapter indexing, or after a Background-C
+  // released build, restore the secondary buffer when heap is healthy again.
   if (secondaryBufferDegraded_ && !renderer.hasSecondaryBuffer()) {
     if (renderer.reallocSecondaryBuffer()) {
       secondaryBufferDegraded_ = false;
       if (!renderer.isX3()) renderer.syncRedRamFromFrameBuffer();
       LOG_INF("ERS", "Secondary display buffer restored; re-enabling normal refresh/AA paths");
+    } else {
+      LOG_ERR("ERS", "Secondary display buffer realloc failed (free=%lu); AA stays off, will retry",
+              esp_get_free_heap_size());
     }
   } else if (secondaryBufferDegraded_ && renderer.hasSecondaryBuffer()) {
     secondaryBufferDegraded_ = false;
@@ -2415,34 +2432,29 @@ bool EpubReaderActivity::heapAllowsInPlaceBuild(const bool embeddedStyle) const 
   return freeHeap >= IN_PLACE_BUILD_MIN_FREE_HEAP_BYTES && contigHeap >= IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES;
 }
 
-bool EpubReaderActivity::currentSectionBuildEligible(const bool embeddedStyle) const {
-  // Background-C builds with the secondary buffer resident: on X4 to keep the fast-refresh
-  // baseline + grayscale AA, on X3 only for AA (the differential baseline lives in the
-  // controller's DTM1, so mid-build BW draws don't need it — see docs/contributing/
-  // eink-controllers.md). The blocking-fallback latch forces the old path after a failed attempt.
-  if (forceBlockingBuildSpine_ == currentSpineIndex) return false;
-  if (!renderer.hasSecondaryBuffer()) return false;
+EpubReaderActivity::SectionBuildMode EpubReaderActivity::chooseSectionBuildMode(const bool embeddedStyle) const {
+  // A failed Background-C attempt latches the old blocking path for this spine.
+  if (forceBlockingBuildSpine_ == currentSpineIndex) return SectionBuildMode::Blocking;
+  // No secondary buffer to keep or release (already degraded): blocking path reallocs it at the end.
+  if (!renderer.hasSecondaryBuffer()) return SectionBuildMode::Blocking;
 
-  // CSS books need their selector index to fit alongside the resident buffer (same gate B uses).
-  if (embeddedStyle) {
-    const CssParser* css = epub->getCssParser();
-    if (!Section::heapAllowsEmbeddedStyle(css ? css->ruleCount() : 0)) return false;
-  }
+  // X3 → always build released. Its differential baseline lives in the controller's DTM1, so
+  // keeping the ~52 KB RAM buffer resident buys no display benefit (fast refresh works without it)
+  // and only starves the build — exactly the foreground policy (inPlace is X4-only). Releasing
+  // also keeps CSS parses above the runtime resolve floor (the resident build css-degraded
+  // on-device, then had to be rebuilt blocking). Mid-build BW draws still work off DTM1.
+  if (renderer.isX3()) return SectionBuildMode::IncrementalReleased;
 
-  if (renderer.isX3()) {
-    // X3 holds the differential baseline in-controller, so building with the buffer resident
-    // costs no display benefit — it's the exact regime Background-B already builds in on X3.
-    // Gate on B's proven floors (both defer image decode, so neither needs the foreground
-    // released path's image-decode headroom). The two-phase build self-aborts (→ blocking
-    // fallback) if a large entry's extract ring won't fit, so no ring pre-check is needed here.
-    const uint32_t freeHeap = esp_get_free_heap_size();
-    const uint32_t contigHeap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
-    return freeHeap >= BG_BUILD_PARSE_MIN_FREE_HEAP_BYTES && contigHeap >= BG_BUILD_MIN_CONTIG_HEAP_BYTES;
-  }
+  // X4 CSS book → released too. Built with the ~48 KB buffer resident, a CSS section reliably
+  // drops below the runtime CSS-resolve floor (MIN_FREE_HEAP_FOR_CSS ≈ 40 KB) mid-parse → lookups
+  // skip → css-degraded → a wasted resident build then a blocking rebuild. Releasing keeps it in
+  // the ~120 KB regime where the blocking path builds these clean.
+  if (embeddedStyle) return SectionBuildMode::IncrementalReleased;
 
-  // X4: keep the secondary buffer resident to preserve the fast-refresh baseline (RED RAM is
-  // re-seeded from it) and AA, so require the stricter in-place headroom.
-  return heapAllowsInPlaceBuild(embeddedStyle);
+  // X4 non-CSS book → keep the buffer resident when the in-place floors fit (fast-refresh baseline
+  // re-seeds from it, AA stays live); otherwise release for headroom.
+  return heapAllowsInPlaceBuild(/*embeddedStyle=*/false) ? SectionBuildMode::IncrementalResident
+                                                         : SectionBuildMode::IncrementalReleased;
 }
 
 EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const RenderLayout& layout,
@@ -2617,15 +2629,30 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
 
     // Background-C: build the current section incrementally on the loop task so input stays
     // responsive and pages appear as they are written. Used for the clean cases — a cache miss
-    // or a resumed partial B build — when heap allows building in place. The CSS-fallback
-    // rebuild keeps the blocking path: the section already shows usable fallback content.
-    const bool incremental =
-        (resumeBackgroundBuild || !cacheHit) && !cssFallbackRebuild && currentSectionBuildEligible(embeddedStyle);
+    // or a resumed partial B build. The CSS-fallback rebuild keeps the blocking path: the section
+    // already shows usable fallback content.
+    const SectionBuildMode mode = (resumeBackgroundBuild || !cacheHit) && !cssFallbackRebuild
+                                      ? chooseSectionBuildMode(embeddedStyle)
+                                      : SectionBuildMode::Blocking;
+    const bool incremental = mode != SectionBuildMode::Blocking;
     bool runBlocking = !incremental;
 
     if (incremental) {
-      LOG_INF("ERS", "Background-C: building spine %d incrementally (free=%lu)", currentSpineIndex,
-              esp_get_free_heap_size());
+      if (mode == SectionBuildMode::IncrementalReleased) {
+        // Tight heap: free the secondary buffer (~48–52 KB) for the build. AA is off until the
+        // build ends and recoverSecondaryBufferIfNeeded() reallocates it (marked via
+        // secondaryBufferDegraded_); mid-build draws are BW. No display downside on X3 (baseline
+        // in controller); on X4 fast refresh drops to half until restored.
+        const uint32_t freeBefore = esp_get_free_heap_size();
+        renderer.releaseSecondaryBuffer();
+        secondaryBufferDegraded_ = true;
+        LOG_INF("ERS", "Background-C: building spine %d incrementally, secondary buffer RELEASED (free %lu->%lu)",
+                currentSpineIndex, freeBefore, esp_get_free_heap_size());
+      } else {
+        LOG_INF("ERS", "Background-C: building spine %d incrementally, buffer resident (free=%lu contig=%lu)",
+                currentSpineIndex, esp_get_free_heap_size(),
+                heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT));
+      }
       GUI.drawPopup(renderer, tr(STR_INDEXING));  // immediate feedback before the first page lands
       renderer.clearFontAccumulation();
       readerPhase_ = ReaderPhase::PRECOMPILING;
@@ -2655,6 +2682,13 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
     }
 
     if (runBlocking) {
+      if (!incremental) {
+        // Background-C was not chosen (CSS-fallback rebuild, no secondary buffer, or the
+        // blocking-fallback latch is set for this spine) — log so the mode is visible in traces.
+        LOG_INF("ERS", "Background-C declined for spine %d (cssFallback=%d hasBuf=%d latched=%d); blocking build",
+                currentSpineIndex, cssFallbackRebuild ? 1 : 0, renderer.hasSecondaryBuffer() ? 1 : 0,
+                forceBlockingBuildSpine_ == currentSpineIndex ? 1 : 0);
+      }
       const BuildOutcome outcome = compileSectionCache(layout, embeddedStyle, imageRendering);
       if (outcome == BuildOutcome::Restarting) {
         return false;  // fragmented-heap recovery reboot in progress

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -157,6 +157,11 @@ class EpubReaderActivity final : public Activity {
   // Used by BTN_FORCE_REFRESH / BTN_FORCE_FAST_REFRESH so the user's manual refresh re-displays
   // the current page in the requested mode instead of raw-flushing a possibly pre-rendered buffer.
   int8_t forceRefreshModeNextRender_ = -1;
+  // Refresh mode + display-mode byte of the page just shown, captured at its triggerDisplay
+  // before the deferred-AA grayscale display overwrites the renderer's live last-mode. Logged
+  // by the page summary so it reflects the page, not the AA pass.
+  HalDisplay::RefreshMode lastPageRefreshMode_ = HalDisplay::RefreshMode::FAST_REFRESH;
+  uint8_t lastPageDisplayModeByte_ = 0;
   // True when secondary display buffer allocation failed; while set we prefer
   // conservative refresh policy and skip grayscale AA to reduce ghosting.
   bool secondaryBufferDegraded_ = false;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -466,11 +466,21 @@ class EpubReaderActivity final : public Activity {
   // the nav target and transitions back to READING; on a failed/degraded build it latches a
   // blocking-rebuild fallback. Serialises against the render task via RenderLock.
   void stepCurrentSectionBuild();
-  // True when the current section may be built incrementally in the background (Background-C):
-  // secondary buffer present, no blocking-rebuild latch for this spine, and enough heap to build
-  // with the buffer resident — X4 uses the in-place floors, X3 the (looser) Background-B floors
-  // since X3 keeps the differential baseline in-controller and defers image decode like B.
-  bool currentSectionBuildEligible(bool embeddedStyle) const;
+  // How the current section's (re)build should run. Resident/Released are both incremental
+  // Background-C builds (responsive, build-while-you-read); they differ only in whether the
+  // secondary buffer stays in RAM or is freed for headroom on a tight heap. Blocking is the old
+  // synchronous path, used only when C can't apply (latch set, no buffer, or a CSS-fallback
+  // rebuild — decided by the caller).
+  enum class SectionBuildMode : uint8_t {
+    Blocking,             // synchronous build (no mid-build display)
+    IncrementalResident,  // Background-C, secondary buffer kept resident
+    IncrementalReleased,  // Background-C, secondary buffer released for headroom, restored after
+  };
+  // Pick the build mode (blocking-fallback latch / buffer presence aside). X3 always releases
+  // (its baseline lives in the controller, so a resident buffer only starves the build); X4
+  // releases for CSS books (resident reliably css-degrades) and for non-CSS books that don't fit
+  // the in-place floors, keeping the buffer resident only for non-CSS builds that do fit.
+  SectionBuildMode chooseSectionBuildMode(bool embeddedStyle) const;
   // Render params for a section build of `spineIndex`, identical to what buildSection()
   // passes to createSectionFile — B must build the exact variant the foreground will load.
   Section::BuildParams makeSectionBuildParams() const;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -401,7 +401,7 @@ class EpubReaderActivity final : public Activity {
   // BuildSection pass: construct/load the section cache for currentSpineIndex and resolve the
   // nav target. Returns true if a section is ready to render; false if render() should return
   // (build failed, finished-book handoff, or a requestUpdate retry was posted).
-  bool buildSection(const RenderLayout& layout);
+  bool buildSection(RenderLock& lock, const RenderLayout& layout);
   // Outcome of compileSectionCache(). Restarting means a fragmented-heap recovery reboot was
   // triggered and the caller must return immediately without further work.
   enum class BuildOutcome : uint8_t { Built, Failed, Restarting };
@@ -411,7 +411,8 @@ class EpubReaderActivity final : public Activity {
   // heap is tight or the in-place attempt fails. On the released path it pre-decodes images
   // eagerly and reallocates the buffer (arming a half-refresh); the in-place path defers images
   // to lazy per-page decode and leaves the baseline intact for a normal fast refresh.
-  BuildOutcome compileSectionCache(const RenderLayout& layout, bool embeddedStyle, uint8_t imageRendering);
+  BuildOutcome compileSectionCache(RenderLock& lock, const RenderLayout& layout, bool embeddedStyle,
+                                   uint8_t imageRendering);
   // True when heap is ample enough to build the current section WITHOUT releasing the secondary
   // buffer (the in-place path). Reuses Section::heapAllowsEmbeddedStyle for CSS books.
   bool heapAllowsInPlaceBuild(bool embeddedStyle) const;
@@ -537,6 +538,7 @@ class EpubReaderActivity final : public Activity {
   void loop() override;
   void render(RenderLock&& lock) override;
   bool isReaderActivity() const override { return true; }
+  bool preventAutoSleep() override { return section && section->hasActiveBuild(); }
   // A pending pre-render leaves the *next* page in the frame buffer; redraw the current page
   // so a screenshot (or any raw frame-buffer capture) matches what the user sees.
   void prepareFramebufferForCapture() override { restoreCurrentPageToBufferIfPreRendered(); }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -121,11 +121,14 @@ class EpubReaderActivity final : public Activity {
   // render() then dispatches to the matching helper. Replaces the former in-line
   // ladder of isPreRenderPass / isBufferDisplayPass / !section bool checks.
   enum class RenderPass : uint8_t {
-    FinishedBook,   // currentSpineIndex == spineCount: hand off to FinishedBookActivity
-    PreRender,      // Background A: render next page content into the framebuffer only
-    BufferDisplay,  // fast page-turn: framebuffer already holds content; add status bar + flush
-    BuildSection,   // no section loaded → build/load the cache, then render normally
-    Normal,         // section present → load page, render, display
+    FinishedBook,     // currentSpineIndex == spineCount: hand off to FinishedBookActivity
+    PreRender,        // Background A: render next page content into the framebuffer only
+    BufferDisplay,    // fast page-turn: framebuffer already holds content; add status bar + flush
+    BuildSection,     // no section loaded → build/load the cache, then render normally
+    SectionBuilding,  // current section is being built incrementally (Background-C): draw the
+                      // requested page from the in-progress LUT, or an "Indexing" popup if it
+                      // isn't built yet. The build itself runs on the loop task, not here.
+    Normal,           // section present → load page, render, display
   };
 
   // Resolved screen geometry for one render pass: oriented + padded margins and the
@@ -288,6 +291,21 @@ class EpubReaderActivity final : public Activity {
   //              next section in the lookahead window (or idles if the window is exhausted)
   enum class BackgroundBuildState : uint8_t { Probe, WaitHeap, Building, Settled };
   BackgroundBuildState backgroundBuildState_ = BackgroundBuildState::Probe;
+  // --- Background C (incremental build of the CURRENT section while the reader watches) ---
+  // When the spine the user just entered has no cache, buildSection() starts an in-place
+  // incremental build owned by `section` and hands the slicing to stepCurrentSectionBuild()
+  // on the loop task, so input stays responsive. The render task only ever draws (the
+  // SectionBuilding pass). State below coordinates that hand-off.
+  //
+  // Page last drawn by the SectionBuilding pass (-1 = none yet / popup showing). Stops the
+  // pass redrawing the same page every idle tick.
+  int buildDisplayedPage_ = -1;
+  // True once the "Indexing" popup has been drawn for the current pending page, so the pass
+  // doesn't re-flush it every tick. Cleared whenever a real page is drawn or the build ends.
+  bool buildingPopupShown_ = false;
+  // Spine for which the incremental build failed/degraded and must be retried with the old
+  // blocking (secondary-buffer-released) path instead of Background-C. -1 = no such latch.
+  int forceBlockingBuildSpine_ = -1;
   // Debug-only Background A glyph for the status-bar overlay. The transient flags
   // (pendingPreRender / preRenderedPage.ready) are cleared at the top of render()
   // before the status bar is drawn, so the overlay could never sample a non-idle
@@ -401,7 +419,7 @@ class EpubReaderActivity final : public Activity {
   // BuildSection pass: construct/load the section cache for currentSpineIndex and resolve the
   // nav target. Returns true if a section is ready to render; false if render() should return
   // (build failed, finished-book handoff, or a requestUpdate retry was posted).
-  bool buildSection(RenderLock& lock, const RenderLayout& layout);
+  bool buildSection(const RenderLayout& layout);
   // Outcome of compileSectionCache(). Restarting means a fragmented-heap recovery reboot was
   // triggered and the caller must return immediately without further work.
   enum class BuildOutcome : uint8_t { Built, Failed, Restarting };
@@ -411,13 +429,16 @@ class EpubReaderActivity final : public Activity {
   // heap is tight or the in-place attempt fails. On the released path it pre-decodes images
   // eagerly and reallocates the buffer (arming a half-refresh); the in-place path defers images
   // to lazy per-page decode and leaves the baseline intact for a normal fast refresh.
-  BuildOutcome compileSectionCache(RenderLock& lock, const RenderLayout& layout, bool embeddedStyle,
-                                   uint8_t imageRendering);
+  BuildOutcome compileSectionCache(const RenderLayout& layout, bool embeddedStyle, uint8_t imageRendering);
   // True when heap is ample enough to build the current section WITHOUT releasing the secondary
   // buffer (the in-place path). Reuses Section::heapAllowsEmbeddedStyle for CSS books.
   bool heapAllowsInPlaceBuild(bool embeddedStyle) const;
   // Normal pass: load the current page from the section cache, render it, persist progress.
   void renderNormalPass(RenderLock& lock, const RenderLayout& layout);
+  // SectionBuilding pass: while Background-C builds the current section, draw the requested
+  // page from the in-progress LUT once it's been written (text-only pages only), or an
+  // "Indexing" popup until then. Does no build work itself — that's stepCurrentSectionBuild().
+  void renderSectionBuildingPass(RenderLock& lock, const RenderLayout& layout);
 
   // --- idle-time background work ---
   // Called by loop() when input is idle and no page turn is pending. Dispatches the
@@ -438,6 +459,18 @@ class EpubReaderActivity final : public Activity {
   // Serialises SD access against the render task via RenderLock; skips the tick instead of
   // blocking when the render task is busy.
   void stepBackgroundSectionBuild();
+  // Background C: advance the incremental build of the CURRENT section (the one the reader is
+  // looking at) by one bounded slice. Runs only while `section` has an active build, with the
+  // highest reader-build priority (ahead of A and B). On a newly built target page or on
+  // completion it posts a requestUpdate() so the render task draws it; on completion it resolves
+  // the nav target and transitions back to READING; on a failed/degraded build it latches a
+  // blocking-rebuild fallback. Serialises against the render task via RenderLock.
+  void stepCurrentSectionBuild();
+  // True when the current section may be built incrementally in the background (Background-C):
+  // secondary buffer present, no blocking-rebuild latch for this spine, and enough heap to build
+  // with the buffer resident — X4 uses the in-place floors, X3 the (looser) Background-B floors
+  // since X3 keeps the differential baseline in-controller and defers image decode like B.
+  bool currentSectionBuildEligible(bool embeddedStyle) const;
   // Render params for a section build of `spineIndex`, identical to what buildSection()
   // passes to createSectionFile — B must build the exact variant the foreground will load.
   Section::BuildParams makeSectionBuildParams() const;
@@ -452,6 +485,10 @@ class EpubReaderActivity final : public Activity {
   // at display time with live values (clock, battery).
   void renderPageContentOnly(const Page& page, int orientedMarginTop, int orientedMarginRight, int orientedMarginBottom,
                              int orientedMarginLeft);
+  // Draws a single text-only page from an in-progress Background-C build (no AA, no pre-render
+  // arming). Releases the lock before the waveform wait (like renderContents) so a C build
+  // slice can run on the loop task during the refresh.
+  void displayBuildPage(RenderLock& lock, const Page& page, const RenderLayout& layout);
   // Draws the status bar over the current frame buffer and flushes to the display.
   // Handles the refresh cycle and grayscale AA pass. page must be the same page
   // that was last rendered into the buffer (needed for image AA re-render).

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -595,8 +595,10 @@ void KOReaderSyncActivity::render(RenderLock&&) {
   }
 
   if (state == SYNCING || state == UPLOADING) {
-    GUI.drawPopup(renderer, statusMessage.c_str());
-    renderer.displayBuffer();
+    // Title frame already composed into the write buffer above (clearScreen); overlay the popup on
+    // it. drawPopup ships the frame itself — a second displayBuffer() here would ship the stale
+    // post-swap buffer.
+    GUI.drawPopup(renderer, statusMessage.c_str(), /*overlayDisplayedFrame=*/false);
     return;
   }
 

--- a/src/activities/reader/MdReaderActivity.cpp
+++ b/src/activities/reader/MdReaderActivity.cpp
@@ -598,11 +598,7 @@ void MdReaderActivity::buildPageIndex() {
 
   LOG_DBG("MDR", "Building page index for %zu bytes...", fileSize);
 
-  // Resync the write buffer to the displayed frame so the popup overlays what's
-  // on screen rather than the stale two-refreshes-ago frame left by a partial
-  // repaint (e.g. the recent-books grid that launched us). See ReaderActivity.
-  renderer.syncWriteBufferFromDisplayed();
-  GUI.drawPopup(renderer, tr(STR_INDEXING));
+  GUI.drawPopup(renderer, tr(STR_INDEXING));  // overlays the displayed frame (drawPopup resyncs the write buffer)
 
   while (offset < fileSize) {
     std::vector<RenderedLine> tempLines;

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -562,15 +562,9 @@ void ReaderActivity::onEnter() {
     // file-existence checks (no parsing), so this is cheap.
     if (Epub(initialBookPath, "/.crosspoint").needsFirstOpenIndexing()) {
       RenderLock lock;
-      // drawPopup() overlays the indexing box on the write buffer and ships it
-      // with a differential refresh. displayBuffer() swaps buffers, so the write
-      // buffer holds the frame from two refreshes ago — and the screen we were
-      // launched from (e.g. the recent-books grid) uses a partial repaint, so
-      // that stale frame shows the previous selection. Without this resync the
-      // diff toggles the old/new selection cells back, making the highlight
-      // visibly jump before the popup appears. Sync to the displayed frame so
-      // the popup overlays what's actually on screen.
-      renderer.syncWriteBufferFromDisplayed();
+      // drawPopup() overlays the indexing box on the displayed frame (it resyncs the write buffer
+      // from the screen first), so the box lands on the launcher screen — e.g. the recent-books grid
+      // — without the stale-buffer diff toggling the old/new selection cells before the popup appears.
       GUI.drawPopup(renderer, tr(STR_INDEXING));
     }
     auto epub = loadEpub(initialBookPath);

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -150,11 +150,7 @@ void TxtReaderActivity::buildPageIndex() {
 
   LOG_DBG("TRS", "Building page index for %zu bytes...", fileSize);
 
-  // Resync the write buffer to the displayed frame so the popup overlays what's
-  // on screen rather than the stale two-refreshes-ago frame left by a partial
-  // repaint (e.g. the recent-books grid that launched us). See ReaderActivity.
-  renderer.syncWriteBufferFromDisplayed();
-  GUI.drawPopup(renderer, tr(STR_INDEXING));
+  GUI.drawPopup(renderer, tr(STR_INDEXING));  // overlays the displayed frame (drawPopup resyncs the write buffer)
 
   while (offset < fileSize) {
     std::vector<std::string> tempLines;

--- a/src/activities/settings/OpdsSettingsActivity.cpp
+++ b/src/activities/settings/OpdsSettingsActivity.cpp
@@ -224,11 +224,14 @@ void OpdsSettingsActivity::render(RenderLock&&) {
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
+  // Full settings frame already composed into the write buffer above; overlay the popup on it.
+  // drawPopup ships the frame itself, so only display directly when no popup was drawn — calling
+  // displayBuffer() again after drawPopup would ship the stale post-swap buffer.
   if (!popupMessage.empty()) {
-    GUI.drawPopup(renderer, popupMessage.c_str());
+    GUI.drawPopup(renderer, popupMessage.c_str(), /*overlayDisplayedFrame=*/false);
   } else if (showSaveError) {
-    GUI.drawPopup(renderer, tr(STR_ERROR_GENERAL_FAILURE));
+    GUI.drawPopup(renderer, tr(STR_ERROR_GENERAL_FAILURE), /*overlayDisplayedFrame=*/false);
+  } else {
+    renderer.displayBuffer();
   }
-
-  renderer.displayBuffer();
 }

--- a/src/activities/util/BmpViewerActivity.cpp
+++ b/src/activities/util/BmpViewerActivity.cpp
@@ -384,14 +384,15 @@ void BmpViewerActivity::setAsSleepScreen() {
   if (!success) {
     LOG_ERR("BMP", "Failed to set %s as sleep screen", filePath.c_str());
     RenderLock lock(*this);
+    // drawPopup ships the frame; preseed its refresh mode to HALF instead of shipping twice.
+    renderer.setNextDisplayRefreshMode(HalDisplay::HALF_REFRESH);
     GUI.drawPopup(renderer, tr(STR_FAILED_TO_SET_SLEEP_SCREEN));
-    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
     return;
   }
 
   RenderLock lock(*this);
+  renderer.setNextDisplayRefreshMode(HalDisplay::HALF_REFRESH);
   GUI.drawPopup(renderer, tr(STR_SLEEP_SCREEN_SET));
-  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 }
 
 void BmpViewerActivity::loop() {

--- a/src/activities/weather/WeatherActivity.cpp
+++ b/src/activities/weather/WeatherActivity.cpp
@@ -501,7 +501,8 @@ void WeatherActivity::render(RenderLock&&) {
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   if (state == State::FETCHING && showRefreshPopup) {
-    GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
+    // Full weather frame already composed into the write buffer above; overlay the popup on it.
+    GUI.drawPopup(renderer, tr(STR_LOADING_POPUP), /*overlayDisplayedFrame=*/false);
   } else {
     renderer.displayBuffer();
   }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -731,7 +731,10 @@ void BaseTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   }
 }
 
-Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message) const {
+Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message, const bool overlayDisplayedFrame) const {
+  // Re-seed the write buffer from the frame on screen so the box overlays current content, not the
+  // stale two-refreshes-ago frame left by the last buffer swap. Compose-then-popup callers skip this.
+  if (overlayDisplayedFrame) renderer.syncWriteBufferFromDisplayed();
   constexpr int margin = 15;
   constexpr int y = 60;
   const int textWidth = renderer.getTextWidth(UI_12_FONT_ID, message, EpdFontFamily::BOLD);

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -156,7 +156,13 @@ class BaseTheme {
   virtual void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                               const std::function<std::string(int index)>& buttonLabel,
                               const std::function<UIIcon(int index)>& rowIcon) const;
-  virtual Rect drawPopup(const GfxRenderer& renderer, const char* message) const;
+  // Draws a centered message box and ships it. By default the box is overlaid on the frame that is
+  // currently on screen: displayBuffer() ends in a buffer swap, so the write buffer holds the frame
+  // from two refreshes ago, and a bare overlay would diff stale content around the box (ghosting).
+  // Syncing the write buffer from the displayed frame first fixes that. Callers that have already
+  // composed a full fresh frame into the write buffer (clearScreen + render, then popup in the same
+  // displayBuffer) must pass overlayDisplayedFrame=false so their render is not discarded.
+  virtual Rect drawPopup(const GfxRenderer& renderer, const char* message, bool overlayDisplayedFrame = true) const;
   virtual void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const;
   virtual void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage,
                              const int pageCount, std::string title, const int paddingBottom = 0,

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -689,7 +689,10 @@ void LyraTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   }
 }
 
-Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message) const {
+Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message, const bool overlayDisplayedFrame) const {
+  // See BaseTheme::drawPopup: overlay the box on the displayed frame unless the caller composed its
+  // own full frame into the write buffer.
+  if (overlayDisplayedFrame) renderer.syncWriteBufferFromDisplayed();
   constexpr int y = 132;
   constexpr int outline = 2;
   const int textWidth = renderer.getTextWidth(UI_12_FONT_ID, message, EpdFontFamily::REGULAR);

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -69,7 +69,7 @@ class LyraTheme : public BaseTheme {
                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
                            std::function<bool()> storeCoverBuffer) const override;
   void drawEmptyRecents(const GfxRenderer& renderer, const Rect rect) const;
-  Rect drawPopup(const GfxRenderer& renderer, const char* message) const override;
+  Rect drawPopup(const GfxRenderer& renderer, const char* message, bool overlayDisplayedFrame = true) const override;
   void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const override;
   void drawTextField(const GfxRenderer& renderer, Rect rect, const int textWidth, bool cursorMode = false,
                      int contentStartX = 0, int contentWidth = 0) const override;


### PR DESCRIPTION
## Background-C: build-while-you-read for uncached sections + supporting fixes

### Sliced sectioning on an empty cache hit

When the reader lands on a section with **no cache** — first open, a TOC/percent/anchor jump, a settings or orientation change that invalidated caches, or a section Background-B was heap-gated out of — it previously froze for a blocking "Indexing…" parse (~1–1.5 s). This branch replaces that with a **sliced, build-while-you-read** path that keeps the UI responsive.

**Handover logic** (two FreeRTOS tasks, serialised by the single `RenderLock`):
- `buildSection()` (render task) detects the cache miss, picks a build mode, draws the "Indexing" popup, kicks off the build so `hasActiveBuild()` is true, and **returns** — handing the work off.
- `stepCurrentSectionBuild()` (loop task) drives the parse in **40 ms slices** during the idle window that opens while the e-ink waveform settles (`renderContents()` releases the lock before the blocking refresh wait). It holds the highest reader-build priority in `serviceBackgroundWork()`.
- As soon as a slice writes the target page it `requestUpdate()`s, and the render task's `SectionBuilding` pass draws that page straight from the in-progress build via the new `Section::loadPageFromActiveBuild()` / `activeBuildPageCount()` API (text-only). Reads sync the writer first so the temporary read handle sees committed bytes. Until the target page exists, the popup stays up.

**Benefit:** crossing into an uncached chapter shows page 0 in ~1–1.5 s with the popup as immediate feedback, instead of a dead-screen freeze, and forward reading can begin before the whole section is built.

**Edge cases handled:**
- **Navigation mid-build** — only an explicit `Page` target advances optimistically (page shown once the build reaches it, popup until then); back works, back past page 0 leaves the chapter. Paragraph/anchor/percent/last-page targets resolve only at `Done`.
- **Failure** (failed / truncated / CSS-degraded) — discard, latch `forceBlockingBuildSpine_`, and fall back to the blocking path (buffer released for ~52 KB headroom).
- **Mid-build exit** — `onExit()` restores the secondary buffer if the reader is left while a released build is in flight.

### X3 fixes / build-mode distinction (`chooseSectionBuildMode()`)

Made the build mode explicit per device instead of one path:
- **X3 → always `IncrementalReleased`.** Its differential baseline lives in the controller's DTM1, so releasing the ~52 KB RAM buffer costs no display benefit (fast refresh still works) and keeps CSS parses above the runtime resolve floor — avoids the resident-CSS path silently css-degrading and forcing a wasted rebuild.
- **X4 + CSS → released too** (resident CSS reliably degrades).
- **X4 + non-CSS → resident** when the in-place floors fit (keeps the fast-refresh baseline live), else released.
- Released builds set `secondaryBufferDegraded_`; `recoverSecondaryBufferIfNeeded()` reallocates and (X4) reseeds on the first render after the build ends.

### Popup fixes

`drawPopup()` overlaid the **write** buffer, which after `displayBuffer()`'s buffer swap holds the frame from two refreshes ago — so popups ghosted stale content around the box (visible on the EPUB section-change "Indexing" popup).
- `drawPopup()` now resyncs the write buffer from the displayed frame by default (`overlayDisplayedFrame=true`), so the box always lands on what's actually on screen. Callers that compose a full fresh frame themselves (Weather, OPDS, KOReaderSync) opt out with `overlayDisplayedFrame=false`.
- Removed the now-redundant explicit syncs at the reader call sites.
- Fixed **double `displayBuffer()`** in OPDS / KOReaderSync / BmpViewer / FileBrowser, where a second ship after `drawPopup` pushed the stale post-swap buffer (popup flashed, then got overwritten). Each now ships exactly once; HALF-refresh intent preserved via `setNextDisplayRefreshMode()`.

### Low-mem safety nets & misc

- Early-abort for sliced builds that start css-degrading mid-parse (`Section::activeBuildCssDegraded()`) instead of finishing a build that will be discarded.
- Background work yields the lock if a refresh/render is in flight, with a re-check under the lock (the render task may have turned a page or started a refresh in the meantime).
- New `docs/background-rendering.md` — current-state reference for the A/B/C background mechanisms; older handoff docs marked historical.
