### PR TITLE
feat: reduce indexing look ahead / keep html files

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -1092,6 +1092,18 @@ uint16_t Section::activeBuildPageCount() const {
   return pageCount;  // pageCount is incremented by onPageComplete() as each page is written
 }
 
+uint16_t Section::estimatedTotalPages() const {
+  // No build live -> the on-disk count is exact. While building, project from how much of the
+  // XHTML has been consumed (activeBuildPercent), but never below what's already laid out. At
+  // 100% the stream is exhausted and pageCount is final. Too early (no pages / 0%) -> fall back
+  // to the watermark. Adapted from crosspoint-reader PR #2452 ("Lazy incremental EPUB indexing").
+  if (!buildState_) return pageCount;
+  const int pct = activeBuildPercent();
+  if (pct <= 0 || pct >= 100 || pageCount == 0) return pageCount;
+  const uint32_t projected = static_cast<uint32_t>(pageCount) * 100u / static_cast<uint32_t>(pct);
+  return projected > pageCount ? static_cast<uint16_t>(projected) : pageCount;
+}
+
 bool Section::activeBuildCssDegraded() const {
   // Read the live CSS resolver's running stats: lowHeapSkips is incremented the moment the
   // resolver drops a disk lookup under heap pressure (see CssParser), so it flags a degrading

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -132,6 +132,12 @@ std::string Section::getSectionFilePath(uint32_t propertyHash) const {
   return epub->getCachePath() + "/sections/" + buf + ".bin";
 }
 
+std::string Section::getSectionHtmlCachePath() const {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "html_%d", spineIndex);
+  return epub->getCachePath() + "/sections/" + buf + ".bin";
+}
+
 std::string Section::getImageBasePath(uint32_t propertyHash) const {
   char buf[32];
   snprintf(buf, sizeof(buf), "img_%d_%08x_", spineIndex, propertyHash);
@@ -431,6 +437,9 @@ struct Section::BuildState {
   // extra SD round-trip.
   bool useTempExtract = false;
   bool extractDone = false;
+  // True when tempPath is the book-keyed HTML cache opened for READ (reused, not produced this
+  // build): phase (a) is skipped and the cache is kept on cleanup rather than deleted.
+  bool reusedHtml = false;
   FsFile tempFile;
   std::string tempPath;
   size_t tempBytesFed = 0;
@@ -586,29 +595,62 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
 
   if (!st.parseStarted) {
     st.parseStarted = true;
-    st.useTempExtract = budgetMs != 0;
-    // Heap, not stack: these must survive across slices. Ring (≤32 KB, sized to the
-    // entry) + 2× PARSE_CHUNK_BYTES scratch — the same buffers readFileToStream held
-    // for the whole stream, so net-neutral vs the old one-shot path.
-    st.zip.reset(new (std::nothrow) ZipFile(epub->getPath()));
+    // The parse always feeds the visitor from a temp SD file (phase b); chunkBuf is its read
+    // buffer, so allocate it whether the cached HTML is reused or produced now.
     st.chunkBuf.reset(new (std::nothrow) uint8_t[PARSE_CHUNK_BYTES]);
-    if (st.zip && st.chunkBuf) {
-      st.reader.reset(new (std::nothrow) ZipFile::EntryReader(*st.zip, PARSE_CHUNK_BYTES));
-    }
-    if (!st.reader) {
-      LOG_ERR("SCT", "Failed to allocate entry reader (%u bytes scratch, free=%lu)",
-              static_cast<uint32_t>(PARSE_CHUNK_BYTES), esp_get_free_heap_size());
+    if (!st.chunkBuf) {
+      LOG_ERR("SCT", "Failed to allocate parse chunk buffer (free=%lu)", esp_get_free_heap_size());
       streamFailed = true;
-    } else {
-      const std::string entryPath = FsHelpers::normalisePath(st.localPath);
-      if (!st.reader->open(entryPath.c_str())) {
-        streamFailed = true;  // EntryReader::open already logged the cause
+    }
+
+    // Book-keyed unzipped-HTML cache (adapted from crosspoint-reader PR #2452): the spine's
+    // inflated XHTML keyed on the spine alone, NOT on render properties. If a valid one exists,
+    // read it directly and skip the (multi-second on a big spine) ZIP inflation — the win across
+    // settings changes and rebuilds. A size mismatch means it is stale/partial (e.g. interrupted
+    // by power loss); drop it and re-inflate.
+    const std::string htmlCachePath = getSectionHtmlCachePath();
+    if (!streamFailed && st.inflatedSize > 0 && Storage.exists(htmlCachePath.c_str()) &&
+        Storage.openFileForRead("SCT", htmlCachePath, st.tempFile)) {
+      if (st.tempFile.size() == st.inflatedSize) {
+        st.useTempExtract = true;
+        st.extractDone = true;  // phase (a) inflation skipped
+        st.reusedHtml = true;   // keep the cache on cleanup rather than deleting it
+        st.tempPath = htmlCachePath;
+        LOG_INF("SCT", "createSectionFile spine=%d reusing cached HTML (%u bytes, free=%lu)", spineIndex,
+                static_cast<uint32_t>(st.inflatedSize), esp_get_free_heap_size());
+      } else {
+        st.tempFile.close();
+        Storage.remove(htmlCachePath.c_str());
       }
     }
-    if (!streamFailed && st.useTempExtract) {
-      st.tempPath = filePath + ".xtmp";
-      if (!Storage.openFileForWrite("SCT", st.tempPath, st.tempFile)) {
+
+    // No usable cache: inflate the entry to the book-level HTML cache (phase a) so it is produced
+    // once and reused thereafter. Always two-phase now (even the blocking path) so every build
+    // populates the cache; the inflate ring is released before parsing, so the blocking path —
+    // which runs with the secondary framebuffer released — stays within heap.
+    if (!streamFailed && !st.reusedHtml) {
+      st.useTempExtract = true;
+      // Heap, not stack: must survive across slices. Ring (≤32 KB, sized to the entry) +
+      // PARSE_CHUNK_BYTES scratch — net-neutral vs the old one-shot path.
+      st.zip.reset(new (std::nothrow) ZipFile(epub->getPath()));
+      if (st.zip) {
+        st.reader.reset(new (std::nothrow) ZipFile::EntryReader(*st.zip, PARSE_CHUNK_BYTES));
+      }
+      if (!st.reader) {
+        LOG_ERR("SCT", "Failed to allocate entry reader (%u bytes scratch, free=%lu)",
+                static_cast<uint32_t>(PARSE_CHUNK_BYTES), esp_get_free_heap_size());
         streamFailed = true;
+      } else {
+        const std::string entryPath = FsHelpers::normalisePath(st.localPath);
+        if (!st.reader->open(entryPath.c_str())) {
+          streamFailed = true;  // EntryReader::open already logged the cause
+        }
+      }
+      if (!streamFailed) {
+        st.tempPath = htmlCachePath;
+        if (!Storage.openFileForWrite("SCT", st.tempPath, st.tempFile)) {
+          streamFailed = true;
+        }
       }
     }
   }
@@ -716,7 +758,13 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
     st.tempFile.close();
   }
   if (!st.tempPath.empty()) {
-    Storage.remove(st.tempPath.c_str());
+    // tempPath is the book-keyed HTML cache. Keep it so later rebuilds skip inflation: when we
+    // reused it, and when we produced a complete one (stream OK). Only delete a cache WE produced
+    // if the stream failed — it may be partial/corrupt (a leftover is otherwise caught by the
+    // size check on the next reuse, so it would just be re-inflated).
+    if (!st.reusedHtml && streamFailed) {
+      Storage.remove(st.tempPath.c_str());
+    }
     st.tempPath.clear();
   }
   st.streamOk = !streamFailed;
@@ -1047,11 +1095,13 @@ void Section::abortSectionBuild() {
   if (!buildState_) {
     return;
   }
-  // Drop the extraction temp file alongside the partial cache file.
+  // Drop the extraction temp file alongside the partial cache file. tempPath is the book-keyed
+  // HTML cache: delete it only if WE were producing it (a partial inflate). When it was reused
+  // (read-only), it is a complete valid cache — keep it so the next build still skips inflation.
   if (buildState_->tempFile) {
     buildState_->tempFile.close();
   }
-  if (!buildState_->tempPath.empty()) {
+  if (!buildState_->reusedHtml && !buildState_->tempPath.empty()) {
     Storage.remove(buildState_->tempPath.c_str());
   }
   // During a live build, `file` is the build's write handle and filePath its cache path

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -603,7 +603,8 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
       streamFailed = true;
     }
 
-    // Book-keyed unzipped-HTML cache (adapted from crosspoint-reader PR #2452): the spine's
+    // Book-keyed unzipped-HTML cache (adapted from crosspoint-reader PR #2452 by GitHub user
+    // itsthisjustin): the spine's
     // inflated XHTML keyed on the spine alone, NOT on render properties. If a valid one exists,
     // read it directly and skip the (multi-second on a big spine) ZIP inflation — the win across
     // settings changes and rebuilds. A size mismatch means it is stale/partial (e.g. interrupted
@@ -1146,7 +1147,8 @@ uint16_t Section::estimatedTotalPages() const {
   // No build live -> the on-disk count is exact. While building, project from how much of the
   // XHTML has been consumed (activeBuildPercent), but never below what's already laid out. At
   // 100% the stream is exhausted and pageCount is final. Too early (no pages / 0%) -> fall back
-  // to the watermark. Adapted from crosspoint-reader PR #2452 ("Lazy incremental EPUB indexing").
+  // to the watermark. Adapted from crosspoint-reader PR #2452 by GitHub user itsthisjustin
+  // ("Lazy incremental EPUB indexing").
   if (!buildState_) return pageCount;
   const int pct = activeBuildPercent();
   if (pct <= 0 || pct >= 100 || pageCount == 0) return pageCount;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -85,7 +85,7 @@ class Section {
   std::string getSectionFilePath(uint32_t propertyHash) const;
   // Path of the book-keyed unzipped-HTML cache for this spine: the inflated XHTML keyed on the
   // spine alone (NOT on render properties), so it is reused across settings changes and rebuilds
-  // to skip ZIP inflation. Adapted from crosspoint-reader PR #2452.
+  // to skip ZIP inflation. Adapted from crosspoint-reader PR #2452 by GitHub user itsthisjustin.
   std::string getSectionHtmlCachePath() const;
   // Computes the image base path for extract images related to this specific section variant
   std::string getImageBasePath(uint32_t propertyHash) const;
@@ -187,7 +187,8 @@ class Section {
   // Best-known total page count: the exact pageCount when no build is live (finalized) or once
   // the stream is consumed, otherwise a byte-based projection (pages so far scaled by the
   // consumed fraction) so a "page X of ~Y" display doesn't read off the small build watermark.
-  // Never reports fewer than the pages already built. Adapted from crosspoint-reader PR #2452.
+  // Never reports fewer than the pages already built. Adapted from crosspoint-reader PR #2452 by
+  // GitHub user itsthisjustin.
   uint16_t estimatedTotalPages() const;
   // Load any page that has already been written during an active build, using the
   // in-memory LUT that grows with every onPageComplete(). Opens a temporary read handle

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -83,6 +83,10 @@ class Section {
 
   // Computes the active file path for this section based on rendering properties
   std::string getSectionFilePath(uint32_t propertyHash) const;
+  // Path of the book-keyed unzipped-HTML cache for this spine: the inflated XHTML keyed on the
+  // spine alone (NOT on render properties), so it is reused across settings changes and rebuilds
+  // to skip ZIP inflation. Adapted from crosspoint-reader PR #2452.
+  std::string getSectionHtmlCachePath() const;
   // Computes the image base path for extract images related to this specific section variant
   std::string getImageBasePath(uint32_t propertyHash) const;
   // Garbage collection: Keep only the most recent N variants per chapter

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -180,6 +180,11 @@ class Section {
   // Increases monotonically as the build progresses; 0 when no build is live.
   // Pages [0, activeBuildPageCount()) are safe to read via loadPageFromActiveBuild().
   uint16_t activeBuildPageCount() const;
+  // Best-known total page count: the exact pageCount when no build is live (finalized) or once
+  // the stream is consumed, otherwise a byte-based projection (pages so far scaled by the
+  // consumed fraction) so a "page X of ~Y" display doesn't read off the small build watermark.
+  // Never reports fewer than the pages already built. Adapted from crosspoint-reader PR #2452.
+  uint16_t estimatedTotalPages() const;
   // Load any page that has already been written during an active build, using the
   // in-memory LUT that grows with every onPageComplete(). Opens a temporary read handle
   // on the same file the build is writing to, syncing the writer first so the read handle

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -137,12 +137,18 @@ constexpr uint32_t PRE_RENDER_MIN_FREE_HEAP_BYTES = 56 * 1024;
 // suggests 30–50 ms); tune from the DEBUG_BACKGROUND_WORK serial counters.
 constexpr uint32_t BG_BUILD_BUDGET_MS = 40;
 
-// How many consecutive sections ahead of the reading position B keeps indexed. After the
-// immediate next section settles, the cursor walks forward to index up to this many spines
-// ahead, then idles until navigation re-anchors the window. Bounds the continuous CPU/SD
-// cost on a battery e-reader (vs. indexing the whole book on first open).
-#ifndef BG_BUILD_LOOKAHEAD
-#define BG_BUILD_LOOKAHEAD 3
+// Background-B keeps a page-budgeted window of layout ready ahead of the reading position rather
+// than a fixed number of sections: it pre-builds whole subsequent spines until roughly this many
+// pages of runway exist (counting the current section's unread tail plus the subsequent sections
+// built so far), then idles until the reader advances and the window re-anchors. A page budget
+// spans spine boundaries naturally — front matter of many tiny one-page spines gets several built,
+// while one big chapter already covers the budget on its own. Bounds continuous CPU/SD cost on a
+// battery e-reader (vs. indexing the whole book up front).
+//
+// Adapted from crosspoint-reader's BUILD_WINDOW_AHEAD (PR #2452, "Lazy incremental EPUB section
+// indexing"); here the window is a page budget that spans spines rather than a per-section count.
+#ifndef BG_BUILD_LOOKAHEAD_PAGES
+#define BG_BUILD_LOOKAHEAD_PAGES 50
 #endif
 
 // Foreground in-place section build (the "keep the secondary buffer" path). When heap is
@@ -785,13 +791,24 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
     resetBackgroundBuild();
     backgroundBuildBaseSpine_ = currentSpineIndex;
     backgroundBuildSpineIndex_ = currentSpineIndex + 1;
+    backgroundWindowPagesBuilt_ = 0;
   }
-  // Index up to BG_BUILD_LOOKAHEAD sections ahead. The cursor advances as each target
-  // settles (Settled case below); already-cached spines settle for free in Probe. Once the
-  // cursor passes the window end or the book end, idle until the next navigation re-anchors.
-  const int windowEnd = std::min(currentSpineIndex + BG_BUILD_LOOKAHEAD, spineCount - 1);
-  if (backgroundBuildSpineIndex_ < currentSpineIndex + 1 || backgroundBuildSpineIndex_ > windowEnd) {
+  // Walk forward from currentSpineIndex+1 to the book end. The cursor advances as each target
+  // settles (Settled case below); already-cached spines settle for free in Probe.
+  if (backgroundBuildSpineIndex_ < currentSpineIndex + 1 || backgroundBuildSpineIndex_ >= spineCount) {
     return;
+  }
+  // Page-budget gate: stop pre-building once ~BG_BUILD_LOOKAHEAD_PAGES of runway is laid out ahead
+  // of the reader — the current section's unread tail plus the subsequent sections built so far.
+  // Only gate at a section boundary (state==Probe, no build in flight) so a section in progress is
+  // never abandoned mid-build; the runway shrinks as the reader advances, re-opening the window.
+  if (backgroundBuildState_ == BackgroundBuildState::Probe) {
+    const int currentTailPages = (section && section->pageCount > 0)
+                                     ? std::max(0, static_cast<int>(section->pageCount) - 1 - section->currentPage)
+                                     : 0;
+    if (currentTailPages + backgroundWindowPagesBuilt_ >= BG_BUILD_LOOKAHEAD_PAGES) {
+      return;
+    }
   }
   const int targetSpine = backgroundBuildSpineIndex_;
 
@@ -814,6 +831,7 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
           p.fontId, p.lineCompression, p.extraParagraphSpacing, p.paragraphAlignment, p.viewportWidth, p.viewportHeight,
           p.hyphenationEnabled, p.embeddedStyle, p.bionicReadingEnabled, p.imageRendering);
       if (cached && !backgroundSection_->isEmbeddedStyleFallback()) {
+        backgroundWindowPagesBuilt_ += backgroundSection_->pageCount;  // already-built runway counts toward the budget
         backgroundSection_.reset();
         backgroundBuildState_ = BackgroundBuildState::Settled;
       } else {
@@ -915,6 +933,7 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
 #if DEBUG_BACKGROUND_WORK
           bgCounters_.bCompletes++;
 #endif
+          backgroundWindowPagesBuilt_ += backgroundSection_->pageCount;  // count this section toward the page budget
           LOG_INF("ERS", "Background build spine=%d complete: %u pages", targetSpine, backgroundSection_->pageCount);
         }
       } else {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -165,6 +165,18 @@ constexpr uint32_t BG_BUILD_BUDGET_MS = 40;
 #ifndef IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES
 #define IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES (28 * 1024)
 #endif
+// CSS books need more margin to build in place: the parse resolves embedded styles, which
+// self-degrade below the runtime CSS-resolve floor (CSS_MIN_FREE_HEAP_FOR_CSS ≈ 40 KB). Since
+// every build is now two-phase (the inflate ring is released BEFORE the CSS-resolving parse),
+// the resolve runs with the ring gone, so a higher free floor keeps it clear of 40 KB; contig is
+// pinned at the inflate-ring size (≤32 KB) for the extraction phase. A miss is still caught by
+// isCssLowHeapDegraded() and rebuilt with the buffer released.
+#ifndef IN_PLACE_BUILD_CSS_MIN_FREE_HEAP_BYTES
+#define IN_PLACE_BUILD_CSS_MIN_FREE_HEAP_BYTES (66 * 1024)
+#endif
+#ifndef IN_PLACE_BUILD_CSS_MIN_CONTIG_HEAP_BYTES
+#define IN_PLACE_BUILD_CSS_MIN_CONTIG_HEAP_BYTES (32 * 1024)
+#endif
 
 constexpr uint8_t TRUNCATED_SECTION_HINT_RENDER_COUNT = 2;
 constexpr const char* TRUNCATED_SECTION_HINT_LINE_1 = "Chapter may be truncated (low memory).";
@@ -2486,9 +2498,13 @@ bool EpubReaderActivity::heapAllowsInPlaceBuild(const bool embeddedStyle) const 
       return false;
     }
   }
+  const uint32_t freeFloor =
+      embeddedStyle ? IN_PLACE_BUILD_CSS_MIN_FREE_HEAP_BYTES : IN_PLACE_BUILD_MIN_FREE_HEAP_BYTES;
+  const uint32_t contigFloor =
+      embeddedStyle ? IN_PLACE_BUILD_CSS_MIN_CONTIG_HEAP_BYTES : IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES;
   const uint32_t freeHeap = esp_get_free_heap_size();
   const uint32_t contigHeap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
-  return freeHeap >= IN_PLACE_BUILD_MIN_FREE_HEAP_BYTES && contigHeap >= IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES;
+  return freeHeap >= freeFloor && contigHeap >= contigFloor;
 }
 
 EpubReaderActivity::SectionBuildMode EpubReaderActivity::chooseSectionBuildMode(const bool embeddedStyle) const {
@@ -2504,16 +2520,16 @@ EpubReaderActivity::SectionBuildMode EpubReaderActivity::chooseSectionBuildMode(
   // on-device, then had to be rebuilt blocking). Mid-build BW draws still work off DTM1.
   if (renderer.isX3()) return SectionBuildMode::IncrementalReleased;
 
-  // X4 CSS book → released too. Built with the ~48 KB buffer resident, a CSS section reliably
-  // drops below the runtime CSS-resolve floor (MIN_FREE_HEAP_FOR_CSS ≈ 40 KB) mid-parse → lookups
-  // skip → css-degraded → a wasted resident build then a blocking rebuild. Releasing keeps it in
-  // the ~120 KB regime where the blocking path builds these clean.
-  if (embeddedStyle) return SectionBuildMode::IncrementalReleased;
-
-  // X4 non-CSS book → keep the buffer resident when the in-place floors fit (fast-refresh baseline
-  // re-seeds from it, AA stays live); otherwise release for headroom.
-  return heapAllowsInPlaceBuild(/*embeddedStyle=*/false) ? SectionBuildMode::IncrementalResident
-                                                         : SectionBuildMode::IncrementalReleased;
+  // X4 → keep the secondary buffer resident when the in-place floors fit (fast-refresh baseline
+  // re-seeds from it, AA stays live during the build); otherwise release for headroom. This now
+  // applies to CSS books too: every build is two-phase, so the inflate ring is released BEFORE the
+  // CSS-resolving parse, keeping the resolve clear of the ~40 KB floor when the (higher) CSS
+  // in-place floor is met. A resident CSS build that still degrades is caught by
+  // isCssLowHeapDegraded() and rebuilt with the buffer released — so this gates "try in place"
+  // rather than guaranteeing it. (Historically CSS books always released, from before the build
+  // was two-phase, when the ring + parser + resolver were all live at once.)
+  return heapAllowsInPlaceBuild(embeddedStyle) ? SectionBuildMode::IncrementalResident
+                                               : SectionBuildMode::IncrementalReleased;
 }
 
 EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const RenderLayout& layout,

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -145,8 +145,9 @@ constexpr uint32_t BG_BUILD_BUDGET_MS = 40;
 // while one big chapter already covers the budget on its own. Bounds continuous CPU/SD cost on a
 // battery e-reader (vs. indexing the whole book up front).
 //
-// Adapted from crosspoint-reader's BUILD_WINDOW_AHEAD (PR #2452, "Lazy incremental EPUB section
-// indexing"); here the window is a page budget that spans spines rather than a per-section count.
+// Adapted from crosspoint-reader's BUILD_WINDOW_AHEAD (PR #2452 by GitHub user itsthisjustin,
+// "Lazy incremental EPUB section indexing"); here the window is a page budget that spans spines
+// rather than a per-section count.
 #ifndef BG_BUILD_LOOKAHEAD_PAGES
 #define BG_BUILD_LOOKAHEAD_PAGES 50
 #endif

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3438,10 +3438,13 @@ void EpubReaderActivity::restoreCurrentPageToBufferIfPreRendered() {
 
 void EpubReaderActivity::renderStatusBar() const {
   // Calculate progress in book. During an active section build pageCount only reflects pages
-  // built so far, not the final chapter length — pass 0 to suppress the fraction and book
-  // progress rather than showing a misleading "3/3" when the chapter has 40 pages total.
+  // built so far, not the final chapter length, so show a byte-based estimate ("page X of ~Y")
+  // instead of the misleading watermark. estimatedTotalPages() returns 0 while it's still too
+  // early to project, which suppresses the fraction/progress (same as a plain pageCount of 0).
+  const bool building = section->hasActiveBuild();
   const int currentPage = section->currentPage + 1;
-  const float pageCount = (section->hasActiveBuild()) ? 0.0f : static_cast<float>(section->pageCount);
+  const int displayPageCount = building ? section->estimatedTotalPages() : section->pageCount;
+  const float pageCount = static_cast<float>(displayPageCount);
   const float sectionChapterProg = (pageCount > 0) ? (static_cast<float>(currentPage) / pageCount) : 0;
   const float bookProgress = epub->calculateProgress(currentSpineIndex, sectionChapterProg) * 100;
 
@@ -3476,7 +3479,8 @@ void EpubReaderActivity::renderStatusBar() const {
       printedPageLabel = std::string("(") + *nearest + ")";
     }
   }
-  GUI.drawStatusBar(renderer, bookProgress, currentPage, pageCount, title, 0, isStarred, printedPageLabel);
+  GUI.drawStatusBar(renderer, bookProgress, currentPage, displayPageCount, title, 0, isStarred, printedPageLabel,
+                    /*fillMargin=*/true, /*pageCountApproximate=*/building);
 
 #if DEBUG_BACKGROUND_WORK
   renderBackgroundDebugOverlay();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -177,6 +177,18 @@ constexpr uint32_t BG_BUILD_BUDGET_MS = 40;
 #ifndef IN_PLACE_BUILD_CSS_MIN_CONTIG_HEAP_BYTES
 #define IN_PLACE_BUILD_CSS_MIN_CONTIG_HEAP_BYTES (32 * 1024)
 #endif
+// Proactive low-heap guard for a resident (AA-buffer-kept) Background-C build. The in-place start
+// floors can't bound the parse's transient working set, which can ride free heap well down on a
+// big chapter (a 123 KB CSS section was observed dipping to ~24 KB). If the between-slice baseline
+// falls below these, abandon the resident build and rebuild on the released path (frees the
+// ~48 KB buffer) before an allocation fails. Pinned below typical mid-build baselines so a build
+// that is coping is not aborted, but above the ~13-15 KB zone where heap-pressure faults appear.
+#ifndef RESIDENT_BUILD_ABORT_FREE_HEAP_BYTES
+#define RESIDENT_BUILD_ABORT_FREE_HEAP_BYTES (30 * 1024)
+#endif
+#ifndef RESIDENT_BUILD_ABORT_CONTIG_HEAP_BYTES
+#define RESIDENT_BUILD_ABORT_CONTIG_HEAP_BYTES (16 * 1024)
+#endif
 
 constexpr uint8_t TRUNCATED_SECTION_HINT_RENDER_COUNT = 2;
 constexpr const char* TRUNCATED_SECTION_HINT_LINE_1 = "Chapter may be truncated (low memory).";
@@ -979,6 +991,21 @@ void EpubReaderActivity::stepCurrentSectionBuild() {
     return;
   }
 
+  // Discard the in-flight build and re-render: buildSection then takes the blocking path (latched
+  // by forceBlockingBuildSpine_), which builds with the secondary buffer released (~52 KB more
+  // headroom). Shared by the low-heap guard and the failure/degrade handling below.
+  const auto fallbackToReleasedRebuild = [&](const char* reason) {
+    LOG_ERR("ERS", "Background-C spine=%d %s; falling back to released rebuild", currentSpineIndex, reason);
+    section->clearCache();
+    section.reset();
+    forceBlockingBuildSpine_ = currentSpineIndex;
+    readerPhase_ = ReaderPhase::READING;
+    buildingPopupShown_ = false;
+    buildDisplayedPage_ = -1;
+    backgroundBuildPercent_ = -1;
+    requestUpdate();  // -> BuildSection -> blocking (released) build
+  };
+
   // Layout needs glyph metrics only; reset accumulation so the next prewarm re-wires the
   // flash-resident metric tables rather than the page-scoped bitmap cache (see
   // stepBackgroundSectionBuild for the full rationale).
@@ -990,6 +1017,15 @@ void EpubReaderActivity::stepCurrentSectionBuild() {
   checkHeapIntegrity("after_c_slice");
 
   if (step == Section::BuildStep::More) {
+    // Proactive low-heap guard: while the build is resident (AA buffer kept), bail to the released
+    // path before heap reaches the fault zone. Only meaningful when the buffer is still resident —
+    // a build already running released has that headroom and should ride it out.
+    if (!secondaryBufferDegraded_ && (esp_get_free_heap_size() < RESIDENT_BUILD_ABORT_FREE_HEAP_BYTES ||
+                                      heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT) <
+                                          RESIDENT_BUILD_ABORT_CONTIG_HEAP_BYTES)) {
+      fallbackToReleasedRebuild("low heap mid-build");
+      return;
+    }
     backgroundBuildPercent_ = static_cast<int8_t>(section->activeBuildPercent());
     // If the page the user is waiting on just became readable, ask the render task to draw it.
     const int want = section->currentPage;
@@ -1002,19 +1038,10 @@ void EpubReaderActivity::stepCurrentSectionBuild() {
 
   backgroundBuildPercent_ = -1;
 
-  // Failed, or finished but truncated / CSS-degraded: discard and retry on the blocking path,
-  // which builds with the secondary buffer released (~52 KB more headroom). The latch stops
-  // buildSection from re-entering Background-C for this spine.
+  // Failed, or finished but truncated / CSS-degraded: discard and retry on the released path. The
+  // latch (set inside the helper) stops buildSection from re-entering Background-C for this spine.
   if (step == Section::BuildStep::Failed || section->isTruncatedCache() || section->isCssLowHeapDegraded()) {
-    LOG_ERR("ERS", "Background-C spine=%d %s; falling back to blocking rebuild", currentSpineIndex,
-            step == Section::BuildStep::Failed ? "failed" : "incomplete");
-    section->clearCache();
-    section.reset();
-    forceBlockingBuildSpine_ = currentSpineIndex;
-    readerPhase_ = ReaderPhase::READING;
-    buildingPopupShown_ = false;
-    buildDisplayedPage_ = -1;
-    requestUpdate();  // -> BuildSection -> blocking build
+    fallbackToReleasedRebuild(step == Section::BuildStep::Failed ? "failed" : "incomplete");
     return;
   }
 

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -267,12 +267,18 @@ class EpubReaderActivity final : public Activity {
   int8_t backgroundBuildPercent_ = -1;
   // --- Background B (idle build of the next consecutive sections' caches) ---
   // Lookahead cursor: spine index the B state below currently targets; -1 when B has no
-  // target. Walks forward through [currentSpineIndex+1 .. +BG_BUILD_LOOKAHEAD] as each
-  // target settles, then idles until navigation re-anchors the window.
+  // target. Walks forward from currentSpineIndex+1 toward the book end as each target settles,
+  // stopping once BG_BUILD_LOOKAHEAD_PAGES of runway is built ahead (see below), then idles
+  // until navigation re-anchors the window.
   int backgroundBuildSpineIndex_ = -1;
   // Reading position the lookahead window is anchored at. When it no longer matches
   // currentSpineIndex (any navigation) the held B state is stale and the window restarts.
   int backgroundBuildBaseSpine_ = -1;
+  // Pages B has laid out ahead in the current window (sum of pageCounts of the subsequent
+  // sections built/cached since the last re-anchor). Combined with the current section's unread
+  // tail, this is the runway the page-budget gate compares against BG_BUILD_LOOKAHEAD_PAGES.
+  // Reset only on re-anchor; preserved across the per-target resetBackgroundBuild() in Settled.
+  int backgroundWindowPagesBuilt_ = 0;
   // Section being built (or already built) for backgroundBuildSpineIndex_. Owned here
   // until buildSection() adopts it on a consecutive boundary cross or discards it on any
   // other navigation. Its destructor aborts a partial build and deletes the partial file.

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -768,7 +768,11 @@ void BaseTheme::fillPopupProgress(const GfxRenderer& renderer, const Rect& layou
 
 void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage,
                               const int pageCount, std::string title, const int paddingBottom, const bool isStarred,
-                              const std::string& printedPageLabel, const bool fillMargin) const {
+                              const std::string& printedPageLabel, const bool fillMargin,
+                              const bool pageCountApproximate) const {
+  // While a section is still being laid out the total page count is a byte-based estimate, shown
+  // with a leading "~" so the reader knows it will firm up as the chapter finishes building.
+  const char* pageCountPrefix = pageCountApproximate ? "~" : "";
   auto metrics = UITheme::getInstance().getMetrics();
   int orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft;
   renderer.getOrientedViewableTRBL(&orientedMarginTop, &orientedMarginRight, &orientedMarginBottom,
@@ -830,11 +834,12 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
     char progressStr[32];
 
     if (SETTINGS.statusBarBookProgressPercentage && SETTINGS.statusBarChapterPageCount) {
-      snprintf(progressStr, sizeof(progressStr), "%d/%d  %.0f%%", currentPage, pageCount, bookProgress);
+      snprintf(progressStr, sizeof(progressStr), "%d/%s%d  %.0f%%", currentPage, pageCountPrefix, pageCount,
+               bookProgress);
     } else if (SETTINGS.statusBarBookProgressPercentage) {
       snprintf(progressStr, sizeof(progressStr), "%.0f%%", bookProgress);
     } else {
-      snprintf(progressStr, sizeof(progressStr), "%d/%d", currentPage, pageCount);
+      snprintf(progressStr, sizeof(progressStr), "%d/%s%d", currentPage, pageCountPrefix, pageCount);
     }
 
     const int progressStrWidth = renderer.getTextWidth(SMALL_FONT_ID, progressStr);

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -167,7 +167,7 @@ class BaseTheme {
   virtual void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage,
                              const int pageCount, std::string title, const int paddingBottom = 0,
                              const bool isStarred = false, const std::string& printedPageLabel = std::string(),
-                             const bool fillMargin = true) const;
+                             const bool fillMargin = true, const bool pageCountApproximate = false) const;
   virtual void drawHelpText(const GfxRenderer& renderer, Rect rect, const char* label) const;
   virtual void drawTextField(const GfxRenderer& renderer, Rect rect, const int textWidth, bool cursorMode = false,
                              int contentStartX = 0, int contentWidth = 0) const;


### PR DESCRIPTION
Pick up a couple of ideas from itsthisjustins upstrem PR for background indexing and apply it to our pre-existing background engine. 