### PR TITLE
fix: Cover pipeline: sentinel rework, sliced PNG reliability, and X4/RBA fixes

### DIFF
--- a/bin/clang-format-fix.ps1
+++ b/bin/clang-format-fix.ps1
@@ -96,6 +96,7 @@ $exclude = @(
     'lib\EpdFont\builtinFonts'
     'lib\Epub\Epub\hyphenation\generated'
     'lib\uzlib'
+    'build'
     '.pio'
     '.venv'
 )

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1029,6 +1029,12 @@ std::string Epub::getThumbBmpPath(int width, int height) const {
   return cachePath + "/thumb_" + std::to_string(width) + "x" + std::to_string(height) + ".bmp";
 }
 
+void Epub::writeThumbSentinel(const std::string& thumbPath) {
+  FsFile thumbBmp;
+  Storage.openFileForWrite("EBP", thumbPath, thumbBmp);
+  thumbBmp.close();
+}
+
 ThumbResult Epub::generateThumbBmp(int height, bool allowExtract) const {
   {
     FsFile existing;
@@ -1051,9 +1057,7 @@ ThumbResult Epub::generateThumbBmp(int height, bool allowExtract) const {
   // since no amount of extraction or retry can conjure a cover that the OPF doesn't declare.
   if (getCoverItemHref().empty()) {
     LOG_DBG("EBP", "No cover item for h=%d — writing structural sentinel", height);
-    FsFile thumbBmp;
-    Storage.openFileForWrite("EBP", getThumbBmpPath(height), thumbBmp);
-    thumbBmp.close();
+    writeThumbSentinel(getThumbBmpPath(height));
     return ThumbResult::StructurallyAbsent;
   }
 
@@ -1073,9 +1077,7 @@ ThumbResult Epub::generateThumbBmp(int height, bool allowExtract) const {
     // bytes. Sentinel so we stop trying.
     LOG_ERR("EBP", "Cached cover image is not a supported format — writing structural sentinel");
     coverImage.close();
-    FsFile thumbBmp;
-    Storage.openFileForWrite("EBP", getThumbBmpPath(height), thumbBmp);
-    thumbBmp.close();
+    writeThumbSentinel(getThumbBmpPath(height));
     return ThumbResult::StructurallyAbsent;
   }
 
@@ -1131,9 +1133,7 @@ ThumbResult Epub::generateThumbBmp(int width, int height, bool allowExtract) con
   // since no amount of extraction or retry can conjure a cover that the OPF doesn't declare.
   if (getCoverItemHref().empty()) {
     LOG_DBG("EBP", "No cover item for %dx%d — writing structural sentinel", width, height);
-    FsFile thumbBmp;
-    Storage.openFileForWrite("EBP", getThumbBmpPath(width, height), thumbBmp);
-    thumbBmp.close();
+    writeThumbSentinel(getThumbBmpPath(width, height));
     return ThumbResult::StructurallyAbsent;
   }
 
@@ -1153,9 +1153,7 @@ ThumbResult Epub::generateThumbBmp(int width, int height, bool allowExtract) con
     // bytes. Sentinel so we stop trying.
     LOG_ERR("EBP", "Cached cover image is not a supported format — writing structural sentinel");
     coverImage.close();
-    FsFile thumbBmp;
-    Storage.openFileForWrite("EBP", getThumbBmpPath(width, height), thumbBmp);
-    thumbBmp.close();
+    writeThumbSentinel(getThumbBmpPath(width, height));
     return ThumbResult::StructurallyAbsent;
   }
 

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1029,51 +1029,60 @@ std::string Epub::getThumbBmpPath(int width, int height) const {
   return cachePath + "/thumb_" + std::to_string(width) + "x" + std::to_string(height) + ".bmp";
 }
 
-bool Epub::generateThumbBmp(int height, bool allowExtract) const {
+ThumbResult Epub::generateThumbBmp(int height, bool allowExtract) const {
   {
     FsFile existing;
     if (Storage.openFileForRead("EBP", getThumbBmpPath(height), existing)) {
       const uint32_t sz = existing.size();
       existing.close();
-      if (sz == 0) {  // 0-byte sentinel — permanent failure, don't retry
+      if (sz == 0) {  // 0-byte sentinel — a prior pass proved this cover structurally absent.
         LOG_DBG("EBP", "Sentinel found for h=%d thumb, skipping retry", height);
-        return false;
+        return ThumbResult::StructurallyAbsent;
       }
       // size>0 is not "done": a thumb truncated by an interrupted write must be regenerated, not
       // returned as valid (the caller's completeness check would otherwise reject it forever and
       // loop). Reuse only a complete BMP; else fall through (openFileForWrite below truncates it).
-      if (coverBmpComplete(getThumbBmpPath(height))) return true;
+      if (coverBmpComplete(getThumbBmpPath(height))) return ThumbResult::Ok;
       LOG_DBG("EBP", "Existing h=%d thumb is truncated — regenerating", height);
     }
   }
 
-  if (!coverImageCachedAndValid(allowExtract)) {
-    if (!allowExtract) {
-      // cover.img not yet extracted — no sentinel, let the sliced extractor produce it.
-      LOG_DBG("EBP", "cover.img not cached for h=%d (no extract) — deferring to sliced extractor", height);
-      return false;
-    }
-    // Write an empty sentinel so we don't retry on every call
+  // No cover item at all is structural — record a sentinel now regardless of allowExtract,
+  // since no amount of extraction or retry can conjure a cover that the OPF doesn't declare.
+  if (getCoverItemHref().empty()) {
+    LOG_DBG("EBP", "No cover item for h=%d — writing structural sentinel", height);
     FsFile thumbBmp;
     Storage.openFileForWrite("EBP", getThumbBmpPath(height), thumbBmp);
     thumbBmp.close();
-    return false;
+    return ThumbResult::StructurallyAbsent;
+  }
+
+  if (!coverImageCachedAndValid(allowExtract)) {
+    // cover.img not yet extracted (or extraction failed transiently). No sentinel — let the
+    // sliced extractor produce it, or retry next pass/boot. The caller counts these.
+    LOG_DBG("EBP", "cover.img not cached/valid for h=%d — transient, deferring", height);
+    return ThumbResult::TransientFail;
   }
 
   FsFile coverImage;
-  if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return false;
+  if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return ThumbResult::TransientFail;
 
   const auto detectedFormat = detectCoverImageFormat(coverImage);
   if (detectedFormat == CoverImageFormat::Unknown) {
-    LOG_ERR("EBP", "Cached cover image is not a supported format");
+    // Cover extracted but its format is unsupported — structural, re-extraction yields the same
+    // bytes. Sentinel so we stop trying.
+    LOG_ERR("EBP", "Cached cover image is not a supported format — writing structural sentinel");
     coverImage.close();
-    return false;
+    FsFile thumbBmp;
+    Storage.openFileForWrite("EBP", getThumbBmpPath(height), thumbBmp);
+    thumbBmp.close();
+    return ThumbResult::StructurallyAbsent;
   }
 
   FsFile thumbBmp;
   if (!Storage.openFileForWrite("EBP", getThumbBmpPath(height), thumbBmp)) {
     coverImage.close();
-    return false;
+    return ThumbResult::TransientFail;
   }
 
   const int thumbW = static_cast<int>(height * 0.6f);
@@ -1089,65 +1098,71 @@ bool Epub::generateThumbBmp(int height, bool allowExtract) const {
   coverImage.close();
   thumbBmp.close();
 
-  // A decode that bailed mid-loop for pending input is not a real failure — drop the
-  // partial thumb (no sentinel) so it's retried once input is serviced.
-  if (!success && CooperativeAbort::wasAborted()) {
-    LOG_DBG("EBP", "Thumb decode aborted for input — removing partial, will retry");
+  if (!success) {
+    // Whether aborted for input or a plain decode failure, this is transient: drop the partial
+    // thumb (never leave it as a false sentinel) and let the caller retry / count it.
+    LOG_DBG("EBP", "Thumb decode for h=%d did not complete — removing partial, transient", height);
     Storage.remove(getThumbBmpPath(height).c_str());
-    return false;
+    return ThumbResult::TransientFail;
   }
-
-  // Leave 0-byte sentinel on failure so we don't retry a known-failing decode.
-  if (!success) LOG_DBG("EBP", "Leaving 0-byte sentinel for h=%d — will not retry", height);
-  LOG_DBG("EBP", "Generated thumb BMP from cover image, success: %s", success ? "yes" : "no");
-  return success;
+  LOG_DBG("EBP", "Generated thumb BMP from cover image (h=%d)", height);
+  return ThumbResult::Ok;
 }
 
-bool Epub::generateThumbBmp(int width, int height, bool allowExtract) const {
+ThumbResult Epub::generateThumbBmp(int width, int height, bool allowExtract) const {
   {
     FsFile existing;
     if (Storage.openFileForRead("EBP", getThumbBmpPath(width, height), existing)) {
       const uint32_t sz = existing.size();
       existing.close();
-      if (sz == 0) {  // 0-byte sentinel — permanent failure, don't retry
+      if (sz == 0) {  // 0-byte sentinel — a prior pass proved this cover structurally absent.
         LOG_DBG("EBP", "Sentinel found for %dx%d thumb, skipping retry", width, height);
-        return false;
+        return ThumbResult::StructurallyAbsent;
       }
       // size>0 is not "done": a thumb truncated by an interrupted write must be regenerated, not
       // returned as valid (the caller's completeness check would otherwise reject it forever and
       // loop). Reuse only a complete BMP; else fall through (openFileForWrite below truncates it).
-      if (coverBmpComplete(getThumbBmpPath(width, height))) return true;
+      if (coverBmpComplete(getThumbBmpPath(width, height))) return ThumbResult::Ok;
       LOG_DBG("EBP", "Existing %dx%d thumb is truncated — regenerating", width, height);
     }
   }
 
-  if (!coverImageCachedAndValid(allowExtract)) {
-    if (!allowExtract) {
-      // cover.img not yet extracted — no sentinel, let the sliced extractor produce it.
-      LOG_DBG("EBP", "cover.img not cached for %dx%d (no extract) — deferring to sliced extractor", width, height);
-      return false;
-    }
-    // Write an empty sentinel so we don't retry on every call
+  // No cover item at all is structural — record a sentinel now regardless of allowExtract,
+  // since no amount of extraction or retry can conjure a cover that the OPF doesn't declare.
+  if (getCoverItemHref().empty()) {
+    LOG_DBG("EBP", "No cover item for %dx%d — writing structural sentinel", width, height);
     FsFile thumbBmp;
     Storage.openFileForWrite("EBP", getThumbBmpPath(width, height), thumbBmp);
     thumbBmp.close();
-    return false;
+    return ThumbResult::StructurallyAbsent;
+  }
+
+  if (!coverImageCachedAndValid(allowExtract)) {
+    // cover.img not yet extracted (or extraction failed transiently). No sentinel — let the
+    // sliced extractor produce it, or retry next pass/boot. The caller counts these.
+    LOG_DBG("EBP", "cover.img not cached/valid for %dx%d — transient, deferring", width, height);
+    return ThumbResult::TransientFail;
   }
 
   FsFile coverImage;
-  if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return false;
+  if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return ThumbResult::TransientFail;
 
   const auto detectedFormat = detectCoverImageFormat(coverImage);
   if (detectedFormat == CoverImageFormat::Unknown) {
-    LOG_ERR("EBP", "Cached cover image is not a supported format");
+    // Cover extracted but its format is unsupported — structural, re-extraction yields the same
+    // bytes. Sentinel so we stop trying.
+    LOG_ERR("EBP", "Cached cover image is not a supported format — writing structural sentinel");
     coverImage.close();
-    return false;
+    FsFile thumbBmp;
+    Storage.openFileForWrite("EBP", getThumbBmpPath(width, height), thumbBmp);
+    thumbBmp.close();
+    return ThumbResult::StructurallyAbsent;
   }
 
   FsFile thumbBmp;
   if (!Storage.openFileForWrite("EBP", getThumbBmpPath(width, height), thumbBmp)) {
     coverImage.close();
-    return false;
+    return ThumbResult::TransientFail;
   }
 
   bool success = false;
@@ -1162,23 +1177,15 @@ bool Epub::generateThumbBmp(int width, int height, bool allowExtract) const {
   coverImage.close();
   thumbBmp.close();
 
-  // A decode that genuinely bailed mid-loop for pending button input is NOT a real
-  // failure — remove the partial/empty thumb so it isn't mistaken for a permanent-
-  // failure sentinel and is retried once input is serviced. wasAborted() is true only
-  // when a decode row loop actually broke for input (markAborted), so a plain failure
-  // (e.g. an oversize image rejected before any rows) still falls through to the sentinel.
-  if (!success && CooperativeAbort::wasAborted()) {
-    LOG_DBG("EBP", "Thumb decode aborted for input — removing partial, will retry");
+  if (!success) {
+    // Whether aborted for input or a plain decode failure, this is transient: drop the partial
+    // thumb (never leave it as a false sentinel) and let the caller retry / count it.
+    LOG_DBG("EBP", "Thumb decode for %dx%d did not complete — removing partial, transient", width, height);
     Storage.remove(getThumbBmpPath(width, height).c_str());
-    return false;
+    return ThumbResult::TransientFail;
   }
-
-  // On failure, leave the 0-byte sentinel so generateThumbBmp won't be retried on every
-  // homescreen load.  The sentinel is removed by ensureCoverThumb when a cache-clear or
-  // sidecar update makes a retry worthwhile.
-  if (!success) LOG_DBG("EBP", "Leaving 0-byte sentinel for %dx%d — will not retry", width, height);
-  LOG_DBG("EBP", "Generated %dx%d thumb BMP from cover image, success: %s", width, height, success ? "yes" : "no");
-  return success;
+  LOG_DBG("EBP", "Generated %dx%d thumb BMP from cover image", width, height);
+  return ThumbResult::Ok;
 }
 
 uint8_t* Epub::readItemContentsToBytes(const std::string& itemHref, size_t* size, const bool trailingNullByte) const {

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1,5 +1,6 @@
 #include "Epub.h"
 
+#include <Bitmap.h>
 #include <CooperativeAbort.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
@@ -955,8 +956,30 @@ bool Epub::ensureCoverImageCached() const {
   return true;
 }
 
+namespace {
+// A cover/thumbnail BMP whose write was interrupted (reboot/abort mid-decode) is left truncated:
+// the header is intact but the pixel rows are short, so it passes a size>0 / exists check yet
+// cannot be drawn (GFX "Failed to read row N"). Reuse a cached BMP only if it actually holds all
+// its declared rows; otherwise the caller must regenerate it. Returns false for a 0-byte sentinel
+// too (callers handle that separately as a permanent-failure marker).
+bool coverBmpComplete(const std::string& path) {
+  FsFile f;
+  if (!Storage.openFileForRead("EBP", path, f)) return false;
+  if (f.size() == 0) {
+    f.close();
+    return false;
+  }
+  Bitmap bmp(f);
+  const bool ok = bmp.parseHeaders() == BmpReaderError::Ok && bmp.isComplete();
+  f.close();
+  return ok;
+}
+}  // namespace
+
 bool Epub::generateCoverBmp(bool cropped) const {
-  if (Storage.exists(getCoverBmpPath(cropped).c_str())) return true;
+  // Reuse only a COMPLETE cached BMP; a truncated one (interrupted write) must be regenerated.
+  if (coverBmpComplete(getCoverBmpPath(cropped))) return true;
+  Storage.remove(getCoverBmpPath(cropped).c_str());  // drop any partial before regenerating
 
   if (!ensureCoverImageCached()) return false;
 
@@ -1010,11 +1033,17 @@ bool Epub::generateThumbBmp(int height, bool allowExtract) const {
   {
     FsFile existing;
     if (Storage.openFileForRead("EBP", getThumbBmpPath(height), existing)) {
-      const bool valid = existing.size() > 0;
+      const uint32_t sz = existing.size();
       existing.close();
-      if (valid) return true;
-      LOG_DBG("EBP", "Sentinel found for h=%d thumb, skipping retry", height);
-      return false;
+      if (sz == 0) {  // 0-byte sentinel — permanent failure, don't retry
+        LOG_DBG("EBP", "Sentinel found for h=%d thumb, skipping retry", height);
+        return false;
+      }
+      // size>0 is not "done": a thumb truncated by an interrupted write must be regenerated, not
+      // returned as valid (the caller's completeness check would otherwise reject it forever and
+      // loop). Reuse only a complete BMP; else fall through (openFileForWrite below truncates it).
+      if (coverBmpComplete(getThumbBmpPath(height))) return true;
+      LOG_DBG("EBP", "Existing h=%d thumb is truncated — regenerating", height);
     }
   }
 
@@ -1078,12 +1107,17 @@ bool Epub::generateThumbBmp(int width, int height, bool allowExtract) const {
   {
     FsFile existing;
     if (Storage.openFileForRead("EBP", getThumbBmpPath(width, height), existing)) {
-      const bool valid = existing.size() > 0;
+      const uint32_t sz = existing.size();
       existing.close();
-      if (valid) return true;
-      // 0-byte sentinel — permanent failure, don't retry.
-      LOG_DBG("EBP", "Sentinel found for %dx%d thumb, skipping retry", width, height);
-      return false;
+      if (sz == 0) {  // 0-byte sentinel — permanent failure, don't retry
+        LOG_DBG("EBP", "Sentinel found for %dx%d thumb, skipping retry", width, height);
+        return false;
+      }
+      // size>0 is not "done": a thumb truncated by an interrupted write must be regenerated, not
+      // returned as valid (the caller's completeness check would otherwise reject it forever and
+      // loop). Reuse only a complete BMP; else fall through (openFileForWrite below truncates it).
+      if (coverBmpComplete(getThumbBmpPath(width, height))) return true;
+      LOG_DBG("EBP", "Existing %dx%d thumb is truncated — regenerating", width, height);
     }
   }
 

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -89,6 +89,9 @@ class Epub {
   std::string getThumbBmpPath() const;
   std::string getThumbBmpPath(int height) const;
   std::string getThumbBmpPath(int width, int height) const;
+  // Write the 0-byte "structurally absent" sentinel at a thumb path (see ThumbResult): the book
+  // has no usable cover, so generateThumbBmp() stops retrying. Best-effort; ignores write errors.
+  static void writeThumbSentinel(const std::string& thumbPath);
   // allowExtract=true: synchronously inflate the embedded cover.img from the ZIP if it
   // isn't cached yet (can stall for seconds on a large cover — fine for one-off callers
   // like the book-info / finished-book screens). allowExtract=false: decode ONLY an

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -9,6 +9,7 @@
 
 #include "Epub/BookMetadataCache.h"
 #include "Epub/EpubImageManifest.h"
+#include "Epub/ThumbResult.h"
 #include "Epub/css/CssParser.h"
 
 class ZipFile;
@@ -91,11 +92,16 @@ class Epub {
   // allowExtract=true: synchronously inflate the embedded cover.img from the ZIP if it
   // isn't cached yet (can stall for seconds on a large cover — fine for one-off callers
   // like the book-info / finished-book screens). allowExtract=false: decode ONLY an
-  // already-cached cover.img and return false (no sentinel) if it's missing, so a sliced
-  // extractor (ReaderActivity::beginCoverExtractSession) can do the inflate off the hot
-  // loop path. The home cover loader passes false.
-  bool generateThumbBmp(int height, bool allowExtract = true) const;
-  bool generateThumbBmp(int width, int height, bool allowExtract = true) const;
+  // already-cached cover.img and report TransientFail (no sentinel) if it's missing, so a
+  // sliced extractor (ReaderActivity::beginCoverExtractSession) can do the inflate off the
+  // hot loop path. The home cover loader passes false.
+  //
+  // A 0-byte sentinel is written ONLY for a StructurallyAbsent outcome (no cover item, or a
+  // cover present but in an unsupported format). Every transient failure returns TransientFail
+  // WITHOUT a sentinel so the next pass — or the next boot — retries; the caller (HomeActivity)
+  // owns a session-scoped counter that promotes a repeatedly-transient book to a sentinel.
+  ThumbResult generateThumbBmp(int height, bool allowExtract = true) const;
+  ThumbResult generateThumbBmp(int width, int height, bool allowExtract = true) const;
   uint8_t* readItemContentsToBytes(const std::string& itemHref, size_t* size = nullptr,
                                    bool trailingNullByte = false) const;
   bool readItemContentsToStream(const std::string& itemHref, Print& out, size_t chunkSize) const;

--- a/lib/Epub/Epub/ThumbResult.h
+++ b/lib/Epub/Epub/ThumbResult.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Outcome of a cover-thumbnail generation attempt. Distinguishes a permanent, structural
+// absence (no cover item in the file, or a cover present but in an unsupported format) from
+// a transient failure (OOM, interrupted write, a decode that bailed, cover.img not yet
+// extracted). Only StructurallyAbsent is written as a 0-byte sentinel by the generator; the
+// caller decides — via a session-scoped retry counter — when a repeatedly-transient book
+// earns one. Kept in its own header so callers that only forward-declare Epub (e.g.
+// ReaderActivity) can name the result type without pulling in the whole Epub class.
+enum class ThumbResult { Ok, TransientFail, StructurallyAbsent };

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -76,6 +76,14 @@ class Bitmap {
   int getRowBytes() const { return rowBytes; }
   bool is1Bit() const { return bpp == 1; }
   uint16_t getBpp() const { return bpp; }
+  // True if the file actually contains every declared pixel row, i.e. it was not truncated by an
+  // interrupted/aborted write (a partial thumbnail left on the SD card after a reboot mid-decode).
+  // Call after parseHeaders() returns Ok. Cheap: compares file size against the pixel-data offset
+  // plus rowBytes*height; readNextRow() would otherwise fail with ShortReadRow partway through.
+  bool isComplete() const {
+    const long need = static_cast<long>(bfOffBits) + static_cast<long>(rowBytes) * static_cast<long>(height);
+    return static_cast<long>(file.size()) >= need;
+  }
 
  private:
   static uint16_t readLE16(FsFile& f);

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -410,7 +410,7 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOu
 // PngDecodeSession — sliced 1-bit PNG decode for use in loop()-driven contexts
 // ============================================================================
 
-bool PngDecodeSession::begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, int targetHeight) {
+bool PngDecodeSession::begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, int targetHeight, bool crop) {
   bmpOut_ = &bmpFile;
 
   PngStreamDecoder::Info info;
@@ -421,7 +421,10 @@ bool PngDecodeSession::begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, 
   width_ = info.width;
   height_ = info.height;
 
-  // Output dimensions (fit, no crop — same as pngFileTo1BitBmpStreamWithSize)
+  // Output dimensions — same policy as pngFileTo1BitBmpStreamWithSize. crop=true scales to the
+  // LARGER fit factor (fill), so the binding dimension lands exactly on the target and the caller
+  // draws the thumb 1:1 (no fractional rescale of a 1-bit dithered image → no moiré). crop=false
+  // scales to the SMALLER factor (fit inside).
   outWidth_ = static_cast<int>(width_);
   outHeight_ = static_cast<int>(height_);
   scaleX_fp_ = 65536;
@@ -431,7 +434,7 @@ bool PngDecodeSession::begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, 
   if (targetWidth > 0 && targetHeight > 0 && (outWidth_ != targetWidth || outHeight_ != targetHeight)) {
     const float sw = static_cast<float>(targetWidth) / width_;
     const float sh = static_cast<float>(targetHeight) / height_;
-    const float scale = (sw < sh) ? sw : sh;
+    const float scale = crop ? ((sw > sh) ? sw : sh) : ((sw < sh) ? sw : sh);
     outWidth_ = static_cast<int>(width_ * scale);
     outHeight_ = static_cast<int>(height_ * scale);
     if (outWidth_ < 1) outWidth_ = 1;

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -138,7 +138,7 @@ void writeBmpHeader2bit(Print& bmpOut, const int width, const int height) {
 }  // namespace
 
 bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                                   bool oneBit, bool crop) {
+                                                   bool oneBit, bool crop, bool enforceSizeCap) {
   LOG_DBG("PNG", "Converting PNG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : "2-bit", targetWidth, targetHeight);
 
   // Decode with the shared uzlib-based core (no PNGdec). Scanlines arrive as
@@ -155,9 +155,10 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOu
   // Reject images whose source pixel count would cause the row-by-row decode to
   // stall the main loop for tens of seconds.  Unlike JPEG (which has DCT pre-scaling),
   // the PNG decoder processes every source row at full resolution before downscaling.
-  // 800*1200 = 960 kpx decodes in ~10 s on the ESP32-C3; cap there.
+  // 800*1200 = 960 kpx decodes in ~10 s on the ESP32-C3; cap there. Skipped for
+  // stall-tolerant one-shot callers (enforceSizeCap=false) that have no sliced fallback.
   constexpr uint32_t MAX_PNG_PIXELS = 800u * 1200u;
-  if (width * height > MAX_PNG_PIXELS) {
+  if (enforceSizeCap && width * height > MAX_PNG_PIXELS) {
     LOG_ERR("PNG", "Source PNG too large for thumbnail (%ux%u, max %u px) — skipping", width, height, MAX_PNG_PIXELS);
     return false;
   }
@@ -574,7 +575,10 @@ bool PngToBmpConverter::pngFileToBmpStream(FsFile& pngFile, Print& bmpOut, bool 
   // Use runtime display dimensions (swapped for portrait cover sizing)
   const int targetWidth = display.getDisplayHeight();
   const int targetHeight = display.getDisplayWidth();
-  return pngFileToBmpStreamInternal(pngFile, bmpOut, targetWidth, targetHeight, false, crop);
+  // Full-screen cover render for one-shot screens (sleep / finished-book / OPDS): stall-tolerant
+  // and with no sliced fallback, so bypass the thumbnail size cap and decode large covers directly.
+  return pngFileToBmpStreamInternal(pngFile, bmpOut, targetWidth, targetHeight, /*oneBit=*/false, crop,
+                                    /*enforceSizeCap=*/false);
 }
 
 bool PngToBmpConverter::pngFileToBmpStreamWithSize(FsFile& pngFile, Print& bmpOut, int targetMaxWidth,

--- a/lib/PngToBmpConverter/PngToBmpConverter.h
+++ b/lib/PngToBmpConverter/PngToBmpConverter.h
@@ -30,9 +30,13 @@ class PngDecodeSession {
 
   // Open pngFile and bmpFile (already opened for read/write respectively),
   // parse the PNG header, write the BMP header, allocate buffers.
-  // targetWidth/targetHeight: desired output size (fit, not crop).
+  // targetWidth/targetHeight: desired output size. crop=true fills the target (scale to the
+  // LARGER fit factor, overflow kept) so the binding dimension matches the target exactly —
+  // this mirrors the synchronous pngFileTo1BitBmpStreamWithSize (crop=true) so cover thumbnails
+  // are drawn 1:1 with no rescale (a fractional rescale of an already-dithered 1-bit image
+  // produces a moiré grid). crop=false fits inside the target (scale to the SMALLER factor).
   // Returns false on any setup failure; the session must not be used after a false return.
-  bool begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, int targetHeight);
+  bool begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, int targetHeight, bool crop = true);
 
   // Decode up to maxSourceRows scanlines and write the corresponding BMP rows.
   // Returns Running if more rows remain, Done when the image is complete, Error on failure.

--- a/lib/PngToBmpConverter/PngToBmpConverter.h
+++ b/lib/PngToBmpConverter/PngToBmpConverter.h
@@ -80,8 +80,14 @@ class PngDecodeSession {
 };
 
 class PngToBmpConverter {
+  // enforceSizeCap: reject sources above MAX_PNG_PIXELS before decoding. This guards the ~10 s
+  // full-resolution decode stall on the per-tick thumbnail path (whose callers recover via the
+  // sliced PngDecodeSession). One-shot, stall-tolerant callers (generateCoverBmp for the sleep /
+  // finished-book / OPDS screens, which have no sliced fallback) pass false so a large but
+  // otherwise-decodable cover still renders. The per-dimension safety bound in PngStreamDecoder
+  // (2048x3072) always applies regardless.
   static bool pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight, bool oneBit,
-                                         bool crop = true);
+                                         bool crop = true, bool enforceSizeCap = true);
 
  public:
   static bool pngFileToBmpStream(FsFile& pngFile, Print& bmpOut, bool crop = true);

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -1,6 +1,8 @@
 #include <BootHeapProbe.h>
 #include <HalDisplay.h>
 #include <HalGPIO.h>
+#include <Logging.h>
+#include <esp_heap_caps.h>
 
 // Global HalDisplay instance, bracketed by static-init heap probes (slots 0/1).
 static BootHeapProbe s_probePreDisplay(0);
@@ -110,13 +112,34 @@ void HalDisplay::syncWriteBufferFromActive() const { einkDisplay.syncWriteBuffer
 
 void HalDisplay::releaseBuffers() { einkDisplay.releaseBuffers(); }
 
-bool HalDisplay::releaseSecondaryBuffer() { return einkDisplay.releaseSecondaryBuffer(); }
+// FBUF: centralized framebuffer-state trace. Every secondary-buffer / RED-RAM / single-buffer
+// transition logs here so a ghosting regression can be tracked to the exact op that left the panel
+// diffing against the wrong baseline. free=largest contiguous 8-bit block (what a realloc needs).
+static uint32_t fbufContig() { return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT); }
 
-bool HalDisplay::reallocSecondaryBuffer() { return einkDisplay.reallocSecondaryBuffer(); }
+bool HalDisplay::releaseSecondaryBuffer() {
+  const bool ok = einkDisplay.releaseSecondaryBuffer();
+  LOG_INF("FBUF", "releaseSecondary -> %d (hasSecondary=%d redSynced=%d contig=%lu)", ok ? 1 : 0,
+          einkDisplay.hasSecondaryBuffer() ? 1 : 0, einkDisplay.isRedRamSynced() ? 1 : 0,
+          static_cast<unsigned long>(fbufContig()));
+  return ok;
+}
+
+bool HalDisplay::reallocSecondaryBuffer() {
+  const bool ok = einkDisplay.reallocSecondaryBuffer();
+  LOG_INF("FBUF", "reallocSecondary -> %d (hasSecondary=%d redSynced=%d contig=%lu)", ok ? 1 : 0,
+          einkDisplay.hasSecondaryBuffer() ? 1 : 0, einkDisplay.isRedRamSynced() ? 1 : 0,
+          static_cast<unsigned long>(fbufContig()));
+  return ok;
+}
 
 bool HalDisplay::hasSecondaryBuffer() const { return einkDisplay.hasSecondaryBuffer(); }
 
-void HalDisplay::setSingleBufferFastDiff(bool enabled) { einkDisplay.setSingleBufferFastDiff(enabled); }
+void HalDisplay::setSingleBufferFastDiff(bool enabled) {
+  LOG_INF("FBUF", "singleBufferFastDiff=%d (hasSecondary=%d redSynced=%d)", enabled ? 1 : 0,
+          einkDisplay.hasSecondaryBuffer() ? 1 : 0, einkDisplay.isRedRamSynced() ? 1 : 0);
+  einkDisplay.setSingleBufferFastDiff(enabled);
+}
 
 void HalDisplay::triggerDisplay(RefreshMode mode, bool turnOffScreen) {
   einkDisplay.triggerDisplay(static_cast<EInkDisplay::RefreshMode>(mode), turnOffScreen);
@@ -139,7 +162,11 @@ void HalDisplay::copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer) { einkDisplay
 
 void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { einkDisplay.copyGrayscaleMsbBuffers(msbBuffer); }
 
-void HalDisplay::syncRedRamFromFrameBuffer() { einkDisplay.syncRedRamFromFrameBuffer(); }
+void HalDisplay::syncRedRamFromFrameBuffer() {
+  einkDisplay.syncRedRamFromFrameBuffer();
+  LOG_INF("FBUF", "syncRedRamFromFrameBuffer (hasSecondary=%d redSynced=%d)", einkDisplay.hasSecondaryBuffer() ? 1 : 0,
+          einkDisplay.isRedRamSynced() ? 1 : 0);
+}
 
 void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.cleanupGrayscaleBuffers(bwBuffer); }
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -618,53 +618,41 @@ void SleepActivity::renderCoverSleepScreen() const {
   }
 
   std::string coverBmpPath;
-  bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
+  const bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
 
-  // Check if the current book is XTC, TXT, or EPUB
+  // generateCoverBmp() runs the full-size PNG/JPEG decoder, whose inflate ring and pixel buffers
+  // need a large contiguous block; on a big cover (e.g. a 1200x1848 PNG) that malloc fails under
+  // sleep-time heap pressure and the cover silently falls back to /sleep.bmp. Free the ~52 KB
+  // secondary framebuffer for headroom (same lever the Home cover loader uses). No realloc: the
+  // sleep render below draws via the grayscale planes / controller RAM, not the secondary buffer,
+  // and enterDeepSleep() tears everything down (chip reset on wake) immediately after.
+  if (renderer.hasSecondaryBuffer()) renderer.releaseSecondaryBuffer();
+
   if (FsHelpers::hasXtcExtension(APP_STATE.openEpubPath)) {
-    // Handle XTC file
     Xtc lastXtc(APP_STATE.openEpubPath, "/.crosspoint");
-    if (!lastXtc.load()) {
-      LOG_ERR("SLP", "Failed to load last XTC");
-      return (this->*renderNoCoverSleepScreen)();
+    if (lastXtc.load() && lastXtc.generateCoverBmp()) {
+      coverBmpPath = lastXtc.getCoverBmpPath();
+    } else {
+      LOG_ERR("SLP", "Failed to load/generate XTC cover bmp");
     }
-
-    if (!lastXtc.generateCoverBmp()) {
-      LOG_ERR("SLP", "Failed to generate XTC cover bmp");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    coverBmpPath = lastXtc.getCoverBmpPath();
   } else if (FsHelpers::hasTxtExtension(APP_STATE.openEpubPath)) {
-    // Handle TXT file - looks for cover image in the same folder
     Txt lastTxt(APP_STATE.openEpubPath, "/.crosspoint");
-    if (!lastTxt.load()) {
-      LOG_ERR("SLP", "Failed to load last TXT");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    if (!lastTxt.generateCoverBmp()) {
+    if (lastTxt.load() && lastTxt.generateCoverBmp()) {
+      coverBmpPath = lastTxt.getCoverBmpPath();
+    } else {
       LOG_ERR("SLP", "No cover image found for TXT file");
-      return (this->*renderNoCoverSleepScreen)();
     }
-
-    coverBmpPath = lastTxt.getCoverBmpPath();
   } else if (FsHelpers::hasEpubExtension(APP_STATE.openEpubPath)) {
-    // Handle EPUB file
     Epub lastEpub(APP_STATE.openEpubPath, "/.crosspoint");
-    // Skip loading css since we only need metadata here
-    if (!lastEpub.load(true, true)) {
-      LOG_ERR("SLP", "Failed to load last epub");
-      return (this->*renderNoCoverSleepScreen)();
+    // Skip loading css since we only need metadata here.
+    if (lastEpub.load(true, true) && lastEpub.generateCoverBmp(cropped)) {
+      coverBmpPath = lastEpub.getCoverBmpPath(cropped);
+    } else {
+      LOG_ERR("SLP", "Failed to load/generate EPUB cover bmp");
     }
+  }
 
-    if (!lastEpub.generateCoverBmp(cropped)) {
-      LOG_ERR("SLP", "Failed to generate cover bmp");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    coverBmpPath = lastEpub.getCoverBmpPath(cropped);
-  } else {
+  if (coverBmpPath.empty()) {
     return (this->*renderNoCoverSleepScreen)();
   }
 

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -785,6 +785,11 @@ void HomeActivity::render(RenderLock&&) {
 }
 
 void HomeActivity::onSelectBook(const std::string& path) {
+  // Arm a clean HALF baseline for the reader's first page. It diffs against whatever RED RAM holds
+  // — this home frame — and a FAST diff of a dramatic home->page change leaves the home screen
+  // ghosting through. The reader's onEnter expects the launching activity to arm this (FileBrowser
+  // does via enforceExitFullRefresh; Home didn't, so books opened from Home ghosted on entry).
+  renderer.setNextDisplayRefreshMode(HalDisplay::HALF_REFRESH);
   ReturnHint hint;
   hint.target = ReturnTo::Home;
   hint.selectName = path;  // used to re-focus the book in the recents strip after return

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -171,6 +171,22 @@ void HomeActivity::loadRecentBooks(int maxBooks) {
   }
 }
 
+bool HomeActivity::coverAttemptsExhausted(const std::string& path) const {
+  const auto it = coverTransientAttempts.find(path);
+  return it != coverTransientAttempts.end() && it->second >= COVER_MAX_TRANSIENT_ATTEMPTS;
+}
+
+void HomeActivity::giveUpCover(RecentBook& book, ThumbResult res) {
+  // Only transient failures count toward the session budget; a structural absence is already
+  // permanent (generateThumbBmp wrote a sentinel) and needs no retry accounting.
+  if (res == ThumbResult::TransientFail) {
+    const uint8_t n = ++coverTransientAttempts[book.path];
+    LOG_DBG("HOME", "Transient cover failure %u/%u for %s", n, COVER_MAX_TRANSIENT_ATTEMPTS, book.path.c_str());
+  }
+  RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, "");
+  book.coverBmpPath = "";
+}
+
 void HomeActivity::loadRecentCovers(int coverHeight) {
   recentsLoading = true;
 
@@ -220,14 +236,34 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
     requestUpdate();
   };
 
+  // Time budget for a single loadRecentCovers() call. Rather than advancing a session by
+  // one small slice per loop() tick (a 1200x1848 PNG cover needs ~940 ZIP-inflate chunks +
+  // ~308 decode-row batches ≈ 1250 ticks — minutes of wall-clock), we drain slices in a
+  // burst until this budget elapses or button input arrives. Mirrors RecentBooksActivity's
+  // COVER_SLICE_BUDGET_MS burst driver. A slice only writes SD files (no screen change), so
+  // bursting costs nothing visually; we still yield promptly to keep input responsive.
+  constexpr uint32_t COVER_SLICE_BUDGET_MS = 150;
+  // Larger ZIP-inflate chunk than the per-tick 4 KB: with the ~48 KB secondary framebuffer
+  // released during loading (see above) there is headroom, and 16 KB cuts the inflate
+  // iteration count 4× on the multi-MB cover.img. The session reuses one malloc'd buffer of
+  // this size across all continueStep() calls (realloc only if the size changes).
+  constexpr size_t COVER_EXTRACT_CHUNK = 16384;
+
   // ── Cover extract session drain ──────────────────────────────────────────────
-  // Sliced ZIP extraction of cover.img for a large embedded PNG cover.
-  // One 4 KB chunk per loop() tick; when done, fall through to beginPngThumbSession.
+  // Sliced ZIP extraction of cover.img for a large embedded PNG cover. Burst-drain
+  // chunks within the time budget; when done, fall through to beginPngThumbSession.
   if (extractSession) {
-    const auto status = extractSession->continueStep(4096);
-    if (status == ReaderActivity::CoverExtractSession::Status::Running) {
-      recentsLoading = false;
-      return;
+    const uint32_t deadline = millis() + COVER_SLICE_BUDGET_MS;
+    auto status = ReaderActivity::CoverExtractSession::Status::Running;
+    while (status == ReaderActivity::CoverExtractSession::Status::Running) {
+      status = extractSession->continueStep(COVER_EXTRACT_CHUNK);
+      // Stop the burst (but keep the session alive) when input is waiting or the budget
+      // is spent — resume from where we left off on the next loadRecentCovers() call.
+      if (status == ReaderActivity::CoverExtractSession::Status::Running &&
+          (mappedInput.hasPendingInput() || static_cast<int32_t>(millis() - deadline) >= 0)) {
+        recentsLoading = false;
+        return;
+      }
     }
     extractSession.reset();
     if (status == ReaderActivity::CoverExtractSession::Status::Error) {
@@ -241,14 +277,20 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
   }
 
   // ── PNG session drain ────────────────────────────────────────────────────────
-  // A sliced PNG decode was started in a previous loop() call.  Drive it a few
-  // rows at a time so button input stays responsive between calls.
+  // A sliced PNG decode was started in a previous loadRecentCovers() call. Burst-drain
+  // row batches within the time budget so a tall cover finishes in a few ticks instead
+  // of hundreds, while still yielding promptly for button input between batches.
   if (pngSession) {
-    constexpr uint32_t ROWS_PER_TICK = 6;
-    const auto status = pngSession->continueRows(ROWS_PER_TICK);
-    if (status == PngDecodeSession::Status::Running) {
-      recentsLoading = false;  // allow a brief pause for input between ticks
-      return;
+    constexpr uint32_t ROWS_PER_BATCH = 6;
+    const uint32_t deadline = millis() + COVER_SLICE_BUDGET_MS;
+    auto status = PngDecodeSession::Status::Running;
+    while (status == PngDecodeSession::Status::Running) {
+      status = pngSession->continueRows(ROWS_PER_BATCH);
+      if (status == PngDecodeSession::Status::Running &&
+          (mappedInput.hasPendingInput() || static_cast<int32_t>(millis() - deadline) >= 0)) {
+        recentsLoading = false;  // pause between batches; resume on the next call
+        return;
+      }
     }
     // Session finished (done or error) — close files.
     pngSessionFiles.close();
@@ -320,15 +362,26 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
             return;
           }
 
+          // This book already burned its transient-failure budget this session — stop retrying it
+          // (a reboot resets the counter and tries again) so it can't starve the others.
+          if (coverAttemptsExhausted(book.path)) {
+            LOG_DBG("HOME", "Cover attempts exhausted for %s this session — skipping", book.path.c_str());
+            giveUpCover(book, ThumbResult::StructurallyAbsent);  // don't re-count; just record empty
+            allValid = false;
+            break;
+          }
+
           // Cover decode needs ~42 KB contiguous heap — free the frame cache first.
           invalidateFrameCacheSafely();
 
           // Try synchronous decode first (handles JPEG and cached covers).
           CooperativeAbort::clearAborted();
-          const bool ok = ReaderActivity::ensureCoverThumb(book.path, sz.first, sz.second);
+          const ThumbResult res = ReaderActivity::ensureCoverThumb(book.path, sz.first, sz.second);
           LOG_DBG("HOME", "ensureCoverThumb(%dx%d) for %s: %s", sz.first, sz.second, book.path.c_str(),
-                  ok ? "ok" : "FAILED");
-          if (!ok) {
+                  res == ThumbResult::Ok                   ? "ok"
+                  : res == ThumbResult::StructurallyAbsent ? "absent"
+                                                           : "transient");
+          if (res != ThumbResult::Ok) {
             // A decode that genuinely bailed mid-loop for pending input is not a real
             // failure: retry the same size later instead of recording an empty cover.
             // consumeAborted() is true only when a decode row loop broke for input, so a
@@ -340,7 +393,10 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
               recentsLoading = false;
               return;
             }
-            if (!pngSessionFailed) {
+            // Structural absence is permanent (generateThumbBmp already wrote a sentinel): don't
+            // waste EPUB opens trying to start a PNG/extract session that can't succeed. Only a
+            // transient failure walks the session ladder.
+            if (res == ThumbResult::TransientFail && !pngSessionFailed) {
               // Try sliced PNG decode (succeeds when cover.img is already cached).
               pngSession = ReaderActivity::beginPngThumbSession(book.path, sz.first, sz.second, pngSessionFiles);
               if (!pngSession) {
@@ -363,10 +419,8 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
               recentsLoading = false;
               return;
             }
-            // No session available — record empty path and move on.
-            RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, "");
-            book.coverBmpPath = "";
-            LOG_DBG("HOME", "After generate: stored coverBmpPath=<empty>");
+            // No session could be started — give up on this book for now (counts the transient).
+            giveUpCover(book, res);
             allValid = false;
             break;
           }
@@ -420,19 +474,32 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
           return;
         }
 
+        // This book already burned its transient-failure budget this session — stop retrying it
+        // (a reboot resets the counter) and advance.
+        if (coverAttemptsExhausted(book.path)) {
+          LOG_DBG("HOME", "Cover attempts exhausted for %s this session — skipping", book.path.c_str());
+          giveUpCover(book, ThumbResult::StructurallyAbsent);  // don't re-count; just record empty
+          nextRecentCoverIndex++;
+          yieldAfterDecode();
+          return;
+        }
+
         // Cover decode needs ~42 KB contiguous heap — free the frame cache first.
         invalidateFrameCacheSafely();
         CooperativeAbort::clearAborted();
-        const bool success = ReaderActivity::ensureCoverThumb(book.path, coverHeight);
-        LOG_DBG("HOME", "ensureCoverThumb(h=%d) for %s: %s", coverHeight, book.path.c_str(), success ? "ok" : "FAILED");
+        const ThumbResult res = ReaderActivity::ensureCoverThumb(book.path, coverHeight);
+        LOG_DBG("HOME", "ensureCoverThumb(h=%d) for %s: %s", coverHeight, book.path.c_str(),
+                res == ThumbResult::Ok                   ? "ok"
+                : res == ThumbResult::StructurallyAbsent ? "absent"
+                                                         : "transient");
         // A decode that genuinely bailed mid-loop for pending input is not a real failure
         // — retry this book later rather than recording an empty cover path.
-        if (!success && CooperativeAbort::consumeAborted()) {
+        if (res != ThumbResult::Ok && CooperativeAbort::consumeAborted()) {
           LOG_DBG("HOME", "Cover decode for %s yielded to input — will retry", book.path.c_str());
           recentsLoading = false;
           return;
         }
-        if (success) {
+        if (res == ThumbResult::Ok) {
           RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, placeholder);
           book.coverBmpPath = placeholder;
           LOG_DBG("HOME", "After generate: stored coverBmpPath=%s", placeholder.c_str());
@@ -440,25 +507,27 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
           return;
         }
 
-        // ensureCoverThumb() decodes an already-extracted cover.img only (allowExtract=false keeps
-        // the multi-second ZIP inflate off the per-tick path), so its first failure for an embedded
-        // cover usually just means cover.img isn't extracted yet. Start the sliced extractor (the
-        // same one the multi-size carousel path uses); the drain at the top of loadRecentCovers
-        // caches cover.img across ticks and the next pass re-runs ensureCoverThumb against it.
+        // A transient failure for an embedded cover usually just means cover.img isn't extracted
+        // yet. Start the sliced extractor (the same one the multi-size carousel path uses); the
+        // drain at the top of loadRecentCovers caches cover.img across ticks and the next pass
+        // re-runs ensureCoverThumb against it. Skip this for a structural absence — there is nothing
+        // to extract, and generateThumbBmp already wrote a permanent sentinel.
         // beginCoverExtractSession() returns null when cover.img is already cached (so an
-        // undecodable cover can't re-trigger extraction) or there is nothing to extract (no embedded
-        // cover / not an EPUB). In that case the cover is genuinely unavailable: record an empty
-        // path AND advance past this book — without the advance, the missing thumb keeps failing the
-        // validThumb check and the same book is retried every render, forever (the bug this fixes).
-        extractSession = ReaderActivity::beginCoverExtractSession(book.path);
-        if (extractSession) {
-          LOG_DBG("HOME", "Started cover extract session for %s (single-height)", book.path.c_str());
-          recentsLoading = false;
-          return;
+        // undecodable cover can't re-trigger extraction) or there is nothing to extract. In that
+        // case the cover is genuinely unavailable this pass: record an empty path AND advance past
+        // this book — without the advance, the missing thumb keeps failing the validThumb check and
+        // the same book is retried every render, forever (the bug this originally fixed).
+        if (res == ThumbResult::TransientFail) {
+          extractSession = ReaderActivity::beginCoverExtractSession(book.path);
+          if (extractSession) {
+            LOG_DBG("HOME", "Started cover extract session for %s (single-height)", book.path.c_str());
+            recentsLoading = false;
+            return;
+          }
         }
-        RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, "");
-        book.coverBmpPath = "";
-        LOG_DBG("HOME", "No extractable cover for %s; storing empty and advancing", book.path.c_str());
+        // No session could be started — give up on this book for now (counts the transient).
+        giveUpCover(book, res);
+        LOG_DBG("HOME", "No cover for %s; storing empty and advancing", book.path.c_str());
         nextRecentCoverIndex++;
         yieldAfterDecode();
         return;
@@ -528,6 +597,7 @@ void HomeActivity::onEnter() {
   pngSession.reset();
   pngSessionFiles.close();
   pngSessionFailed = false;
+  coverTransientAttempts.clear();
   coverRendered = false;
   secondaryBufferReleased = false;
   freeCoverBuffer();

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -306,11 +306,10 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
       for (size_t i = nextThumbSizeIndex; i < thumbSizes.size(); i++) {
         const auto& sz = thumbSizes[i];
         const std::string path = UITheme::getCoverThumbPath(placeholder, sz.first, sz.second);
-        FsFile thumbFile;
-        const bool validThumb = Storage.openFileForRead("HOME", path, thumbFile) && thumbFile.size() > 0;
-        LOG_DBG("HOME", "Cover check [%dx%d] path=%s valid=%d size=%u", sz.first, sz.second, path.c_str(),
-                validThumb ? 1 : 0, (unsigned)thumbFile.size());
-        thumbFile.close();
+        // Require a complete BMP (all pixel rows present), not just size>0: a thumbnail truncated by
+        // an interrupted write passes size>0 but fails to draw, and would never be regenerated.
+        const bool validThumb = ReaderActivity::isCoverThumbComplete(path);
+        LOG_DBG("HOME", "Cover check [%dx%d] path=%s valid=%d", sz.first, sz.second, path.c_str(), validThumb ? 1 : 0);
 
         if (!validThumb) {
           // Button input has priority: never start a fresh decode while a press is
@@ -405,11 +404,10 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
     } else {
       // Single-height path (non-carousel themes).
       const std::string path = UITheme::getCoverThumbPath(placeholder, coverHeight);
-      FsFile thumbFile;
-      const bool validThumb = Storage.openFileForRead("HOME", path, thumbFile) && thumbFile.size() > 0;
-      LOG_DBG("HOME", "Cover check [h=%d] path=%s valid=%d size=%u", coverHeight, path.c_str(), validThumb ? 1 : 0,
-              (unsigned)thumbFile.size());
-      thumbFile.close();
+      // Require a complete BMP (all pixel rows present), not just size>0: a thumbnail truncated by
+      // an interrupted write passes size>0 but fails to draw, and would never be regenerated.
+      const bool validThumb = ReaderActivity::isCoverThumbComplete(path);
+      LOG_DBG("HOME", "Cover check [h=%d] path=%s valid=%d", coverHeight, path.c_str(), validThumb ? 1 : 0);
 
       LOG_DBG("HOME", "loadRecentCovers[%zu]: coverBmpPath=%s placeholder=%s anyMissing=%d", nextRecentCoverIndex,
               book.coverBmpPath.c_str(), placeholder.c_str(), validThumb ? 0 : 1);

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -495,12 +495,12 @@ void HomeActivity::restoreSecondaryBuffer(bool callerHoldsRenderLock) {
       // Two-buffer differential is available again — turn off the single-buffer
       // RED-RAM-baseline mode so normal fast refresh resumes against the secondary.
       renderer.setSingleBufferFastDiff(false);
-      // reallocSecondaryBuffer() fills the new secondary with WHITE. Reseed RED RAM from
-      // the last displayed frame so the next fast differential has the correct baseline.
-      // No-op on X3: its differential lives in the controller, not the secondary buffer.
-      if (!renderer.isX3()) {
-        renderer.syncRedRamFromFrameBuffer();
-      }
+      // Do NOT syncRedRamFromFrameBuffer() here: reallocSecondaryBuffer() fills the new secondary
+      // with WHITE, and syncRedRamFromFrameBuffer() copies that white buffer into RED RAM —
+      // overwriting the correct baseline. RED already holds the home frame (synced before the
+      // release; the controller retains it through release/realloc, which don't touch RED). The
+      // white reseed made the next FAST refresh (e.g. Home->Settings) diff against white, ghosting
+      // the home screen through. Leave RED intact.
       LOG_DBG("HOME", "Restored secondary framebuffer after cover loading (free=%lu)",
               static_cast<unsigned long>(esp_get_free_heap_size()));
     }

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -176,13 +176,40 @@ bool HomeActivity::coverAttemptsExhausted(const std::string& path) const {
   return it != coverTransientAttempts.end() && it->second >= COVER_MAX_TRANSIENT_ATTEMPTS;
 }
 
-void HomeActivity::giveUpCover(RecentBook& book, ThumbResult res) {
+void HomeActivity::giveUpCover(RecentBook& book, ThumbResult res, const std::vector<ThumbSlot>& slots) {
   // Only transient failures count toward the session budget; a structural absence is already
   // permanent (generateThumbBmp wrote a sentinel) and needs no retry accounting.
   if (res == ThumbResult::TransientFail) {
     const uint8_t n = ++coverTransientAttempts[book.path];
     LOG_DBG("HOME", "Transient cover failure %u/%u for %s", n, COVER_MAX_TRANSIENT_ATTEMPTS, book.path.c_str());
   }
+
+  // Permanent give-up = structurally absent, or transient failures past this session's budget
+  // (e.g. an embedded cover the decoder rejects every time — oversize PNG, corrupt image). Mirror
+  // RecentBooksActivity: write a valid placeholder BMP at each thumb slot so isCoverThumbComplete()
+  // treats the book as resolved on disk and it is never re-decoded on the next boot. A still-retryable
+  // transient failure records an empty cover instead, so it gets a fresh attempt next session.
+  const bool permanent = (res == ThumbResult::StructurallyAbsent) || coverAttemptsExhausted(book.path);
+
+  if (permanent) {
+    bool allWritten = !slots.empty();
+    for (const auto& slot : slots) {
+      if (!ReaderActivity::isCoverThumbComplete(slot.path) &&
+          !ReaderActivity::writeCoverPlaceholderBmp(slot.path, slot.width, slot.height)) {
+        allWritten = false;
+      }
+    }
+    if (allWritten) {
+      const std::string placeholder = ReaderActivity::coverThumbPlaceholder(book.path);
+      LOG_DBG("HOME", "Wrote cover placeholder(s) for %s — resolved, will not re-decode", book.path.c_str());
+      RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, placeholder);
+      book.coverBmpPath = placeholder;
+      return;
+    }
+    // Placeholder write failed (e.g. tight heap) — fall through to empty; retry next pass.
+    LOG_DBG("HOME", "Placeholder write failed for %s — recording empty, will retry", book.path.c_str());
+  }
+
   RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, "");
   book.coverBmpPath = "";
 }
@@ -214,6 +241,22 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
   }
 
   const auto thumbSizes = GUI.getCoverThumbSizes(coverHeight);
+
+  // Build the placeholder slots for a book on give-up. Multi-size themes placeholder every
+  // WxH thumb; the single-height path placeholders its one thumb_<h>.bmp (width = h*0.6, matching
+  // the decode). Each slot's path is exactly what the loader's isCoverThumbComplete() checks.
+  const auto slotsForBook = [&](const std::string& placeholder) {
+    std::vector<ThumbSlot> slots;
+    if (!thumbSizes.empty()) {
+      slots.reserve(thumbSizes.size());
+      for (const auto& sz : thumbSizes) {
+        slots.push_back({UITheme::getCoverThumbPath(placeholder, sz.first, sz.second), sz.first, sz.second});
+      }
+    } else {
+      slots.push_back({UITheme::getCoverThumbPath(placeholder, coverHeight), coverHeight * 6 / 10, coverHeight});
+    }
+    return slots;
+  };
 
   // HomeActivity::loop runs on the main task while rendering runs on the render task.
   // Invalidate the Lyra frame cache under the render lock to avoid freeing cached
@@ -300,12 +343,14 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
       // Remove the partially-written BMP and leave no sentinel — ensureCoverThumb will retry.
       // (If the cover is permanently undecodable, generateThumbBmp will write a fresh sentinel.)
       const auto& failBook = recentBooks[nextRecentCoverIndex];
-      if (nextThumbSizeIndex < thumbSizes.size()) {
-        const std::string placeholder = ReaderActivity::coverThumbPlaceholder(failBook.path);
-        const auto& sz = thumbSizes[nextThumbSizeIndex];
-        const std::string failPath = UITheme::getCoverThumbPath(placeholder, sz.first, sz.second);
-        Storage.remove(failPath.c_str());
-      }
+      const std::string placeholder = ReaderActivity::coverThumbPlaceholder(failBook.path);
+      const std::string failPath =
+          thumbSizes.empty() ? UITheme::getCoverThumbPath(placeholder, coverHeight)
+                             : (nextThumbSizeIndex < thumbSizes.size()
+                                    ? UITheme::getCoverThumbPath(placeholder, thumbSizes[nextThumbSizeIndex].first,
+                                                                 thumbSizes[nextThumbSizeIndex].second)
+                                    : std::string());
+      if (!failPath.empty()) Storage.remove(failPath.c_str());
       LOG_ERR("HOME", "PNG session failed for %s", failBook.path.c_str());
       // Fall through to the for-loop where the normal failure path stores empty-path and continues.
     } else {
@@ -365,8 +410,10 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
           // This book already burned its transient-failure budget this session — stop retrying it
           // (a reboot resets the counter and tries again) so it can't starve the others.
           if (coverAttemptsExhausted(book.path)) {
-            LOG_DBG("HOME", "Cover attempts exhausted for %s this session — skipping", book.path.c_str());
-            giveUpCover(book, ThumbResult::StructurallyAbsent);  // don't re-count; just record empty
+            LOG_DBG("HOME", "Cover attempts exhausted for %s this session — writing placeholder", book.path.c_str());
+            // Already counted to the budget; don't re-count. coverAttemptsExhausted() makes this
+            // a permanent give-up inside giveUpCover(), so a durable placeholder BMP is written.
+            giveUpCover(book, ThumbResult::StructurallyAbsent, slotsForBook(placeholder));
             allValid = false;
             break;
           }
@@ -419,8 +466,9 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
               recentsLoading = false;
               return;
             }
-            // No session could be started — give up on this book for now (counts the transient).
-            giveUpCover(book, res);
+            // No session could be started — give up on this book for now (counts the transient;
+            // writes a durable placeholder once the budget is spent).
+            giveUpCover(book, res, slotsForBook(placeholder));
             allValid = false;
             break;
           }
@@ -439,7 +487,7 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
 
       LOG_DBG("HOME", "loadRecentCovers[%zu]: coverBmpPath=%s placeholder=%s", nextRecentCoverIndex,
               book.coverBmpPath.c_str(), placeholder.c_str());
-      if (!allValid) continue;  // decode failed — empty path already stored, advance to next book
+      if (!allValid) continue;  // gave up on this book — giveUpCover() already stored empty/placeholder
       // All sizes valid or just completed — store canonical placeholder and yield if a decode happened.
       if (book.coverBmpPath != placeholder) {
         LOG_DBG("HOME", "Self-heal/store: coverBmpPath -> placeholder=%s", placeholder.c_str());
@@ -477,8 +525,10 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
         // This book already burned its transient-failure budget this session — stop retrying it
         // (a reboot resets the counter) and advance.
         if (coverAttemptsExhausted(book.path)) {
-          LOG_DBG("HOME", "Cover attempts exhausted for %s this session — skipping", book.path.c_str());
-          giveUpCover(book, ThumbResult::StructurallyAbsent);  // don't re-count; just record empty
+          LOG_DBG("HOME", "Cover attempts exhausted for %s this session — writing placeholder", book.path.c_str());
+          // Already counted to the budget; don't re-count. coverAttemptsExhausted() makes this a
+          // permanent give-up inside giveUpCover(), so a durable placeholder BMP is written.
+          giveUpCover(book, ThumbResult::StructurallyAbsent, slotsForBook(placeholder));
           nextRecentCoverIndex++;
           yieldAfterDecode();
           return;
@@ -507,27 +557,36 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
           return;
         }
 
-        // A transient failure for an embedded cover usually just means cover.img isn't extracted
-        // yet. Start the sliced extractor (the same one the multi-size carousel path uses); the
-        // drain at the top of loadRecentCovers caches cover.img across ticks and the next pass
-        // re-runs ensureCoverThumb against it. Skip this for a structural absence — there is nothing
-        // to extract, and generateThumbBmp already wrote a permanent sentinel.
-        // beginCoverExtractSession() returns null when cover.img is already cached (so an
-        // undecodable cover can't re-trigger extraction) or there is nothing to extract. In that
-        // case the cover is genuinely unavailable this pass: record an empty path AND advance past
-        // this book — without the advance, the missing thumb keeps failing the validThumb check and
-        // the same book is retried every render, forever (the bug this originally fixed).
+        // Transient failure — walk the same session ladder as the multi-size path (skip it for a
+        // structural absence: nothing to extract, and generateThumbBmp already wrote a sentinel).
+        // (1) Sliced PNG decode: succeeds when cover.img is already cached, and unlike the
+        //     synchronous decoder it has no ~960k-px area cap — it decodes large covers (e.g.
+        //     1200x1848) across ticks. This is why the synchronous ensureCoverThumb "too large"
+        //     rejection is only transient: the sliced path below can still produce the thumb.
+        // (2) Sliced ZIP extract: when cover.img isn't cached yet, extract it across ticks; the
+        //     drain at the top of loadRecentCovers re-runs this ladder once it lands.
         if (res == ThumbResult::TransientFail) {
-          extractSession = ReaderActivity::beginCoverExtractSession(book.path);
-          if (extractSession) {
-            LOG_DBG("HOME", "Started cover extract session for %s (single-height)", book.path.c_str());
-            recentsLoading = false;
-            return;
+          if (!pngSessionFailed) {
+            pngSession = ReaderActivity::beginPngThumbSession(book.path, coverHeight, pngSessionFiles);
+            if (pngSession) {
+              LOG_DBG("HOME", "Started PNG session for %s (single-height, %u rows)", book.path.c_str(),
+                      pngSession->totalRows());
+              recentsLoading = false;
+              return;
+            }
+            extractSession = ReaderActivity::beginCoverExtractSession(book.path);
+            if (extractSession) {
+              LOG_DBG("HOME", "Started cover extract session for %s (single-height)", book.path.c_str());
+              recentsLoading = false;
+              return;
+            }
           }
+          pngSessionFailed = false;  // consumed
         }
-        // No session could be started — give up on this book for now (counts the transient).
-        giveUpCover(book, res);
-        LOG_DBG("HOME", "No cover for %s; storing empty and advancing", book.path.c_str());
+        // No session could be started — give up on this book for now (counts the transient;
+        // writes a durable placeholder once the budget is spent).
+        giveUpCover(book, res, slotsForBook(placeholder));
+        LOG_DBG("HOME", "No cover for %s; advancing", book.path.c_str());
         nextRecentCoverIndex++;
         yieldAfterDecode();
         return;

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -249,9 +250,9 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
     std::vector<ThumbSlot> slots;
     if (!thumbSizes.empty()) {
       slots.reserve(thumbSizes.size());
-      for (const auto& sz : thumbSizes) {
-        slots.push_back({UITheme::getCoverThumbPath(placeholder, sz.first, sz.second), sz.first, sz.second});
-      }
+      std::transform(thumbSizes.begin(), thumbSizes.end(), std::back_inserter(slots), [&](const auto& sz) {
+        return ThumbSlot{UITheme::getCoverThumbPath(placeholder, sz.first, sz.second), sz.first, sz.second};
+      });
     } else {
       slots.push_back({UITheme::getCoverThumbPath(placeholder, coverHeight), coverHeight * 6 / 10, coverHeight});
     }

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -94,9 +95,19 @@ class HomeActivity final : public Activity {
   void restoreSecondaryBuffer(bool callerHoldsRenderLock = false);
   void loadRecentBooks(int maxBooks);
   void loadRecentCovers(int coverHeight);
-  // Give up on a book's cover for now: store an empty cover path and, for a transient failure,
-  // bump the session retry counter. Shared by the single-height and multi-size cover paths.
-  void giveUpCover(RecentBook& book, ThumbResult res);
+  // One thumbnail slot to placeholder on a permanent give-up: the exact on-disk path the cover
+  // loader checks, plus the (w,h) the placeholder BMP should be written at.
+  struct ThumbSlot {
+    std::string path;
+    int width;
+    int height;
+  };
+  // Give up on a book's cover for this pass. Bumps the session retry counter for a transient
+  // failure. When the failure is permanent — structurally absent, or transient but past the
+  // session retry budget — writes a valid placeholder BMP at each slot (like RecentBooksActivity)
+  // so the book reads as resolved on disk and is not re-decoded on the next boot; otherwise just
+  // records an empty cover so it retries next session. Shared by both cover paths.
+  void giveUpCover(RecentBook& book, ThumbResult res, const std::vector<ThumbSlot>& slots);
   // True once a book has burned COVER_MAX_TRANSIENT_ATTEMPTS transient failures this session.
   bool coverAttemptsExhausted(const std::string& path) const;
 

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include "../Activity.h"
@@ -58,6 +59,17 @@ class HomeActivity final : public Activity {
   ReaderActivity::PngThumbFiles pngSessionFiles;  // open FsFiles borrowed by pngSession
   bool pngSessionFailed = false;                  // set on error; triggers empty-path store same as sync failure
 
+  // Session-scoped transient-failure counter, keyed by book path. A cover can fail to load for
+  // transient reasons (OOM under heap pressure, an interrupted write, an extraction that could not
+  // start). We retry such a book on later passes, but bounded: after COVER_MAX_TRANSIENT_ATTEMPTS
+  // transient failures in one Home session we stop retrying it THIS session (store an empty cover
+  // and advance) so a persistently-failing book can't starve the others. No persistent sentinel is
+  // written for transient failures — a reboot resets the map and gives every book a fresh chance;
+  // only a structurally-absent cover (no cover item / unsupported format) earns a permanent sentinel
+  // (written by generateThumbBmp). Cleared in onEnter().
+  static constexpr uint8_t COVER_MAX_TRANSIENT_ATTEMPTS = 2;
+  std::unordered_map<std::string, uint8_t> coverTransientAttempts;
+
   uint8_t* coverBuffer = nullptr;
   size_t coverBufferSize = 0;
   int coverRectX = 0;
@@ -82,6 +94,11 @@ class HomeActivity final : public Activity {
   void restoreSecondaryBuffer(bool callerHoldsRenderLock = false);
   void loadRecentBooks(int maxBooks);
   void loadRecentCovers(int coverHeight);
+  // Give up on a book's cover for now: store an empty cover path and, for a transient failure,
+  // bump the session retry counter. Shared by the single-height and multi-size cover paths.
+  void giveUpCover(RecentBook& book, ThumbResult res);
+  // True once a book has burned COVER_MAX_TRANSIENT_ATTEMPTS transient failures this session.
+  bool coverAttemptsExhausted(const std::string& path) const;
 
  public:
   explicit HomeActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::string focusBookPath = {},

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -115,28 +115,10 @@ bool RecentBooksActivity::loadNextCover() {
     const std::string placeholder = ReaderActivity::coverThumbPlaceholder(book.path);
     const std::string thumbPath = gridThumbPath(placeholder, tw, th);
 
-    // A 0-byte file is a "no extractable cover" sentinel left by a previous pass. Skip it cheaply:
-    // without this we re-open the EPUB three times per scan (generateThumbBmp + beginPngThumbSession
-    // + beginCoverExtractSession all load it) just to rediscover it has no cover — the "read again
-    // and again" seen for cover-less books like test_jpeg_images.epub.
-    {
-      FsFile tf;
-      bool noCoverSentinel = false;
-      if (Storage.openFileForRead("RBA", thumbPath, tf)) {
-        noCoverSentinel = (tf.size() == 0);
-        tf.close();
-      }
-      if (noCoverSentinel) {
-        if (!book.coverBmpPath.empty()) {
-          RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, "");
-          book.coverBmpPath.clear();
-        }
-        continue;  // no cover — advance to the next book without touching the EPUB
-      }
-    }
-
-    // size>0 is not enough: a thumbnail truncated by an interrupted write passes it but fails to
-    // draw partway. Require all pixel rows to be present, else regenerate (isCoverThumbComplete).
+    // Require a COMPLETE BMP (all pixel rows present), not just size>0: a thumbnail truncated by an
+    // interrupted write passes size>0 but fails to draw partway, so regenerate it. A no-cover book's
+    // placeholder BMP (written below) is also a complete BMP, so it passes here and is treated as a
+    // resolved cover — no re-opening the EPUB three times per scan to rediscover it has no cover.
     const bool valid = ReaderActivity::isCoverThumbComplete(thumbPath);
     if (!valid) {
       const bool ok = ReaderActivity::ensureCoverThumb(book.path, tw, th);
@@ -144,22 +126,27 @@ bool RecentBooksActivity::loadNextCover() {
       pngSessionFailed = false;  // consumed
       if (!ok && !wasPostFailure) {
         pngSession = ReaderActivity::beginPngThumbSession(book.path, tw, th, pngSessionFiles);
-        if (!pngSession) {
-          extractSession = ReaderActivity::beginCoverExtractSession(book.path);
-          if (extractSession) {
-            LOG_DBG("RBA", "Started cover extract session for %s (%zu bytes)", book.path.c_str(),
-                    extractSession->totalBytes());
-            return false;
-          }
-          // No thumb produced AND no decode/extract session could start → the book genuinely has no
-          // extractable cover. Drop a 0-byte sentinel so the cheap skip above short-circuits future
-          // scans instead of re-opening the EPUB each time. (A transient post-failure retry —
-          // wasPostFailure — is NOT sentinelled: the session error handler already cleaned up.)
-          FsFile sentinel;
-          if (Storage.openFileForWrite("RBA", thumbPath, sentinel)) sentinel.close();
-          LOG_DBG("RBA", "No extractable cover for %s — wrote no-cover sentinel", book.path.c_str());
-        } else {
+        if (pngSession) {
           LOG_DBG("RBA", "Started PNG session for %s (%u rows)", book.path.c_str(), pngSession->totalRows());
+          return false;
+        }
+        extractSession = ReaderActivity::beginCoverExtractSession(book.path);
+        if (extractSession) {
+          LOG_DBG("RBA", "Started cover extract session for %s (%zu bytes)", book.path.c_str(),
+                  extractSession->totalBytes());
+          return false;
+        }
+        // No thumb produced AND no decode/extract session could start → genuinely no extractable
+        // cover. But NOT if a sidecar image exists: that is a real cover source that simply failed
+        // to convert this pass (e.g. tight heap) and should be retried, not permanently placeholdered.
+        // Otherwise write a valid placeholder BMP so future scans treat the book as resolved and stop
+        // re-opening the EPUB. (A transient post-failure retry — wasPostFailure — is skipped here too.)
+        if (ReaderActivity::sidecarCoverPath(book.path).empty() &&
+            ReaderActivity::writeCoverPlaceholderBmp(thumbPath, tw, th)) {
+          LOG_DBG("RBA", "No extractable cover for %s — wrote placeholder", book.path.c_str());
+          RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, placeholder);
+          book.coverBmpPath = placeholder;
+          nextCoverIndex++;
           return false;
         }
       }

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -121,7 +121,7 @@ bool RecentBooksActivity::loadNextCover() {
     // resolved cover — no re-opening the EPUB three times per scan to rediscover it has no cover.
     const bool valid = ReaderActivity::isCoverThumbComplete(thumbPath);
     if (!valid) {
-      const bool ok = ReaderActivity::ensureCoverThumb(book.path, tw, th);
+      const bool ok = (ReaderActivity::ensureCoverThumb(book.path, tw, th) == ThumbResult::Ok);
       const bool wasPostFailure = pngSessionFailed;
       pngSessionFailed = false;  // consumed
       if (!ok && !wasPostFailure) {

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -72,6 +72,13 @@ bool RecentBooksActivity::loadNextCover() {
   if (pngSession) {
     constexpr uint32_t ROWS_PER_TICK = 6;
     const auto status = pngSession->continueRows(ROWS_PER_TICK);
+    // Progress evidence (throttled): proves the sliced decode is advancing rather than stalled.
+    const uint32_t now = millis();
+    if (now - lastCoverProgressLogMs_ >= 1000) {
+      lastCoverProgressLogMs_ = now;
+      LOG_DBG("RBA", "PNG cover decode: %u/%u rows for %s", pngSession->rowsDone(), pngSession->totalRows(),
+              recentBooks[nextCoverIndex].path.c_str());
+    }
     if (status == PngDecodeSession::Status::Running) {
       return false;  // not done yet — render() will requestUpdate() and call us again
     }
@@ -108,12 +115,34 @@ bool RecentBooksActivity::loadNextCover() {
     const std::string placeholder = ReaderActivity::coverThumbPlaceholder(book.path);
     const std::string thumbPath = gridThumbPath(placeholder, tw, th);
 
-    FsFile thumbFile;
-    const bool valid = Storage.openFileForRead("RBA", thumbPath, thumbFile) && thumbFile.size() > 0;
-    thumbFile.close();
+    // A 0-byte file is a "no extractable cover" sentinel left by a previous pass. Skip it cheaply:
+    // without this we re-open the EPUB three times per scan (generateThumbBmp + beginPngThumbSession
+    // + beginCoverExtractSession all load it) just to rediscover it has no cover — the "read again
+    // and again" seen for cover-less books like test_jpeg_images.epub.
+    {
+      FsFile tf;
+      bool noCoverSentinel = false;
+      if (Storage.openFileForRead("RBA", thumbPath, tf)) {
+        noCoverSentinel = (tf.size() == 0);
+        tf.close();
+      }
+      if (noCoverSentinel) {
+        if (!book.coverBmpPath.empty()) {
+          RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, "");
+          book.coverBmpPath.clear();
+        }
+        continue;  // no cover — advance to the next book without touching the EPUB
+      }
+    }
+
+    // size>0 is not enough: a thumbnail truncated by an interrupted write passes it but fails to
+    // draw partway. Require all pixel rows to be present, else regenerate (isCoverThumbComplete).
+    const bool valid = ReaderActivity::isCoverThumbComplete(thumbPath);
     if (!valid) {
       const bool ok = ReaderActivity::ensureCoverThumb(book.path, tw, th);
-      if (!ok && !pngSessionFailed) {
+      const bool wasPostFailure = pngSessionFailed;
+      pngSessionFailed = false;  // consumed
+      if (!ok && !wasPostFailure) {
         pngSession = ReaderActivity::beginPngThumbSession(book.path, tw, th, pngSessionFiles);
         if (!pngSession) {
           extractSession = ReaderActivity::beginCoverExtractSession(book.path);
@@ -122,12 +151,18 @@ bool RecentBooksActivity::loadNextCover() {
                     extractSession->totalBytes());
             return false;
           }
+          // No thumb produced AND no decode/extract session could start → the book genuinely has no
+          // extractable cover. Drop a 0-byte sentinel so the cheap skip above short-circuits future
+          // scans instead of re-opening the EPUB each time. (A transient post-failure retry —
+          // wasPostFailure — is NOT sentinelled: the session error handler already cleaned up.)
+          FsFile sentinel;
+          if (Storage.openFileForWrite("RBA", thumbPath, sentinel)) sentinel.close();
+          LOG_DBG("RBA", "No extractable cover for %s — wrote no-cover sentinel", book.path.c_str());
         } else {
           LOG_DBG("RBA", "Started PNG session for %s (%u rows)", book.path.c_str(), pngSession->totalRows());
           return false;
         }
       }
-      pngSessionFailed = false;  // consumed
       RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, ok ? placeholder : "");
       book.coverBmpPath = ok ? placeholder : "";
       nextCoverIndex++;
@@ -334,23 +369,58 @@ void RecentBooksActivity::render(RenderLock&& lock) {
   // jump to a stale buffer position during the transition.
   if (openingBook) return;
 
-  if (APP_STATE.recentBooksGridView) {
-    renderGridView(std::move(lock));
-    if (!firstRenderDone) {
-      firstRenderDone = true;
-      requestUpdate();
-    } else if (!coversLoaded && !coversLoading) {
-      coversLoading = true;
-      if (loadNextCover()) {
-        coversLoaded = true;
-      } else {
-        fullRedrawNeeded = true;
-        requestUpdate();
-      }
-      coversLoading = false;
-    }
-  } else {
+  if (!APP_STATE.recentBooksGridView) {
     renderListView(std::move(lock));
+    return;
+  }
+
+  // After the first paint, generate covers in time-bounded bursts. A cover slice (a PNG-decode
+  // row batch or a ZIP-extract chunk) only writes SD files — it does NOT change the screen — so we
+  // must NOT repaint per slice. Doing so turned every 6-row slice into a full ~2 s e-ink refresh,
+  // so a 1848-row cover needed 300+ refreshes (~10 min, and brutal on the panel). Instead drive
+  // slices here until a cover actually finishes (repaint once to show it), or until input is
+  // pending / a small time budget elapses (return WITHOUT repainting and resume on the next tick).
+  if (firstRenderDone && !coversLoaded && !coversLoading) {
+    // The cursor moved while a cover is still decoding: repaint the selection NOW (cheap two-cell
+    // partial) and resume decoding next tick. Otherwise the budget loop below would swallow the
+    // move and the highlight would only jump once the cover finished (seen as a frozen cursor).
+    if (prevSelectorIndex != selectorIndex) {
+      requestUpdate();
+      renderGridView(std::move(lock));  // partial path: fullRedrawNeeded stays false
+      return;
+    }
+
+    constexpr uint32_t COVER_SLICE_BUDGET_MS = 150;
+    coversLoading = true;
+    const size_t startIdx = nextCoverIndex;
+    const uint32_t deadline = millis() + COVER_SLICE_BUDGET_MS;
+    bool coverFinished = false;
+    while (true) {
+      if (loadNextCover()) {  // all covers resolved
+        coversLoaded = true;
+        coverFinished = true;
+        break;
+      }
+      if (nextCoverIndex != startIdx) {  // a book's cover just completed → worth showing now
+        coverFinished = true;
+        break;
+      }
+      if (mappedInput.hasPendingInput() || static_cast<int32_t>(millis() - deadline) >= 0) break;
+    }
+    coversLoading = false;
+
+    if (!coverFinished) {
+      requestUpdate();  // still slicing one cover — come back and continue, no repaint
+      return;
+    }
+    if (!coversLoaded) requestUpdate();  // more covers remain — continue after this repaint
+    fullRedrawNeeded = true;
+  }
+
+  renderGridView(std::move(lock));
+  if (!firstRenderDone) {
+    firstRenderDone = true;
+    requestUpdate();  // kick off cover generation now that the grid is on screen
   }
 }
 
@@ -418,7 +488,9 @@ void RecentBooksActivity::renderGridCell(int index, bool selected, int cellX, in
     bool thumbDrawn = false;
     if (Storage.openFileForRead("RBA", thumbPath, file)) {
       Bitmap bmp(file);
-      if (bmp.parseHeaders() == BmpReaderError::Ok) {
+      // Skip a truncated thumbnail (interrupted write): its header parses but readNextRow() fails
+      // partway, leaving a half-drawn cover and a GFX error. The validity check above regenerates it.
+      if (bmp.parseHeaders() == BmpReaderError::Ok && bmp.isComplete()) {
         const int imgW = bmp.getWidth();
         const int imgH = bmp.getHeight();
         const int innerW = tw - 2;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -47,6 +47,8 @@ class RecentBooksActivity final : public Activity {
   std::unique_ptr<PngDecodeSession> pngSession;
   ReaderActivity::PngThumbFiles pngSessionFiles;
   bool pngSessionFailed = false;
+  // Throttle for the cover-decode progress log (millis() of the last line emitted).
+  uint32_t lastCoverProgressLogMs_ = 0;
 
   // Partial selection repaint: track previous index so we only redraw two cells
   int prevSelectorIndex = -1;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2403,7 +2403,10 @@ void EpubReaderActivity::recoverSecondaryBufferIfNeeded() {
       // otherwise leave RED RAM reseeding skipped on the normal path. No-op if it was never set
       // (e.g. recovering from an indexing OOM instead of a released build).
       renderer.setSingleBufferFastDiff(false);
-      if (!renderer.isX3()) renderer.syncRedRamFromFrameBuffer();
+      // Do NOT syncRedRamFromFrameBuffer() here: reallocSecondaryBuffer() whitened the new secondary,
+      // and syncRedRamFromFrameBuffer() would copy that white into RED RAM, destroying the baseline.
+      // RED already holds the last displayed page (kept current by the released build's FAST refreshes;
+      // the controller retains it through realloc). Reseeding from white ghosted the next page.
       LOG_INF("ERS", "Secondary display buffer restored; re-enabling normal refresh/AA paths");
     } else {
       const uint32_t freeHeap = esp_get_free_heap_size();
@@ -2728,7 +2731,10 @@ EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const R
       // uses the normal host-reseeded baseline, not a stale controller-retained one. No-op if it was
       // never set.
       renderer.setSingleBufferFastDiff(false);
-      if (!renderer.isX3()) renderer.syncRedRamFromFrameBuffer();
+      // Do NOT syncRedRamFromFrameBuffer() here: reallocSecondaryBuffer() whitened the new secondary,
+      // and syncRedRamFromFrameBuffer() would copy that white into RED RAM, destroying the baseline.
+      // RED already holds the frame displayed before the build (the popup); reseeding from white made
+      // the first page after the build diff against white and ghost.
       LOG_DBG("ERS", "Index end mem (after fb realloc): free=%lu", esp_get_free_heap_size());
     }
   }
@@ -3320,11 +3326,15 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
         imageProcessingActive_ = false;
         return;  // fragmented-heap recovery reboot in progress
       }
-    } else if (!renderer.isX3()) {
-      // The realloc whitened the secondary buffer. Reseed RED RAM from the last displayed frame
-      // so the next fast differential diffs against the correct baseline, not the white new buffer.
-      renderer.syncRedRamFromFrameBuffer();
     }
+    // NOTE: do NOT syncRedRamFromFrameBuffer() here. reallocSecondaryBuffer() fills the new
+    // secondary with WHITE, and syncRedRamFromFrameBuffer() copies frameBufferActive (that white
+    // buffer) into RED RAM — which DESTROYS the correct baseline: RED already holds the previously
+    // displayed frame (the page under this one) from its own post-display sync, and _redRamSynced
+    // survives release/realloc. Reseeding from the white buffer made the next FAST differential diff
+    // the new page against white, so the previous page (e.g. the cover) bled through ("next page
+    // overloaded over the cover"). The displayed frame is gone from both host buffers after the
+    // release, so the controller's retained RED RAM is the only correct baseline — leave it intact.
   }
   imageProcessingActive_ = false;
   renderer.clearScreen();

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -184,7 +184,7 @@ NextBookMetadata loadNextBookMetadata(const std::string& nextBookPath) {
       if (!metadata.series.empty() && !epub.getSeriesIndex().empty()) {
         metadata.series += " #" + epub.getSeriesIndex();
       }
-      if (epub.generateThumbBmp(kFinishedBookCoverMaxWidth, kFinishedBookCoverHeight)) {
+      if (epub.generateThumbBmp(kFinishedBookCoverMaxWidth, kFinishedBookCoverHeight) == ThumbResult::Ok) {
         metadata.coverPath = epub.getThumbBmpPath(kFinishedBookCoverMaxWidth, kFinishedBookCoverHeight);
       } else {
         metadata.coverPath = getSidecarCoverBmpPath(nextBookPath, kFinishedBookCoverMaxWidth, kFinishedBookCoverHeight);

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -423,18 +423,22 @@ ThumbResult ReaderActivity::ensureCoverThumb(const std::string& bookPath, int he
   return ThumbResult::TransientFail;
 }
 
-std::unique_ptr<PngDecodeSession> ReaderActivity::beginPngThumbSession(const std::string& bookPath, int width,
-                                                                       int height, PngThumbFiles& filesOut) {
-  const std::string dir = bookCacheDir(bookPath);
-  const std::string name = "thumb_" + std::to_string(width) + "x" + std::to_string(height) + ".bmp";
+namespace {
+// Shared core: start a sliced PNG decode into an explicitly-named thumb file. The two public
+// overloads differ only in that name ("thumb_<W>x<H>.bmp" vs "thumb_<H>.bmp"), so they both
+// funnel through here to avoid duplicating the sidecar/cover.img source selection and setup.
+std::unique_ptr<PngDecodeSession> beginPngThumbSessionImpl(const std::string& bookPath, int width, int height,
+                                                           const std::string& name,
+                                                           ReaderActivity::PngThumbFiles& filesOut) {
+  const std::string dir = ReaderActivity::bookCacheDir(bookPath);
   const std::string bmpPath = dir + "/" + name;
 
   // Already cached (valid) — caller should have checked, but be safe.
-  if (thumbFileValid(bmpPath)) return nullptr;
+  if (ReaderActivity::isCoverThumbComplete(bmpPath)) return nullptr;
 
   // Sidecar PNG takes priority over embedded cover.
   std::string srcPath;
-  const std::string sidecar = sidecarCoverPath(bookPath);
+  const std::string sidecar = ReaderActivity::sidecarCoverPath(bookPath);
   bool isSidecar = false;
   if (!sidecar.empty() && FsHelpers::hasPngExtension(sidecar)) {
     srcPath = sidecar;
@@ -489,6 +493,20 @@ std::unique_ptr<PngDecodeSession> ReaderActivity::beginPngThumbSession(const std
   LOG_DBG("PNG", "beginPngThumbSession: started sliced decode for %s -> %s (%dx%d)", srcPath.c_str(), bmpPath.c_str(),
           width, height);
   return session;
+}
+}  // namespace
+
+std::unique_ptr<PngDecodeSession> ReaderActivity::beginPngThumbSession(const std::string& bookPath, int width,
+                                                                       int height, PngThumbFiles& filesOut) {
+  const std::string name = "thumb_" + std::to_string(width) + "x" + std::to_string(height) + ".bmp";
+  return beginPngThumbSessionImpl(bookPath, width, height, name, filesOut);
+}
+
+std::unique_ptr<PngDecodeSession> ReaderActivity::beginPngThumbSession(const std::string& bookPath, int height,
+                                                                       PngThumbFiles& filesOut) {
+  // Single-height thumbs scale to height*0.6 wide (mirrors the synchronous single-height decode).
+  const std::string name = "thumb_" + std::to_string(height) + ".bmp";
+  return beginPngThumbSessionImpl(bookPath, height * 6 / 10, height, name, filesOut);
 }
 
 std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path) {

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -1,5 +1,6 @@
 #include "ReaderActivity.h"
 
+#include <Bitmap.h>
 #include <CooperativeAbort.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
@@ -186,11 +187,14 @@ std::string ReaderActivity::convertSidecarToBmp(const std::string& cacheDir, con
   if (!Storage.exists(cacheDir.c_str())) Storage.mkdir(cacheDir.c_str());
   const std::string bmpPath = cacheDir + "/" + fileName;
   if (Storage.exists(bmpPath.c_str())) {
-    FsFile existing;
-    const uint32_t existingSize = Storage.openFileForRead("COVER", bmpPath, existing) ? (uint32_t)existing.size() : 0;
-    existing.close();
-    LOG_DBG("COVER", "convertSidecarToBmp: BMP already exists path=%s size=%u", bmpPath.c_str(), existingSize);
-    return bmpPath;
+    // Reuse only a COMPLETE BMP. A previous conversion truncated by an interrupted write would
+    // otherwise be returned and drawn forever (fails partway); remove it and reconvert instead.
+    if (isCoverThumbComplete(bmpPath)) {
+      LOG_DBG("COVER", "convertSidecarToBmp: BMP already exists (complete) path=%s", bmpPath.c_str());
+      return bmpPath;
+    }
+    LOG_DBG("COVER", "convertSidecarToBmp: existing BMP truncated, regenerating path=%s", bmpPath.c_str());
+    Storage.remove(bmpPath.c_str());
   }
 
   FsFile src;
@@ -227,15 +231,26 @@ std::string ReaderActivity::coverThumbPlaceholder(const std::string& bookPath) {
   return bookCacheDir(bookPath) + "/thumb_[HEIGHT].bmp";
 }
 
-namespace {
-// True if a thumbnail file exists and is non-empty (a 0-byte sentinel left by a prior failed
-// extraction must be treated as missing so regeneration retries).
-bool thumbFileValid(const std::string& path) {
+bool ReaderActivity::isCoverThumbComplete(const std::string& path) {
   FsFile f;
-  const bool ok = Storage.openFileForRead("COVER", path, f) && f.size() > 0;
+  if (!Storage.openFileForRead("COVER", path, f)) return false;
+  if (f.size() == 0) {  // 0-byte sentinel from a prior failed extraction → treat as missing
+    f.close();
+    return false;
+  }
+  Bitmap bmp(f);
+  // Header intact but pixel data short → truncated by an interrupted write; treat as invalid so
+  // the caller regenerates rather than keeping the unrenderable partial forever.
+  const bool ok = bmp.parseHeaders() == BmpReaderError::Ok && bmp.isComplete();
   f.close();
   return ok;
 }
+
+namespace {
+// True if a thumbnail file exists and is usable. A 0-byte sentinel left by a prior failed
+// extraction, OR a partial BMP left truncated by an interrupted write, must be treated as missing
+// so regeneration retries (see ReaderActivity::isCoverThumbComplete).
+bool thumbFileValid(const std::string& path) { return ReaderActivity::isCoverThumbComplete(path); }
 }  // namespace
 
 bool ReaderActivity::ensureCoverThumb(const std::string& bookPath, int width, int height) {

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -307,13 +307,36 @@ namespace {
 // extraction, OR a partial BMP left truncated by an interrupted write, must be treated as missing
 // so regeneration retries (see ReaderActivity::isCoverThumbComplete).
 bool thumbFileValid(const std::string& path) { return ReaderActivity::isCoverThumbComplete(path); }
+
+// Migration heal for stale sentinels written by an older build's blunt failure policy (any
+// extraction/decode failure — even a transient one — used to leave a permanent 0-byte sentinel).
+// Under the current policy a sentinel means "structurally absent"; if one exists yet the book's
+// cover.img is present AND a valid image format, the sentinel is stale — clear it so the normal
+// generateThumbBmp path gets a fresh chance. No-op unless BOTH a sentinel and a valid cover.img
+// exist, so a legitimately-absent cover keeps its sentinel.
+void healStaleEpubSentinel(const std::string& bookPath, const std::string& thumbFile) {
+  if (!FsHelpers::hasEpubExtension(bookPath)) return;
+  FsFile sentinel;
+  if (!Storage.openFileForRead("COVER", thumbFile, sentinel)) return;
+  const bool isSentinel = sentinel.size() == 0;
+  sentinel.close();
+  if (!isSentinel) return;
+
+  // coverImageCachedValidOnly() checks cover.img exists + non-empty + a known image format,
+  // without triggering any extraction — exactly the "sentinel is stale" condition.
+  Epub epub(bookPath, "/.crosspoint");
+  if (epub.load(true, true) && epub.coverImageCachedValidOnly()) {
+    LOG_DBG("COVER", "Healing stale sentinel %s (cover.img present & valid)", thumbFile.c_str());
+    Storage.remove(thumbFile.c_str());
+  }
+}
 }  // namespace
 
-bool ReaderActivity::ensureCoverThumb(const std::string& bookPath, int width, int height) {
+ThumbResult ReaderActivity::ensureCoverThumb(const std::string& bookPath, int width, int height) {
   const std::string dir = bookCacheDir(bookPath);
   const std::string name = "thumb_" + std::to_string(width) + "x" + std::to_string(height) + ".bmp";
   const std::string file = dir + "/" + name;
-  if (thumbFileValid(file)) return true;
+  if (thumbFileValid(file)) return ThumbResult::Ok;
 
   // Source preference: a sidecar image beside the book wins over the embedded cover.
   const std::string sidecar = sidecarCoverPath(bookPath);
@@ -324,40 +347,44 @@ bool ReaderActivity::ensureCoverThumb(const std::string& bookPath, int width, in
     const std::string result = convertSidecarToBmp(dir, sidecar, width, height, name);
     LOG_DBG("COVER", "convertSidecarToBmp(%dx%d) sidecar=%s result=%s", width, height, sidecar.c_str(),
             result.empty() ? "FAILED" : result.c_str());
-    if (!result.empty()) return true;
-    // Sidecar conversion bailed mid-decode for pending input — don't pay for an
-    // embedded-cover parse now; let the caller retry once the press is serviced.
-    if (CooperativeAbort::wasAborted()) return false;
+    if (!result.empty()) return ThumbResult::Ok;
+    // Sidecar conversion failed (bailed for input, OOM, decode error) — transient. Let the
+    // caller retry; don't fall through to an embedded-cover parse this pass.
+    return ThumbResult::TransientFail;
   }
 
   // No usable sidecar — fall back to the embedded cover.  generateThumbBmp() only
   // DECODES an already-extracted cover.img (abortable, ≤~1 s); it no longer inflates
-  // the cover from the ZIP itself.  If cover.img isn't cached yet it returns false
+  // the cover from the ZIP itself.  If cover.img isn't cached yet it reports TransientFail
   // without a sentinel, and the caller's sliced beginCoverExtractSession extracts it
   // across ticks before a later pass decodes it.  This keeps the 35 s ZIP inflate off
   // the per-tick path while still covering both embedded JPEG and PNG covers.
   if (FsHelpers::hasEpubExtension(bookPath)) {
+    // Clear any sentinel left permanent by an older build for what was only a transient failure,
+    // so a book whose cover.img is actually present & valid gets decoded instead of skipped.
+    healStaleEpubSentinel(bookPath, file);
     Epub epub(bookPath, "/.crosspoint");
     // allowExtract=false: decode only an already-cached cover.img; the sliced
     // beginCoverExtractSession owns the (potentially multi-second) ZIP inflate.
-    return epub.load(true, true) && epub.generateThumbBmp(width, height, /*allowExtract=*/false);
+    if (!epub.load(true, true)) return ThumbResult::TransientFail;
+    return epub.generateThumbBmp(width, height, /*allowExtract=*/false);
   }
   if (FsHelpers::hasXtcExtension(bookPath)) {
     Xtc xtc(bookPath, "/.crosspoint");
-    return xtc.load() && xtc.generateThumbBmp(width, height);
+    return (xtc.load() && xtc.generateThumbBmp(width, height)) ? ThumbResult::Ok : ThumbResult::TransientFail;
   }
   if (FsHelpers::hasTxtExtension(bookPath) || FsHelpers::hasMarkdownExtension(bookPath)) {
     Txt txt(bookPath, "/.crosspoint");
-    return txt.generateThumbBmp(width, height);
+    return txt.generateThumbBmp(width, height) ? ThumbResult::Ok : ThumbResult::TransientFail;
   }
-  return false;
+  return ThumbResult::TransientFail;
 }
 
-bool ReaderActivity::ensureCoverThumb(const std::string& bookPath, int height) {
+ThumbResult ReaderActivity::ensureCoverThumb(const std::string& bookPath, int height) {
   const std::string dir = bookCacheDir(bookPath);
   const std::string name = "thumb_" + std::to_string(height) + ".bmp";
   const std::string file = dir + "/" + name;
-  if (thumbFileValid(file)) return true;
+  if (thumbFileValid(file)) return ThumbResult::Ok;
 
   // Embedded single-height thumbnails scale to height*0.6 wide; mirror that for the sidecar.
   const std::string sidecar = sidecarCoverPath(bookPath);
@@ -367,30 +394,33 @@ bool ReaderActivity::ensureCoverThumb(const std::string& bookPath, int height) {
     const std::string result = convertSidecarToBmp(dir, sidecar, height * 6 / 10, height, name);
     LOG_DBG("COVER", "convertSidecarToBmp(h=%d) sidecar=%s result=%s", height, sidecar.c_str(),
             result.empty() ? "FAILED" : result.c_str());
-    if (!result.empty()) return true;
-    // Sidecar conversion bailed mid-decode for pending input — don't pay for an
-    // embedded-cover parse now; let the caller retry once the press is serviced.
-    if (CooperativeAbort::wasAborted()) return false;
+    if (!result.empty()) return ThumbResult::Ok;
+    // Sidecar conversion failed (bailed for input, OOM, decode error) — transient. Let the
+    // caller retry; don't fall through to an embedded-cover parse this pass.
+    return ThumbResult::TransientFail;
   }
 
   // Embedded EPUB cover: generateThumbBmp() decodes an already-extracted cover.img only
   // (see the width/height overload) — the sliced beginCoverExtractSession handles the
   // ZIP inflate so the 35 s stall stays off the per-tick path.
   if (FsHelpers::hasEpubExtension(bookPath)) {
+    // Clear any sentinel left permanent by an older build for what was only a transient failure.
+    healStaleEpubSentinel(bookPath, file);
     Epub epub(bookPath, "/.crosspoint");
     // allowExtract=false: decode only an already-cached cover.img; the sliced
     // beginCoverExtractSession owns the (potentially multi-second) ZIP inflate.
-    return epub.load(true, true) && epub.generateThumbBmp(height, /*allowExtract=*/false);
+    if (!epub.load(true, true)) return ThumbResult::TransientFail;
+    return epub.generateThumbBmp(height, /*allowExtract=*/false);
   }
   if (FsHelpers::hasXtcExtension(bookPath)) {
     Xtc xtc(bookPath, "/.crosspoint");
-    return xtc.load() && xtc.generateThumbBmp(height);
+    return (xtc.load() && xtc.generateThumbBmp(height)) ? ThumbResult::Ok : ThumbResult::TransientFail;
   }
   if (FsHelpers::hasTxtExtension(bookPath) || FsHelpers::hasMarkdownExtension(bookPath)) {
     Txt txt(bookPath, "/.crosspoint");
-    return txt.generateThumbBmp(height);
+    return txt.generateThumbBmp(height) ? ThumbResult::Ok : ThumbResult::TransientFail;
   }
-  return false;
+  return ThumbResult::TransientFail;
 }
 
 std::unique_ptr<PngDecodeSession> ReaderActivity::beginPngThumbSession(const std::string& bookPath, int width,

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -246,6 +246,62 @@ bool ReaderActivity::isCoverThumbComplete(const std::string& path) {
   return ok;
 }
 
+bool ReaderActivity::writeCoverPlaceholderBmp(const std::string& path, int width, int height) {
+  if (width <= 0 || height <= 0) return false;
+  const int rowBytes = ((width + 31) / 32) * 4;  // 1-bit rows padded to 4 bytes
+  uint8_t row[256];                              // cover thumbs are <=464px wide (rowBytes<=60)
+  if (rowBytes > static_cast<int>(sizeof(row))) return false;
+  const uint32_t imageSize = static_cast<uint32_t>(rowBytes) * static_cast<uint32_t>(height);
+  const uint32_t offBits = 14 + 40 + 8;  // file header + info header + 2-entry palette
+
+  FsFile f;
+  if (!Storage.openFileForWrite("COVER", path, f)) return false;
+  auto w16 = [&](uint16_t v) {
+    const uint8_t b[2] = {static_cast<uint8_t>(v), static_cast<uint8_t>(v >> 8)};
+    f.write(b, 2);
+  };
+  auto w32 = [&](uint32_t v) {
+    const uint8_t b[4] = {static_cast<uint8_t>(v), static_cast<uint8_t>(v >> 8), static_cast<uint8_t>(v >> 16),
+                          static_cast<uint8_t>(v >> 24)};
+    f.write(b, 4);
+  };
+  f.write(reinterpret_cast<const uint8_t*>("BM"), 2);
+  w32(offBits + imageSize);                     // bfSize
+  w16(0);                                       // reserved1
+  w16(0);                                       // reserved2
+  w32(offBits);                                 // bfOffBits
+  w32(40);                                      // biSize
+  w32(static_cast<uint32_t>(width));            // biWidth
+  w32(static_cast<uint32_t>(-height));          // biHeight (negative => top-down)
+  w16(1);                                       // biPlanes
+  w16(1);                                       // biBitCount
+  w32(0);                                       // biCompression = BI_RGB
+  w32(imageSize);                               // biSizeImage
+  w32(0);                                       // biXPelsPerMeter
+  w32(0);                                       // biYPelsPerMeter
+  w32(2);                                       // biClrUsed (black, white)
+  w32(0);                                       // biClrImportant
+  const uint8_t black[4] = {0, 0, 0, 0};        // palette index 0 = black
+  const uint8_t white[4] = {255, 255, 255, 0};  // palette index 1 = white
+  f.write(black, 4);
+  f.write(white, 4);
+  // Pixel rows (top-down): white interior (bit 1) with a 1px black frame (bit 0). A 1-bit BMP draws
+  // only its dark pixels, so this renders as an empty framed box — a clear "no cover" placeholder.
+  const int lastBit = width - 1;
+  for (int y = 0; y < height; y++) {
+    if (y == 0 || y == height - 1) {
+      memset(row, 0x00, rowBytes);  // full black border row
+    } else {
+      memset(row, 0xFF, rowBytes);                                                           // white
+      row[0] = static_cast<uint8_t>(row[0] & 0x7F);                                          // black left edge (col 0)
+      row[lastBit / 8] = static_cast<uint8_t>(row[lastBit / 8] & ~(0x80 >> (lastBit % 8)));  // right edge
+    }
+    f.write(row, rowBytes);
+  }
+  f.close();
+  return true;
+}
+
 namespace {
 // True if a thumbnail file exists and is usable. A 0-byte sentinel left by a prior failed
 // extraction, OR a partial BMP left truncated by an interrupted write, must be treated as missing

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -44,6 +44,11 @@ class ReaderActivity final : public Activity {
   static std::string coverThumbPlaceholder(const std::string& bookPath);
   static bool ensureCoverThumb(const std::string& bookPath, int width, int height);
   static bool ensureCoverThumb(const std::string& bookPath, int height);
+  // True only if a cover thumbnail BMP exists AND holds all its declared pixel rows. A thumbnail
+  // whose write was interrupted (reboot/abort mid-decode) is left truncated on the SD card; it
+  // passes a naive size>0 check but fails to draw partway (GFX "Failed to read row N"). Treating
+  // such a file as invalid lets the caller regenerate it instead of drawing/keeping it forever.
+  static bool isCoverThumbComplete(const std::string& path);
 
   // Sliced extraction of a ZIP entry to a file, one chunk per continueStep() call.
   // Used to extract an embedded PNG cover (cover.img) without blocking loop() for

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -49,6 +49,11 @@ class ReaderActivity final : public Activity {
   // passes a naive size>0 check but fails to draw partway (GFX "Failed to read row N"). Treating
   // such a file as invalid lets the caller regenerate it instead of drawing/keeping it forever.
   static bool isCoverThumbComplete(const std::string& path);
+  // Write a minimal but VALID 1-bit BMP (white box with a black frame) at the thumbnail path, used
+  // to mark a book that has no extractable cover. Being a complete BMP it passes
+  // isCoverThumbComplete(), so the cover loops treat the book as resolved and never re-open the EPUB
+  // to rediscover the absence — without the 0-byte-file "mess" (we now treat empty files as invalid).
+  static bool writeCoverPlaceholderBmp(const std::string& path, int width, int height);
 
   // Sliced extraction of a ZIP entry to a file, one chunk per continueStep() call.
   // Used to extract an embedded PNG cover (cover.img) without blocking loop() for

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -104,12 +104,17 @@ class ReaderActivity final : public Activity {
     }
   };
 
-  // Start a sliced PNG decode for bookPath at the given thumb dimensions.
-  // Returns nullptr if the cover is not a PNG, is already cached, or setup fails.
-  // On success, *filesOut owns the open FsFiles; caller must keep them alive until
-  // the session completes and then close them.
+  // Start a sliced PNG decode for bookPath at the given thumb dimensions. Writes the
+  // "thumb_<W>x<H>.bmp" (multi-size) form. Returns nullptr if the cover is not a PNG, is already
+  // cached, or setup fails. On success, *filesOut owns the open FsFiles; caller must keep them
+  // alive until the session completes and then close them.
   // On failure (nullptr return), the thumb file is left as a 0-byte sentinel.
   static std::unique_ptr<PngDecodeSession> beginPngThumbSession(const std::string& bookPath, int width, int height,
+                                                                PngThumbFiles& filesOut);
+
+  // Single-height variant: writes the "thumb_<H>.bmp" form used by the non-carousel themes, at
+  // width = H*0.6 (matching the synchronous single-height decode). Same contract as above.
+  static std::unique_ptr<PngDecodeSession> beginPngThumbSession(const std::string& bookPath, int height,
                                                                 PngThumbFiles& filesOut);
 
   // Render a sidecar image (or copy a sidecar BMP) into a scaled 1-bit BMP at

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "../Activity.h"
+#include "Epub/ThumbResult.h"
 #include "activities/home/FileBrowserActivity.h"
 
 class Epub;
@@ -42,8 +43,12 @@ class ReaderActivity final : public Activity {
   // returns. A sidecar image beside the book always takes precedence over the embedded cover
   // as the *source*; the embedded cover is only parsed when no sidecar exists.
   static std::string coverThumbPlaceholder(const std::string& bookPath);
-  static bool ensureCoverThumb(const std::string& bookPath, int width, int height);
-  static bool ensureCoverThumb(const std::string& bookPath, int height);
+  // Produce (or reuse) the cover thumbnail BMP for a book. Returns ThumbResult so the caller can
+  // tell a structural absence (no cover / unsupported — safe to record permanently) from a
+  // transient failure (retry next pass/boot). A sidecar image beside the book, when present and
+  // convertible, always yields Ok and clears any stale sentinel first.
+  static ThumbResult ensureCoverThumb(const std::string& bookPath, int width, int height);
+  static ThumbResult ensureCoverThumb(const std::string& bookPath, int height);
   // True only if a cover thumbnail BMP exists AND holds all its declared pixel rows. A thumbnail
   // whose write was interrupted (reboot/abort mid-decode) is left truncated on the SD card; it
   // passes a naive size>0 check but fails to draw partway (GFX "Failed to read row N"). Treating


### PR DESCRIPTION
## Summary

A set of fixes to the cover-thumbnail pipeline, RecentBooks/Home cover loading, and X4 display refresh. The largest thread reworks how embedded covers are decoded and how failures are classified, and makes the sliced PNG decoder reliable for large covers.

## Cover thumbnail pipeline

- **Rework sentinel logic.** Introduce a `ThumbResult { Ok, TransientFail, StructurallyAbsent }` outcome for `generateThumbBmp`/`ensureCoverThumb`. A 0-byte "structurally absent" sentinel is now written only when a cover is genuinely unusable (no cover item, or an unsupported/oversize format) — never on a transient failure (OOM, interrupted write, not-yet-extracted). Transient failures retry, bounded by a per-session counter in HomeActivity; a repeatedly-failing cover gets a durable placeholder BMP. Stale sentinels from older builds are healed when a valid `cover.img` is present.
- **Wire the sliced PNG decoder into the single-height cover path.** Large embedded PNG covers that the synchronous decoder rejects now decode across ticks via `PngDecodeSession` on the non-carousel themes, matching the carousel path.
- **Fix the PNG moire grid.** The sliced session aspect-fit its output (e.g. 240x369) while themes drew it at the exact tile height (400), forcing a fractional rescale of an already-dithered 1-bit image, producing a moire grid. The session now crop-fills to the exact target (like the synchronous path), so covers draw 1:1.
- **Render large embedded covers on the sleep screen.** Gate the 960k-px thumbnail size cap behind `enforceSizeCap` so the one-shot, stall-tolerant full-screen cover render decodes large covers; free the secondary framebuffer for decode headroom.
- Extract `Epub::writeThumbSentinel` (pure refactor collapsing four duplicate sentinel writes).

## RecentBooks / Home cover loading

- Burst-slice cover extraction and decode within a time budget; release the ~48 KB secondary framebuffer during cold-cache loading for headroom; various OOM-avoidance fixes on the cover-loading path.

## X4 display

- Additional X4 ghosting fixes and refresh-mode logging in HalDisplay.

## Testing

- Firmware builds clean (`pio run -e default`).
- Cover-pipeline changes verified on device (X4): the moire fix, the large-embedded-cover thumbnail render, and the sleep-screen large-cover render were all confirmed working.

Generated with Claude Code

