### PR TITLE
refactor: X3 OEM differential grayscale (AA-pre-BW) — default path only

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2862,6 +2862,10 @@ size_t GfxRenderer::getBufferSize() const { return frameBufferSize; }
 // unused
 // void GfxRenderer::grayscaleRevert() const { display.grayscaleRevert(); }
 
+void GfxRenderer::displayGrayscaleBase(HalDisplay::RefreshMode fallback) const {
+  display.displayGrayscaleBase(fallback, fadingFix);
+}
+
 void GfxRenderer::preconditionGrayscale() const { display.preconditionGrayscale(); }
 
 void GfxRenderer::preconditionGrayscale(int x, int y, int w, int h) const {

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2873,8 +2873,9 @@ void GfxRenderer::preconditionGrayscale(int x, int y, int w, int h) const {
   // Rotate the logical rect's opposite corners to physical panel coords; the
   // physical bbox stays axis-aligned for all four orientations.
   int ax, ay, bx, by;
-  rotateCoordinates(orientation, x, y, &ax, &ay, panelWidth, panelHeight);
-  rotateCoordinates(orientation, x + w - 1, y + h - 1, &bx, &by, panelWidth, panelHeight);
+  const Orientation o = getOrientation();
+  rotateCoordinates(o, x, y, &ax, &ay, panelWidth, panelHeight);
+  rotateCoordinates(o, x + w - 1, y + h - 1, &bx, &by, panelWidth, panelHeight);
   int x0 = ax < bx ? ax : bx, x1 = ax > bx ? ax : bx;
   int y0 = ay < by ? ay : by, y1 = ay > by ? ay : by;
   if (x0 < 0) x0 = 0;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2862,6 +2862,26 @@ size_t GfxRenderer::getBufferSize() const { return frameBufferSize; }
 // unused
 // void GfxRenderer::grayscaleRevert() const { display.grayscaleRevert(); }
 
+void GfxRenderer::preconditionGrayscale() const { display.preconditionGrayscale(); }
+
+void GfxRenderer::preconditionGrayscale(int x, int y, int w, int h) const {
+  if (w <= 0 || h <= 0) return;
+  // Rotate the logical rect's opposite corners to physical panel coords; the
+  // physical bbox stays axis-aligned for all four orientations.
+  int ax, ay, bx, by;
+  rotateCoordinates(orientation, x, y, &ax, &ay, panelWidth, panelHeight);
+  rotateCoordinates(orientation, x + w - 1, y + h - 1, &bx, &by, panelWidth, panelHeight);
+  int x0 = ax < bx ? ax : bx, x1 = ax > bx ? ax : bx;
+  int y0 = ay < by ? ay : by, y1 = ay > by ? ay : by;
+  if (x0 < 0) x0 = 0;
+  if (y0 < 0) y0 = 0;
+  if (x1 >= panelWidth) x1 = panelWidth - 1;
+  if (y1 >= panelHeight) y1 = panelHeight - 1;
+  if (x1 < x0 || y1 < y0) return;
+  display.preconditionGrayscale(static_cast<uint16_t>(x0), static_cast<uint16_t>(y0),
+                                static_cast<uint16_t>(x1 - x0 + 1), static_cast<uint16_t>(y1 - y0 + 1));
+}
+
 void GfxRenderer::copyGrayscaleLsbBuffers() const { display.copyGrayscaleLsbBuffers(frameBuffer); }
 
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -280,6 +280,10 @@ class GfxRenderer {
   // frame is displayed and before the grayscale planes are written.
   void preconditionGrayscale() const;
   void preconditionGrayscale(int x, int y, int w, int h) const;
+  // Display the framebuffer as the base frame for a grayscale overlay that
+  // follows (X3: OEM differential base waveform; others: plain display with
+  // `fallback`).
+  void displayGrayscaleBase(HalDisplay::RefreshMode fallback = HalDisplay::HALF_REFRESH) const;
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
   void displayGrayBuffer() const;

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -273,6 +273,13 @@ class GfxRenderer {
   // GfxRenderer.cpp for the per-level pixel breakdown and a worked example.
   void setTextDarkness(const uint8_t d) { textDarkness.store(d, std::memory_order_relaxed); }
   uint8_t getTextDarkness() const { return static_cast<uint8_t>(textDarkness.load(std::memory_order_relaxed)); }
+
+  // Grayscale preconditioning settle pass (no-op on X4). The rect overload
+  // takes the gray region in LOGICAL screen coordinates and rotates it to the
+  // panel; the no-arg overload settles the full frame. Call after the BW base
+  // frame is displayed and before the grayscale planes are written.
+  void preconditionGrayscale() const;
+  void preconditionGrayscale(int x, int y, int w, int h) const;
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
   void displayGrayBuffer() const;

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -135,6 +135,12 @@ void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* m
   einkDisplay.copyGrayscaleBuffers(lsbBuffer, msbBuffer);
 }
 
+void HalDisplay::preconditionGrayscale() { einkDisplay.preconditionGrayscale(); }
+
+void HalDisplay::preconditionGrayscale(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+  einkDisplay.preconditionGrayscale(x, y, w, h);
+}
+
 void HalDisplay::copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer) { einkDisplay.copyGrayscaleLsbBuffers(lsbBuffer); }
 
 void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { einkDisplay.copyGrayscaleMsbBuffers(msbBuffer); }

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -135,6 +135,10 @@ void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* m
   einkDisplay.copyGrayscaleBuffers(lsbBuffer, msbBuffer);
 }
 
+void HalDisplay::displayGrayscaleBase(RefreshMode fallback, bool turnOffScreen) {
+  einkDisplay.displayGrayscaleBase(convertRefreshMode(fallback), turnOffScreen);
+}
+
 void HalDisplay::preconditionGrayscale() { einkDisplay.preconditionGrayscale(); }
 
 void HalDisplay::preconditionGrayscale(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -95,6 +95,13 @@ class HalDisplay {
   // for the contract the caller must uphold.
   void setSingleBufferFastDiff(bool enabled);
 
+  // X3 grayscale preconditioning (OEM "AA-pre-BW(mid)" settle pass), windowed
+  // to the gray region in physical panel coordinates (no-arg = full frame).
+  // Call after the BW base frame is displayed and before the grayscale planes
+  // are written; no-op on X4. See EInkDisplay::preconditionGrayscale.
+  void preconditionGrayscale();
+  void preconditionGrayscale(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+
   void copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* msbBuffer);
   void copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer);
   void copyGrayscaleMsbBuffers(const uint8_t* msbBuffer);

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -102,6 +102,12 @@ class HalDisplay {
   void preconditionGrayscale();
   void preconditionGrayscale(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
 
+  // Display the framebuffer as the base frame for a grayscale overlay that
+  // follows. X3 uses the OEM differential base waveform ("AA-pre-BW(mid)");
+  // other panels display normally with `fallback` mode (previous behavior).
+  // Deliberately does NOT force the X3 resync that displayBuffer(HALF) does.
+  void displayGrayscaleBase(RefreshMode fallback = HALF_REFRESH, bool turnOffScreen = false);
+
   void copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* msbBuffer);
   void copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer);
   void copyGrayscaleMsbBuffers(const uint8_t* msbBuffer);

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -580,7 +580,15 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const BookOver
 
   drawOverlay();
 
-  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+  if (hasGreyscale && !renderer.getFastGrayscaleLut()) {
+    // Default X3 grayscale path: display the BW base with the OEM differential
+    // "AA-pre-BW(mid)" waveform so the panel is left in the calibrated state the
+    // gray nudge expects (no-op → plain HALF refresh on X4). The community-fast
+    // LUT path keeps the plain base refresh it was tuned for.
+    renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+  } else {
+    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+  }
 
   if (hasGreyscale) {
     bitmap.rewindToData();

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -257,8 +257,29 @@ void XtcReaderActivity::renderPage() {
       renderer.writePhysicalPortraitPackedRow(y, row, maxSrcX, invertBits);
     }
 
-    // Display BW with conditional refresh based on pagesUntilFullRefresh
-    ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
+    // Display the BW base frame ahead of the grayscale overlay. The default X3
+    // path uses the OEM differential grayscale pipeline (SDK AA-pre-BW); the
+    // community-fast LUT path keeps the strong-base + community gray-nudge flow
+    // it was tuned for. On X4 both branches behave as before (no-ops fall back
+    // to the same refreshes displayWithRefreshCycle issued).
+    if (renderer.getFastGrayscaleLut()) {
+      ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
+    } else {
+      const int freq = SETTINGS.getRefreshFrequency();
+      if (freq != 0 && pagesUntilFullRefresh <= 1) {
+        // Periodic ghost cleanup: scrub via the normal HALF path, then run the
+        // settle flavor of the grayscale base pass (DTM planes are equal after
+        // the sync, so only the gentle reinforcement cells fire).
+        renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+        renderer.preconditionGrayscale();
+        pagesUntilFullRefresh = freq;
+      } else {
+        // Differential "AA-pre-BW(mid)" base update as the page turn on X3;
+        // plain FAST refresh on X4.
+        renderer.displayGrayscaleBase(HalDisplay::FAST_REFRESH);
+        if (freq != 0) pagesUntilFullRefresh--;
+      }
+    }
 
     // Pass 2: LSB buffer - mark DARK gray only (XTH value 1)
     // In LUT: 0 bit = apply gray effect, 1 bit = untouched


### PR DESCRIPTION
Ports the OEM X3 "AA-pre-BW(mid)" differential grayscale pipeline from upstream
`crosspoint-reader/community-sdk` #19 and `crosspoint-reader/crosspoint-reader` #2334
into our diverged fork. **X3-only; X4 behaviour is unchanged.**

## Commits
- Two plumbing commits cherry-picked **verbatim from Justin Mitchell** (`@justin@jmitch.com`): `GfxRenderer`/`HalDisplay` exposing `preconditionGrayscale()` and `displayGrayscaleBase()`.
- One follow-up (mine, co-authoring Justin): call-site wiring + SDK submodule bump + a fork adaptation (atomic `orientation` → `getOrientation()`).

Requires the matching `open-x4-sdk` submodule bump (4 commits cherry-picked onto `crosspoint-xdk` branch `graybase-port`, Justin preserved as author), included here as the gitlink change.

## Design decision
Community-fast 7-frame LUT path is kept **unchanged** (it was tuned for the strong-base + community gray-nudge flow). The new differential base/precondition logic applies to the **default** X3 grayscale path only. Call sites gate on `renderer.getFastGrayscaleLut()`:
- XtcReaderActivity grayscale page turn
- grayscale sleep screen

On X4 both branches fall back to the same refreshes as before (SDK methods are no-ops/plain `displayBuffer`).

## Verification
- Firmware builds (Flash 94.4%).
- 204/204 host unit tests pass.
- ⚠️ **X3 on-device validation still pending** — waveforms are reverse-engineered from OEM V5.6.33; the benefit (less muddy grayscale) is subjective and unverified on hardware.