### PR TITLE
feat: Full-screen selector for multi-option settings

### DIFF
--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -106,17 +106,19 @@ inline std::vector<SettingInfo> buildSettingsList() {
                         {StrId::STR_DARK, StrId::STR_LIGHT, StrId::STR_CUSTOM, StrId::STR_COVER, StrId::STR_NONE_OPT,
                          StrId::STR_COVER_CUSTOM, StrId::STR_PAGE_OVERLAY, StrId::STR_QUICK_RESUME},
                         "sleepScreen", StrId::STR_CAT_DISPLAY)
-          .withSubcategory(StrId::STR_MENU_DISP_SLEEP));
+          .withSubcategory(StrId::STR_MENU_DISP_SLEEP)
+          .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_SLEEP_COVER_MODE, &CrossPointSettings::sleepScreenCoverMode,
                                        {StrId::STR_FIT, StrId::STR_CROP}, "sleepScreenCoverMode",
                                        StrId::STR_CAT_DISPLAY));
   settings.push_back(SettingInfo::Enum(StrId::STR_SLEEP_COVER_FILTER, &CrossPointSettings::sleepScreenCoverFilter,
                                        {StrId::STR_NONE_OPT, StrId::STR_FILTER_CONTRAST, StrId::STR_INVERTED},
                                        "sleepScreenCoverFilter", StrId::STR_CAT_DISPLAY));
-  settings.push_back(SettingInfo::Enum(
-      StrId::STR_SLEEP_COVER_OVERLAY, &CrossPointSettings::sleepCoverOverlay,
-      {StrId::STR_OVERLAY_OFF, StrId::STR_OVERLAY_WHITE, StrId::STR_OVERLAY_GRAY, StrId::STR_OVERLAY_BLACK},
-      "sleepCoverOverlay", StrId::STR_CAT_DISPLAY));
+  settings.push_back(SettingInfo::Enum(StrId::STR_SLEEP_COVER_OVERLAY, &CrossPointSettings::sleepCoverOverlay,
+                                       {StrId::STR_OVERLAY_OFF, StrId::STR_OVERLAY_WHITE, StrId::STR_OVERLAY_GRAY,
+                                        StrId::STR_OVERLAY_BLACK},
+                                       "sleepCoverOverlay", StrId::STR_CAT_DISPLAY)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_SLEEP_IMAGE_PICK_MODE, &CrossPointSettings::sleepImagePickMode,
                                        {StrId::STR_RANDOM, StrId::STR_SEQUENTIAL}, "sleepImagePickMode",
                                        StrId::STR_CAT_DISPLAY));
@@ -139,17 +141,19 @@ inline std::vector<SettingInfo> buildSettingsList() {
                          .withSubcategory(StrId::STR_MENU_DISP_REFRESH));
   settings.push_back(SettingInfo::Toggle(StrId::STR_SUNLIGHT_FADING_FIX, &CrossPointSettings::fadingFix, "fadingFix",
                                          StrId::STR_CAT_DISPLAY));
-  settings.push_back(SettingInfo::Enum(
-      StrId::STR_UI_THEME, &CrossPointSettings::uiTheme,
-      {StrId::STR_THEME_CLASSIC, StrId::STR_THEME_LYRA, StrId::STR_THEME_LYRA_EXTENDED, StrId::STR_THEME_LYRA_CAROUSEL},
-      "uiTheme", StrId::STR_CAT_DISPLAY));
+  settings.push_back(SettingInfo::Enum(StrId::STR_UI_THEME, &CrossPointSettings::uiTheme,
+                                       {StrId::STR_THEME_CLASSIC, StrId::STR_THEME_LYRA, StrId::STR_THEME_LYRA_EXTENDED,
+                                        StrId::STR_THEME_LYRA_CAROUSEL},
+                                       "uiTheme", StrId::STR_CAT_DISPLAY)
+                         .withSelectorActivity());
 
   // --- Reader ---
   // General reader settings
   settings.push_back(
       SettingInfo::Enum(StrId::STR_ORIENTATION, &CrossPointSettings::orientation,
                         {StrId::STR_PORTRAIT, StrId::STR_LANDSCAPE_CW, StrId::STR_INVERTED, StrId::STR_LANDSCAPE_CCW},
-                        "orientation", StrId::STR_CAT_READER));
+                        "orientation", StrId::STR_CAT_READER)
+          .withSelectorActivity());
   // EPUB font submenu — family first, then size/AA/darkness.
   // DynamicEnum so SD card font families can be appended at the consumer
   // side (SettingsActivity / CrossPointWebServer enrich enumLabels before
@@ -165,7 +169,8 @@ inline std::vector<SettingInfo> buildSettingsList() {
       SettingInfo::Enum(StrId::STR_FONT_SIZE, &CrossPointSettings::fontSize,
                         {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE, StrId::STR_X_LARGE, StrId::STR_TINY},
                         "fontSize", StrId::STR_CAT_READER)
-          .withSubmenu(StrId::STR_MENU_READER_FONT));
+          .withSubmenu(StrId::STR_MENU_READER_FONT)
+          .withSelectorActivity());
   settings.push_back(SettingInfo::Toggle(StrId::STR_TEXT_AA, &CrossPointSettings::textAntiAliasing, "textAntiAliasing",
                                          StrId::STR_CAT_READER)
                          .withSubmenu(StrId::STR_MENU_READER_FONT));
@@ -180,7 +185,8 @@ inline std::vector<SettingInfo> buildSettingsList() {
   settings.push_back(SettingInfo::Enum(StrId::STR_TEXT_DARKNESS, &CrossPointSettings::textDarkness,
                                        {StrId::STR_NORMAL, StrId::STR_DARK, StrId::STR_EXTRA_DARK, StrId::STR_MAX_DARK},
                                        "textDarkness", StrId::STR_CAT_READER)
-                         .withSubmenu(StrId::STR_MENU_READER_FONT));
+                         .withSubmenu(StrId::STR_MENU_READER_FONT)
+                         .withSelectorActivity());
   // TXT/MD font submenu — same dynamic structure as EPUB, includes SD card fonts.
   settings.push_back(SettingInfo::DynamicEnum(StrId::STR_TXT_FONT_FAMILY, {StrId::STR_BOOKERLY, StrId::STR_NOTO_SANS},
                                               txtFontFamilyDynamicGetter, txtFontFamilyDynamicSetter, "txtFontFamily",
@@ -191,12 +197,14 @@ inline std::vector<SettingInfo> buildSettingsList() {
       SettingInfo::Enum(StrId::STR_TXT_FONT_SIZE, &CrossPointSettings::txtFontSize,
                         {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE, StrId::STR_X_LARGE, StrId::STR_TINY},
                         "txtFontSize", StrId::STR_CAT_READER)
-          .withSubmenu(StrId::STR_MENU_TXT_FONT));
+          .withSubmenu(StrId::STR_MENU_TXT_FONT)
+          .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_PARA_ALIGNMENT, &CrossPointSettings::paragraphAlignment,
                                        {StrId::STR_JUSTIFY, StrId::STR_ALIGN_LEFT, StrId::STR_CENTER,
                                         StrId::STR_ALIGN_RIGHT, StrId::STR_BOOK_S_STYLE},
                                        "paragraphAlignment", StrId::STR_CAT_READER)
-                         .withSubcategory(StrId::STR_MENU_READER_LAYOUT));
+                         .withSubcategory(StrId::STR_MENU_READER_LAYOUT)
+                         .withSelectorActivity());
   // Formatting settings
   settings.push_back(SettingInfo::Toggle(StrId::STR_EMBEDDED_STYLE, &CrossPointSettings::embeddedStyle, "embeddedStyle",
                                          StrId::STR_CAT_READER));
@@ -246,11 +254,13 @@ inline std::vector<SettingInfo> buildSettingsList() {
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_DOUBLE_PRESS, &CrossPointSettings::btnDoubleBack,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnDoubleBack",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_BACK));
+                         .withSubmenu(StrId::STR_BTN_BACK)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_LONG_PRESS, &CrossPointSettings::btnLongBack,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_GO_HOME), "btnLongBack",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_BACK));
+                         .withSubmenu(StrId::STR_BTN_BACK)
+                         .withSelectorActivity());
   // Confirm button: short=reader menu, double=ignore, long=KOReader sync
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_SHORT_PRESS, &CrossPointSettings::btnShortConfirm,
                                        {StrId::STR_BTN_DEF_READER_MENU}, "btnShortConfirm", StrId::STR_CAT_CONTROLS)
@@ -258,72 +268,88 @@ inline std::vector<SettingInfo> buildSettingsList() {
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_DOUBLE_PRESS, &CrossPointSettings::btnDoubleConfirm,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnDoubleConfirm",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_CONFIRM));
+                         .withSubmenu(StrId::STR_BTN_CONFIRM)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_LONG_PRESS, &CrossPointSettings::btnLongConfirm,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_KOREADER_SYNC), "btnLongConfirm",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_CONFIRM));
+                         .withSubmenu(StrId::STR_BTN_CONFIRM)
+                         .withSelectorActivity());
   // Left button: short=previous page, double=ignore, long=chapter back
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_SHORT_PRESS, &CrossPointSettings::btnShortLeft,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_PREV_PAGE), "btnShortLeft",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_LEFT));
+                         .withSubmenu(StrId::STR_BTN_LEFT)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_DOUBLE_PRESS, &CrossPointSettings::btnDoubleLeft,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnDoubleLeft",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_LEFT));
+                         .withSubmenu(StrId::STR_BTN_LEFT)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_LONG_PRESS, &CrossPointSettings::btnLongLeft,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_CHAPTER_BACK), "btnLongLeft",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_LEFT));
+                         .withSubmenu(StrId::STR_BTN_LEFT)
+                         .withSelectorActivity());
   // Right button: short=next page, double=ignore, long=chapter forward
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_SHORT_PRESS, &CrossPointSettings::btnShortRight,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_NEXT_PAGE), "btnShortRight",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_RIGHT));
+                         .withSubmenu(StrId::STR_BTN_RIGHT)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_DOUBLE_PRESS, &CrossPointSettings::btnDoubleRight,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnDoubleRight",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_RIGHT));
+                         .withSubmenu(StrId::STR_BTN_RIGHT)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_LONG_PRESS, &CrossPointSettings::btnLongRight,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_CHAPTER_FORWARD), "btnLongRight",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_RIGHT));
+                         .withSubmenu(StrId::STR_BTN_RIGHT)
+                         .withSelectorActivity());
   // Page Back button: short=previous page, double=ignore, long=chapter back
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_SHORT_PRESS, &CrossPointSettings::btnShortPageBack,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_PREV_PAGE), "btnShortPageBack",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_UP));
+                         .withSubmenu(StrId::STR_BTN_UP)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_DOUBLE_PRESS, &CrossPointSettings::btnDoublePageBack,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnDoublePageBack",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_UP));
+                         .withSubmenu(StrId::STR_BTN_UP)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_LONG_PRESS, &CrossPointSettings::btnLongPageBack,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_CHAPTER_BACK), "btnLongPageBack",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_UP));
+                         .withSubmenu(StrId::STR_BTN_UP)
+                         .withSelectorActivity());
   // Page Forward button: short=next page, double=ignore, long=chapter forward
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_SHORT_PRESS, &CrossPointSettings::btnShortPageForward,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_NEXT_PAGE), "btnShortPageForward",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_DOWN));
+                         .withSubmenu(StrId::STR_BTN_DOWN)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_DOUBLE_PRESS, &CrossPointSettings::btnDoublePageForward,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnDoublePageForward",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_DOWN));
+                         .withSubmenu(StrId::STR_BTN_DOWN)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_LONG_PRESS, &CrossPointSettings::btnLongPageForward,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_CHAPTER_FORWARD), "btnLongPageForward",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_DOWN));
+                         .withSubmenu(StrId::STR_BTN_DOWN)
+                         .withSelectorActivity());
   // Power button: short=ignore, double=ignore, long=sleep (via hold timer, not event system)
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_SHORT_PRESS, &CrossPointSettings::btnShortPower,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnShortPower",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_POWER));
+                         .withSubmenu(StrId::STR_BTN_POWER)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_DOUBLE_PRESS, &CrossPointSettings::btnDoublePower,
                                        makeBtnActionOptions(StrId::STR_BTN_DEF_IGNORE), "btnDoublePower",
                                        StrId::STR_CAT_CONTROLS)
-                         .withSubmenu(StrId::STR_BTN_POWER));
+                         .withSubmenu(StrId::STR_BTN_POWER)
+                         .withSelectorActivity());
   settings.push_back(SettingInfo::Enum(StrId::STR_BTN_LONG_PRESS, &CrossPointSettings::btnLongPower,
                                        {StrId::STR_BTN_DEF_SLEEP}, "btnLongPower", StrId::STR_CAT_CONTROLS)
                          .withSubmenu(StrId::STR_BTN_POWER));
@@ -363,7 +389,8 @@ inline std::vector<SettingInfo> buildSettingsList() {
                          StrId::STR_TZ_UTC_PLUS4, StrId::STR_TZ_IST, StrId::STR_TZ_UTC_PLUS7, StrId::STR_TZ_UTC_PLUS8,
                          StrId::STR_TZ_UTC_PLUS9, StrId::STR_TZ_AEST, StrId::STR_TZ_NZST, StrId::STR_TZ_UTC_MINUS3,
                          StrId::STR_TZ_EST, StrId::STR_TZ_CST, StrId::STR_TZ_MST, StrId::STR_TZ_PST},
-                        "timeZone", StrId::STR_CLOCK));
+                        "timeZone", StrId::STR_CLOCK)
+          .withSelectorActivity());
   // Weather
   settings.push_back(
       SettingInfo::Toggle(StrId::STR_USE_WEATHER, &CrossPointSettings::useWeather, "useWeather", StrId::STR_WEATHER));

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1978,6 +1978,16 @@ void EpubReaderActivity::applyBookReaderOverrides(
                                   bookBionicReadingOverride, bookParagraphAlignmentOverride,
                                   bookTextAntiAliasingOverride, bookHyphenationOverride);
 
+  // A changed override forces a full section relayout (section.reset() below → rebuild with the
+  // "Indexing…" popup). That popup FAST-refreshes against whatever is on the panel; when the change
+  // arrived via the full-screen selector, the extra menu/submenu/selector redraws leave the FAST
+  // baseline out of sync and the popup box ghosts. Arm a one-shot HALF so drawPopup() establishes a
+  // clean baseline — the same deliberate-transition signal the chapter/percent/footnote jumps use
+  // (hasRefreshOverridePending() at the popup then also arms forceHalfRefreshAfterPopup_ for the
+  // first content page). Reached only when something actually changed (early-out above), so routine
+  // no-op reopens of the menu don't pay for it.
+  ReaderUtils::enforceExitFullRefresh(renderer);
+
   RenderLock lock(*this);
   if (section) {
     navTarget = NavigationTarget::makePage(section->currentPage);

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -198,7 +198,8 @@ void EpubReaderMenuActivity::buildMenuItems(bool hasFootnotes, bool hasStarredPa
                                  s->pendingSdFontFamilyOverride.clear();
                                }
                              })
-                             .withSubmenu(StrId::STR_READER_OVERRIDES);
+                             .withSubmenu(StrId::STR_READER_OVERRIDES)
+                             .withSelectorActivity();
 
     familySetting.enumLabels = {tr(STR_DEFAULT_VALUE), tr(STR_BOOKERLY), tr(STR_NOTO_SANS)};
     for (const auto& fam : families) {
@@ -223,7 +224,8 @@ void EpubReaderMenuActivity::buildMenuItems(bool hasFootnotes, bool hasStarredPa
                             auto* s = static_cast<EpubReaderMenuActivity*>(ctx);
                             s->pendingFontSizeOverride = (v == 0) ? -1 : static_cast<int8_t>(v - 1);
                           })
-                          .withSubmenu(StrId::STR_READER_OVERRIDES));
+                          .withSubmenu(StrId::STR_READER_OVERRIDES)
+                          .withSelectorActivity());
 
   // Text darkness: straightforward 0-3 cycle
   menuItems.push_back(
@@ -234,7 +236,8 @@ void EpubReaderMenuActivity::buildMenuItems(bool hasFootnotes, bool hasStarredPa
             return static_cast<const EpubReaderMenuActivity*>(ctx)->pendingTextDarkness;
           },
           [](void* ctx, uint8_t v) { static_cast<EpubReaderMenuActivity*>(ctx)->pendingTextDarkness = v; })
-          .withSubmenu(StrId::STR_READER_OVERRIDES));
+          .withSubmenu(StrId::STR_READER_OVERRIDES)
+          .withSelectorActivity());
 
   menuItems.push_back(
       SettingInfo::DynamicEnumCtx(
@@ -261,7 +264,8 @@ void EpubReaderMenuActivity::buildMenuItems(bool hasFootnotes, bool hasStarredPa
                             auto* s = static_cast<EpubReaderMenuActivity*>(ctx);
                             s->pendingParagraphAlignmentOverride = (v == 0) ? -1 : static_cast<int8_t>(v - 1);
                           })
-                          .withSubmenu(StrId::STR_READER_OVERRIDES));
+                          .withSubmenu(StrId::STR_READER_OVERRIDES)
+                          .withSelectorActivity());
 
   // Text anti-aliasing: default / on / off (mirrors QuickOverrides)
   menuItems.push_back(

--- a/src/activities/settings/EnumSelectionActivity.cpp
+++ b/src/activities/settings/EnumSelectionActivity.cpp
@@ -1,0 +1,78 @@
+#include "EnumSelectionActivity.h"
+
+#include <I18n.h>
+
+#include "CrossPointSettings.h"
+#include "MappedInputManager.h"
+#include "components/UITheme.h"
+
+uint8_t EnumSelectionActivity::optionCount() const {
+  return overrideCount > 0 ? overrideCount : setting.getEnumOptionCount();
+}
+
+std::string EnumSelectionActivity::optionLabel(uint8_t index) const {
+  if (labelOverride) {
+    std::string label = labelOverride(index);
+    if (!label.empty()) return label;
+  }
+  return setting.getEnumOptionLabel(index);
+}
+
+void EnumSelectionActivity::onEnter() {
+  Activity::onEnter();
+  selectedIndex = static_cast<int>(setting.getEnumSelectedIndex());
+  const int count = static_cast<int>(optionCount());
+  if (selectedIndex >= count) selectedIndex = 0;  // clamp stale/out-of-range persisted value
+  requestUpdate();
+}
+
+void EnumSelectionActivity::onExit() { Activity::onExit(); }
+
+void EnumSelectionActivity::loop() {
+  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+    finish();
+    return;
+  }
+
+  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+    handleSelection();
+    return;
+  }
+
+  const int count = static_cast<int>(optionCount());
+  buttonNavigator.onNextList(selectedIndex, count, [this] { requestUpdate(); });
+  buttonNavigator.onPreviousList(selectedIndex, count, [this] { requestUpdate(); });
+}
+
+void EnumSelectionActivity::handleSelection() {
+  setting.setEnumSelectedIndex(static_cast<uint8_t>(selectedIndex));
+  finish();
+}
+
+void EnumSelectionActivity::render(RenderLock&&) {
+  renderer.clearScreen();
+
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const Rect contentRect = UITheme::getContentRect(renderer, true, false);
+
+  GUI.drawHeader(renderer, Rect{contentRect.x, metrics.topPadding, contentRect.width, metrics.headerHeight},
+                 I18N.get(setting.nameId));
+
+  const int contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
+  const int contentHeight = contentRect.height - contentTop - metrics.verticalSpacing;
+
+  const int count = static_cast<int>(optionCount());
+  const uint8_t activeIndex = setting.getEnumSelectedIndex();
+  GUI.drawList(
+      renderer, Rect{contentRect.x, contentTop, contentRect.width, contentHeight}, count, selectedIndex,
+      [this](int index) { return optionLabel(static_cast<uint8_t>(index)); }, nullptr, nullptr,
+      [activeIndex](int index) -> std::string {
+        return index == static_cast<int>(activeIndex) ? tr(STR_SELECTED) : "";
+      },
+      true);
+
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+
+  renderer.displayBuffer();
+}

--- a/src/activities/settings/EnumSelectionActivity.h
+++ b/src/activities/settings/EnumSelectionActivity.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <GfxRenderer.h>
+
+#include <string>
+
+#include "../Activity.h"
+#include "SettingInfo.h"
+#include "util/ButtonNavigator.h"
+
+class MappedInputManager;
+
+/// Full-screen list picker for a single ENUM SettingInfo.
+///
+/// Generalises the older font-only selector: instead of cycling an enum in place
+/// by repeatedly pressing Confirm (tedious and blind for 4-5 option settings), it
+/// shows every option as a scrollable list with the current value checked, and
+/// writes the chosen value back through the SettingInfo's own accessor path.
+///
+/// The idea of opening a selection window for a multi-option toggle is adopted
+/// from crosspoint-reader PR #2358 (originating in PR #1842 by @pablohc). This
+/// implementation reuses the existing MenuListActivity list chrome rather than a
+/// separate popup component, so it adds no per-theme render surface and keeps only
+/// one activity resident at a time.
+///
+/// The activity does NOT persist settings itself — the caller's result handler is
+/// responsible for SETTINGS.saveToFile() and any dependent-setting normalisation,
+/// exactly as the previous font-selector call-sites already did.
+class EnumSelectionActivity final : public Activity {
+ public:
+  // Optional per-index label override, used when the option labels are richer than
+  // the SettingInfo's static enum labels (e.g. SD-card font families appended at
+  // the call site). Return an empty string to fall back to the SettingInfo label.
+  // A plain function pointer + count keeps this free of heap-allocating std::function
+  // in the common (no-override) path.
+  using LabelOverrideFn = std::string (*)(uint8_t index);
+
+  EnumSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const SettingInfo& setting,
+                        LabelOverrideFn labelOverride = nullptr, uint8_t overrideCount = 0)
+      : Activity("EnumSelect", renderer, mappedInput),
+        setting(setting),
+        labelOverride(labelOverride),
+        overrideCount(overrideCount) {}
+
+  void onEnter() override;
+  void onExit() override;
+  void loop() override;
+  void render(RenderLock&&) override;
+
+ private:
+  [[nodiscard]] uint8_t optionCount() const;
+  [[nodiscard]] std::string optionLabel(uint8_t index) const;
+  void handleSelection();
+
+  const SettingInfo& setting;
+  LabelOverrideFn labelOverride;
+  uint8_t overrideCount;
+
+  ButtonNavigator buttonNavigator;
+  int selectedIndex = 0;
+};

--- a/src/activities/settings/SettingActionDispatch.cpp
+++ b/src/activities/settings/SettingActionDispatch.cpp
@@ -5,12 +5,15 @@
 #include "ClearCacheActivity.h"
 #include "ClockSettingsActivity.h"
 #include "DetectTimezoneActivity.h"
+#include "EnumSelectionActivity.h"
 #include "FontDownloadActivity.h"
+#include "FontSelectionActivity.h"
 #include "KOReaderSettingsActivity.h"
 #include "LanguageSelectActivity.h"
 #include "OpdsServerListActivity.h"
 #include "OtaUpdateActivity.h"
 #include "ReadingStatsActivity.h"
+#include "SdCardFontGlobals.h"
 #include "SdFirmwareUpdateActivity.h"
 #include "StatusBarSettingsActivity.h"
 #include "SwitchToUsbDriveActivity.h"
@@ -63,4 +66,20 @@ std::unique_ptr<Activity> createActivityForAction(SettingAction action, GfxRende
       return nullptr;
   }
   return nullptr;
+}
+
+std::unique_ptr<Activity> createSelectorActivity(const SettingInfo& setting, GfxRenderer& renderer,
+                                                 MappedInputManager& mappedInput) {
+  // Font-family settings keep their dedicated selector: it enumerates SD-card font
+  // families (which aren't part of the setting's static enum list) on top of the
+  // built-in families. The EPUB/TXT variant is distinguished by the getter, matching
+  // the sniff previously duplicated at each call site.
+  if (setting.valueGetter == fontFamilyDynamicGetter || setting.valueGetter == txtFontFamilyDynamicGetter) {
+    const auto target = (setting.valueGetter == txtFontFamilyDynamicGetter) ? FontSelectionActivity::Target::TXT
+                                                                            : FontSelectionActivity::Target::EPUB;
+    return std::make_unique<FontSelectionActivity>(renderer, mappedInput, target);
+  }
+
+  if (setting.type != SettingType::ENUM) return nullptr;
+  return std::make_unique<EnumSelectionActivity>(renderer, mappedInput, setting);
 }

--- a/src/activities/settings/SettingActionDispatch.h
+++ b/src/activities/settings/SettingActionDispatch.h
@@ -11,3 +11,11 @@ class MappedInputManager;
 // Returns nullptr for None, Submenu, or unknown actions (caller handles those).
 std::unique_ptr<Activity> createActivityForAction(SettingAction action, GfxRenderer& renderer,
                                                   MappedInputManager& mappedInput);
+
+// Creates the full-screen selector activity for a setting flagged with
+// withSelectorActivity(). Returns the SD-card-aware FontSelectionActivity for the
+// reader/TXT font-family settings, and the generic EnumSelectionActivity for any
+// other ENUM setting. Callers own persistence in their result handler. Returns
+// nullptr if the setting is not an ENUM (defensive; the flag is only set on enums).
+std::unique_ptr<Activity> createSelectorActivity(const SettingInfo& setting, GfxRenderer& renderer,
+                                                 MappedInputManager& mappedInput);

--- a/src/activities/settings/SettingInfo.h
+++ b/src/activities/settings/SettingInfo.h
@@ -290,6 +290,43 @@ struct SettingInfo {
   // Marked const because it mutates the external SETTINGS global (via valuePtr),
   // not the SettingInfo itself.
   void toggleValue() const;
+
+  // --- ENUM option accessors, used by the full-screen EnumSelectionActivity ---
+  // These mirror the read/write logic in getDisplayValue()/toggleValue() but expose
+  // the option set directly so a list selector can render every choice and jump to
+  // one, instead of cycling. enumLabels takes precedence over enumValues (see the
+  // enumLabels contract above). All are no-ops / empty for non-ENUM types.
+
+  // Number of selectable options (0 for non-ENUM).
+  [[nodiscard]] uint8_t getEnumOptionCount() const {
+    if (type != SettingType::ENUM) return 0;
+    return static_cast<uint8_t>(enumLabels.empty() ? enumValues.size() : enumLabels.size());
+  }
+
+  // Localised label for option `index` (empty if out of range or non-ENUM).
+  [[nodiscard]] std::string getEnumOptionLabel(uint8_t index) const {
+    if (type != SettingType::ENUM) return {};
+    if (!enumLabels.empty()) return index < enumLabels.size() ? enumLabels[index] : std::string{};
+    return index < enumValues.size() ? std::string(I18N.get(enumValues[index])) : std::string{};
+  }
+
+  // Currently selected option index (0 if unreadable).
+  [[nodiscard]] uint8_t getEnumSelectedIndex() const {
+    if (type != SettingType::ENUM) return 0;
+    if (valuePtr) return SETTINGS.*(valuePtr);
+    if (valueGetter) return callValueGetter();
+    return 0;
+  }
+
+  // Writes the selected option index through the same path getDisplayValue() reads.
+  void setEnumSelectedIndex(uint8_t index) const {
+    if (type != SettingType::ENUM) return;
+    if (index >= getEnumOptionCount()) return;
+    if (valuePtr)
+      SETTINGS.*(valuePtr) = index;
+    else if (valueSetter)
+      callValueSetter(index);
+  }
 };
 
 inline void SettingInfo::prepareSubmenus(std::vector<SettingInfo>& items,

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -9,8 +9,8 @@
 #include <cstring>
 
 #include "CrossPointSettings.h"
-#include "FontSelectionActivity.h"
 #include "MappedInputManager.h"
+#include "SdCardFontGlobals.h"
 #include "SettingActionDispatch.h"
 #include "SettingsList.h"
 #include "SettingsSubmenuActivity.h"
@@ -286,14 +286,14 @@ void SettingsActivity::toggleCurrentSetting() {
   if (setting.isSeparator) return;
 
   if (setting.usesSelectorActivity) {
-    const auto target = (setting.valueGetter == txtFontFamilyDynamicGetter) ? FontSelectionActivity::Target::TXT
-                                                                            : FontSelectionActivity::Target::EPUB;
-    startActivityForResult(std::make_unique<FontSelectionActivity>(renderer, mappedInput, target),
-                           [this](const ActivityResult&) {
-                             CrossPointSettings::normalizeDependentSettings(SETTINGS);
-                             SETTINGS.saveToFile();
-                             needsHalfRefresh = true;
-                           });
+    auto selector = createSelectorActivity(setting, renderer, mappedInput);
+    if (selector) {
+      startActivityForResult(std::move(selector), [this](const ActivityResult&) {
+        CrossPointSettings::normalizeDependentSettings(SETTINGS);
+        SETTINGS.saveToFile();
+        needsHalfRefresh = true;
+      });
+    }
     return;
   }
 

--- a/src/activities/settings/SettingsSubmenuActivity.cpp
+++ b/src/activities/settings/SettingsSubmenuActivity.cpp
@@ -6,9 +6,7 @@
 #include <I18n.h>
 
 #include "CrossPointSettings.h"
-#include "FontSelectionActivity.h"
 #include "MappedInputManager.h"
-#include "SdCardFontGlobals.h"
 #include "SettingActionDispatch.h"
 #include "activities/SliderPickerActivity.h"
 #include "components/UITheme.h"
@@ -103,14 +101,14 @@ void SettingsSubmenuActivity::toggleCurrentItem() {
   if (setting.isSeparator) return;
 
   if (setting.usesSelectorActivity) {
-    const auto target = (setting.valueGetter == txtFontFamilyDynamicGetter) ? FontSelectionActivity::Target::TXT
-                                                                            : FontSelectionActivity::Target::EPUB;
-    startActivityForResult(std::make_unique<FontSelectionActivity>(renderer, mappedInput, target),
-                           [this](const ActivityResult&) {
-                             SETTINGS.saveToFile();
-                             needsHalfRefresh = true;
-                             requestUpdate();
-                           });
+    auto selector = createSelectorActivity(setting, renderer, mappedInput);
+    if (selector) {
+      startActivityForResult(std::move(selector), [this](const ActivityResult&) {
+        SETTINGS.saveToFile();
+        needsHalfRefresh = true;
+        requestUpdate();
+      });
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

Multi-option enum settings previously required repeatedly pressing Confirm to cycle blindly through every option. This adds a full-screen list picker (`EnumSelectionActivity`) that shows all options with the current value highlighted and marked, and writes the choice back through the setting's own accessor path.

The font-family selector is **generalised rather than duplicated**: a single `createSelectorActivity()` helper dispatches font-family settings to the existing SD-card-aware `FontSelectionActivity` and every other enum to the new generic picker, removing the selector logic that was duplicated across `SettingsActivity` and `SettingsSubmenuActivity`.

All 4+-option enums opt in via `withSelectorActivity()` — the settings list plus the reader-menu font / size / darkness / alignment overrides. Shorter (2–3 option) enums keep cycling inline.

## Attribution

Adopts the **"open a selection window for a multi-option toggle"** idea from [crosspoint-reader PR #2358](https://github.com/crosspoint-reader/crosspoint-reader/pull/2358), originating in PR #1842 by **@pablohc**. Our take reuses the existing `MenuListActivity` list chrome instead of introducing a separate popup component, so no per-theme render surface is added and only one activity is resident at a time.

## Commits

1. **Full-screen selector for multi-option settings** — the feature (new `EnumSelectionActivity`, `SettingInfo` enum accessors, `createSelectorActivity()` dedup, `withSelectorActivity()` on long enums).
2. **Fix indexing-popup ghosting after a reader override relayout** — changing a per-book override via the selector reindexes the section; the "Indexing…" popup FAST-refreshed against a stale baseline (extra menu/submenu/selector redraws) and ghosted. Arm a one-shot HALF in `applyBookReaderOverrides()` when an override actually changed, so `drawPopup()` establishes a clean baseline — the same deliberate-transition signal the chapter/percent/footnote jumps use.

## Testing

- Builds clean (`pio run`), cppcheck clean, clang-format applied.
- Confirmed on device: full-screen picker opens with the current value highlighted for long enums in Settings and in the reader menu; the indexing-popup ghosting after a font-size/family override is resolved.
- Flash usage unchanged (~94.7%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
