### PR TITLE
refactor: Split benchmark/sync out of EpubReaderActivity; gate benchmark behind ENABLE_BENCHMARKS

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1,4 +1,4 @@
-#define DEBUG_MEMORY_CONSUMPTION 1
+﻿#define DEBUG_MEMORY_CONSUMPTION 1
 #define DEBUG_BACKGROUND_WORK 1
 #define DEBUG_BACKGROUND_OVERLAY 0
 
@@ -42,7 +42,6 @@
 #include "EpubReaderFootnotesActivity.h"
 #include "EpubReaderPercentSelectionActivity.h"
 #include "EpubReaderPrintedPageInputActivity.h"
-#include "EpubRenderBenchmarkActivity.h"
 #include "FinishedBookActivity.h"
 #include "GlobalBookmarkIndex.h"
 #include "KOReaderCredentialStore.h"
@@ -239,30 +238,6 @@ uint8_t epubProgressPercentByte(const Epub& epub, const int spineIndex, const in
   return ReaderUtils::fractionProgressPercentByte(epub.calculateProgress(spineIndex, chapterProgress));
 }
 
-// Writes the canonical EPUB progress.bin layout: spine(2) + page(2) + pageCount(2) + percent(1).
-// Used by the per-page saveProgress() and by transient writers (sync restore, bookmark jump) so
-// the on-disk format stays consistent regardless of caller.
-bool writeReaderProgressCache(const std::string& cachePath, const int spineIndex, const int currentPage,
-                              const int pageCount, const uint8_t percent) {
-  FsFile f;
-  if (!Storage.openFileForWrite("ERS", cachePath + "/progress.bin", f)) {
-    LOG_ERR("ERS", "Failed to open progress cache: %s", cachePath.c_str());
-    return false;
-  }
-
-  uint8_t data[7];
-  data[0] = spineIndex & 0xFF;
-  data[1] = (spineIndex >> 8) & 0xFF;
-  data[2] = currentPage & 0xFF;
-  data[3] = (currentPage >> 8) & 0xFF;
-  data[4] = pageCount & 0xFF;
-  data[5] = (pageCount >> 8) & 0xFF;
-  data[6] = percent;
-  f.write(data, 7);
-  f.close();
-  return true;
-}
-
 int clampPercent(int percent) {
   if (percent < 0) {
     return 0;
@@ -271,20 +246,6 @@ int clampPercent(int percent) {
     return 100;
   }
   return percent;
-}
-
-const char* orientationToString(const GfxRenderer::Orientation orientation) {
-  switch (orientation) {
-    case GfxRenderer::Portrait:
-      return "Portrait";
-    case GfxRenderer::LandscapeClockwise:
-      return "Landscape CW";
-    case GfxRenderer::PortraitInverted:
-      return "Portrait Inverted";
-    case GfxRenderer::LandscapeCounterClockwise:
-      return "Landscape CCW";
-  }
-  return "Unknown";
 }
 
 int getImageOnlyPageYOffset(const Page& page, const int viewportHeight) {
@@ -1415,7 +1376,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       return;
     }
     case EpubReaderMenuActivity::MenuAction::RENDER_BENCHMARK: {
+#if ENABLE_BENCHMARKS
       runRenderBenchmark();
+#endif  // ENABLE_BENCHMARKS
       break;
     }
     case EpubReaderMenuActivity::MenuAction::SCREENSHOT: {
@@ -1443,387 +1406,6 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       break;
     }
   }
-}
-
-void EpubReaderActivity::runRenderBenchmark() {
-  if (!epub) {
-    return;
-  }
-
-  if (!section) {
-    requestUpdateAndWait();
-    if (!section) {
-      return;
-    }
-  }
-
-  const LastRenderStats startSnapshot = lastRenderStats;
-  BenchmarkAggregate aggregate;
-  auto recordRender = [&aggregate](const LastRenderStats& snapshot) {
-    if (!snapshot.valid) {
-      return;
-    }
-
-    aggregate.renderCount++;
-    aggregate.imagePageCount += snapshot.hadImages ? 1 : 0;
-    aggregate.cacheRebuildCount += snapshot.cacheRebuilt ? 1 : 0;
-    if (snapshot.footnoteCount > aggregate.maxFootnotes) {
-      aggregate.maxFootnotes = snapshot.footnoteCount;
-    }
-
-    aggregate.totalRequestRenderMs += snapshot.requestRenderMs;
-    if (aggregate.renderCount == 1 || snapshot.requestRenderMs < aggregate.minRequestRenderMs) {
-      aggregate.minRequestRenderMs = snapshot.requestRenderMs;
-    }
-    if (snapshot.requestRenderMs > aggregate.maxRequestRenderMs) {
-      aggregate.maxRequestRenderMs = snapshot.requestRenderMs;
-    }
-
-    aggregate.totalRenderMs += snapshot.phases.totalMs;
-    if (aggregate.renderCount == 1 || snapshot.phases.totalMs < aggregate.minRenderMs) {
-      aggregate.minRenderMs = snapshot.phases.totalMs;
-    }
-    if (snapshot.phases.totalMs > aggregate.maxRenderMs) {
-      aggregate.maxRenderMs = snapshot.phases.totalMs;
-    }
-
-    aggregate.totalSectionLoadMs += snapshot.sectionLoadMs;
-    aggregate.totalPageLoadMs += snapshot.pageLoadMs;
-    aggregate.totalPhases.prewarmMs += snapshot.phases.prewarmMs;
-    aggregate.totalPhases.bwRenderMs += snapshot.phases.bwRenderMs;
-    aggregate.totalPhases.displayMs += snapshot.phases.displayMs;
-    aggregate.totalPhases.bwStoreMs += snapshot.phases.bwStoreMs;
-    aggregate.totalPhases.grayLsbMs += snapshot.phases.grayLsbMs;
-    aggregate.totalPhases.grayMsbMs += snapshot.phases.grayMsbMs;
-    aggregate.totalPhases.grayDisplayMs += snapshot.phases.grayDisplayMs;
-    aggregate.totalPhases.bwRestoreMs += snapshot.phases.bwRestoreMs;
-    aggregate.totalPhases.totalMs += snapshot.phases.totalMs;
-
-    aggregate.totalFontCacheHits += snapshot.fontCacheHits;
-    aggregate.totalFontCacheMisses += snapshot.fontCacheMisses;
-    aggregate.totalFontDecompressMs += snapshot.fontDecompressMs;
-    aggregate.totalFontGetBitmapTimeUs += snapshot.fontGetBitmapTimeUs;
-    aggregate.totalFontGetBitmapCalls += snapshot.fontGetBitmapCalls;
-
-    if (aggregate.renderCount == 1 || snapshot.freeHeapAfter < aggregate.minFreeHeapAfter) {
-      aggregate.minFreeHeapAfter = snapshot.freeHeapAfter;
-    }
-    if (snapshot.freeHeapAfter > aggregate.maxFreeHeapAfter) {
-      aggregate.maxFreeHeapAfter = snapshot.freeHeapAfter;
-    }
-  };
-  const unsigned long startTime = millis();
-  int forwardTurns = 0;
-  int backwardTurns = 0;
-
-  for (int i = 0; i < 10; i++) {
-    if (!stepPageState(true)) {
-      break;
-    }
-    requestUpdateAndWait();
-    recordRender(lastRenderStats);
-    forwardTurns++;
-  }
-
-  const unsigned long forwardMs = millis() - startTime;
-  const unsigned long backwardStart = millis();
-
-  for (int i = 0; i < 10; i++) {
-    if (!stepPageState(false)) {
-      break;
-    }
-    requestUpdateAndWait();
-    recordRender(lastRenderStats);
-    backwardTurns++;
-  }
-
-  const unsigned long backwardMs = millis() - backwardStart;
-
-  startActivityForResult(
-      std::make_unique<EpubRenderBenchmarkActivity>(
-          renderer, mappedInput,
-          buildRenderBenchmarkReport(startSnapshot, aggregate, forwardTurns, forwardMs, backwardTurns, backwardMs)),
-      [this](const ActivityResult&) { requestUpdate(); });
-}
-
-std::string EpubReaderActivity::buildRenderBenchmarkReport(const LastRenderStats& startSnapshot,
-                                                           const BenchmarkAggregate& aggregate, const int forwardTurns,
-                                                           const unsigned long forwardMs, const int backwardTurns,
-                                                           const unsigned long backwardMs) const {
-  const LastRenderStats& endSnapshot = lastRenderStats.valid ? lastRenderStats : startSnapshot;
-
-  std::string report;
-  report.reserve(768);
-
-  auto appendLine = [&report](const std::string& line) {
-    if (!report.empty()) {
-      report += '\n';
-    }
-    report += line;
-  };
-
-  appendLine("Forward 10: " + std::to_string(forwardTurns) + " turns in " + std::to_string(forwardMs) + " ms");
-  if (forwardTurns > 0) {
-    appendLine("Forward avg: " + std::to_string(forwardMs / static_cast<unsigned long>(forwardTurns)) + " ms/turn");
-  }
-  appendLine("Backward 10: " + std::to_string(backwardTurns) + " turns in " + std::to_string(backwardMs) + " ms");
-  if (backwardTurns > 0) {
-    appendLine("Backward avg: " + std::to_string(backwardMs / static_cast<unsigned long>(backwardTurns)) + " ms/turn");
-  }
-  appendLine("Measured renders: " + std::to_string(aggregate.renderCount) + ", image pages " +
-             std::to_string(aggregate.imagePageCount) + ", cache rebuilds " +
-             std::to_string(aggregate.cacheRebuildCount));
-
-  appendLine("Start: spine " + std::to_string(startSnapshot.spineIndex) + ", page " +
-             std::to_string(startSnapshot.pageIndex + 1) + "/" + std::to_string(startSnapshot.pageCount));
-  appendLine("End: spine " + std::to_string(endSnapshot.spineIndex) + ", page " +
-             std::to_string(endSnapshot.pageIndex + 1) + "/" + std::to_string(endSnapshot.pageCount));
-  appendLine("Orientation: " +
-             std::string(orientationToString(static_cast<GfxRenderer::Orientation>(endSnapshot.orientation))));
-  appendLine("Viewport: " + std::to_string(endSnapshot.viewportWidth) + "x" +
-             std::to_string(endSnapshot.viewportHeight) + " px, margins T/R/B/L " +
-             std::to_string(endSnapshot.marginTop) + "/" + std::to_string(endSnapshot.marginRight) + "/" +
-             std::to_string(endSnapshot.marginBottom) + "/" + std::to_string(endSnapshot.marginLeft));
-  appendLine("Font: " + std::to_string(endSnapshot.effectiveFontId) + ", embedded CSS " +
-             std::string(endSnapshot.embeddedStyle ? "on" : "off") + ", images " +
-             std::to_string(endSnapshot.imageRendering) + ", AA " +
-             std::string(endSnapshot.textAntiAliasing ? "on" : "off"));
-  appendLine("Last page: images " + std::string(endSnapshot.hadImages ? "yes" : "no") + ", footnotes " +
-             std::to_string(endSnapshot.footnoteCount) + ", cache rebuilt " +
-             std::string(endSnapshot.cacheRebuilt ? "yes" : "no"));
-  if (aggregate.renderCount > 0) {
-    appendLine("Render avg/min/max: request " +
-               std::to_string(aggregate.totalRequestRenderMs / static_cast<unsigned long>(aggregate.renderCount)) +
-               "/" + std::to_string(aggregate.minRequestRenderMs) + "/" + std::to_string(aggregate.maxRequestRenderMs) +
-               " ms, core " +
-               std::to_string(aggregate.totalRenderMs / static_cast<unsigned long>(aggregate.renderCount)) + "/" +
-               std::to_string(aggregate.minRenderMs) + "/" + std::to_string(aggregate.maxRenderMs) + " ms");
-    appendLine("Aggregate loads: section " + std::to_string(aggregate.totalSectionLoadMs) + " ms, page " +
-               std::to_string(aggregate.totalPageLoadMs) + " ms, max footnotes " +
-               std::to_string(aggregate.maxFootnotes));
-    appendLine("Aggregate phases: prewarm " + std::to_string(aggregate.totalPhases.prewarmMs) + ", bw " +
-               std::to_string(aggregate.totalPhases.bwRenderMs) + ", display " +
-               std::to_string(aggregate.totalPhases.displayMs) + ", planes " +
-               std::to_string(aggregate.totalPhases.grayLsbMs) + ", gray display " +
-               std::to_string(aggregate.totalPhases.grayDisplayMs) + ", restore " +
-               std::to_string(aggregate.totalPhases.bwRestoreMs));
-    appendLine("Aggregate font: hits " + std::to_string(aggregate.totalFontCacheHits) + ", misses " +
-               std::to_string(aggregate.totalFontCacheMisses) + ", decompress " +
-               std::to_string(aggregate.totalFontDecompressMs) + " ms");
-    appendLine("Aggregate glyph lookups: " + std::to_string(aggregate.totalFontGetBitmapCalls) + " calls, " +
-               std::to_string(aggregate.totalFontGetBitmapTimeUs) + " us total");
-    appendLine("Heap after render min/max: " + std::to_string(aggregate.minFreeHeapAfter) + "/" +
-               std::to_string(aggregate.maxFreeHeapAfter));
-  }
-  appendLine("Last render: request " + std::to_string(endSnapshot.requestRenderMs) + " ms, section load " +
-             std::to_string(endSnapshot.sectionLoadMs) + " ms, page load " + std::to_string(endSnapshot.pageLoadMs) +
-             " ms, render total " + std::to_string(endSnapshot.phases.totalMs) + " ms");
-  appendLine("Phases: prewarm " + std::to_string(endSnapshot.phases.prewarmMs) + ", bw " +
-             std::to_string(endSnapshot.phases.bwRenderMs) + ", display " +
-             std::to_string(endSnapshot.phases.displayMs) + ", planes " + std::to_string(endSnapshot.phases.grayLsbMs) +
-             ", gray display " + std::to_string(endSnapshot.phases.grayDisplayMs) + ", restore " +
-             std::to_string(endSnapshot.phases.bwRestoreMs));
-  appendLine("Font cache: hits " + std::to_string(endSnapshot.fontCacheHits) + ", misses " +
-             std::to_string(endSnapshot.fontCacheMisses) + ", decompress " +
-             std::to_string(endSnapshot.fontDecompressMs) + " ms, groups " +
-             std::to_string(endSnapshot.fontUniqueGroups));
-  appendLine("Font buffers: page " + std::to_string(endSnapshot.fontPageBufferBytes) + ", glyph table " +
-             std::to_string(endSnapshot.fontPageGlyphsBytes) + ", peak temp " +
-             std::to_string(endSnapshot.fontPeakTempBytes));
-  appendLine("Glyph lookups: " + std::to_string(endSnapshot.fontGetBitmapCalls) + " calls, " +
-             std::to_string(endSnapshot.fontGetBitmapTimeUs) + " us total");
-  appendLine("Heap: before " + std::to_string(endSnapshot.freeHeapBefore) + "/" +
-             std::to_string(endSnapshot.largestFreeBlockBefore) + ", after " +
-             std::to_string(endSnapshot.freeHeapAfter) + "/" + std::to_string(endSnapshot.largestFreeBlockAfter));
-
-  return report;
-}
-
-void EpubReaderActivity::launchKOReaderSync(const SyncLaunchMode mode) {
-  if (!epub) {
-    return;
-  }
-
-  const int currentPage = section ? section->currentPage : 0;
-  const int totalPages = section ? section->pageCount : 0;
-  KOReaderSyncIntentState syncIntent = KOReaderSyncIntentState::COMPARE;
-  if (mode == SyncLaunchMode::PULL_REMOTE) {
-    syncIntent = KOReaderSyncIntentState::PULL_REMOTE;
-  } else if (mode == SyncLaunchMode::PUSH_LOCAL) {
-    syncIntent = KOReaderSyncIntentState::PUSH_LOCAL;
-  } else if (mode == SyncLaunchMode::AUTO_PUSH) {
-    syncIntent = KOReaderSyncIntentState::AUTO_PUSH;
-  }
-
-  auto& sync = APP_STATE.koReaderSyncSession;
-  sync.active = true;
-  sync.epubPath = epub->getPath();
-  sync.spineIndex = currentSpineIndex;
-  sync.page = currentPage;
-  sync.totalPagesInSpine = totalPages;
-  // Populate paragraph index and XHTML seek hint from section LUT if available.
-  if (section) {
-    if (const auto pIdx = section->getParagraphIndexForPage(static_cast<uint16_t>(currentPage))) {
-      sync.paragraphIndex = *pIdx;
-      sync.hasParagraphIndex = true;
-      if (const auto hint = section->getXhtmlByteOffsetForPage(static_cast<uint16_t>(currentPage))) {
-        sync.xhtmlSeekHint = *hint;
-      } else {
-        sync.xhtmlSeekHint = 0;
-      }
-    } else {
-      sync.paragraphIndex = 0;
-      sync.hasParagraphIndex = false;
-      sync.xhtmlSeekHint = 0;
-    }
-  } else {
-    sync.paragraphIndex = 0;
-    sync.hasParagraphIndex = false;
-    sync.xhtmlSeekHint = 0;
-  }
-  sync.intent = syncIntent;
-  sync.outcome = KOReaderSyncOutcomeState::PENDING;
-  sync.resultSpineIndex = 0;
-  sync.resultPage = 0;
-  sync.resultParagraphIndex = 0;
-  sync.resultHasParagraphIndex = false;
-  // Only auto-push-on-close should bypass the reader on resume; explicit syncs from the
-  // reader menu always come back to the reader. Reset here so a stale flag from a prior
-  // run cannot steal the user back to home.
-  sync.exitToHomeAfterSync = (mode == SyncLaunchMode::AUTO_PUSH);
-  APP_STATE.saveToFile();
-
-  LOG_DBG("ERS", "Standalone sync handoff: spine=%d page=%d/%d", currentSpineIndex, currentPage, totalPages);
-  logReaderMemSnapshot("before_replace_with_sync");
-  activityManager.goToKOReaderSync();
-}
-
-bool EpubReaderActivity::tryAutoPushOnClose() {
-  // Three-page minimum filters out brief inspections — opening to check the cover or
-  // skim the TOC shouldn't burn a network round-trip. Counter is per-activity-instance.
-  constexpr int MIN_SESSION_PAGES = 3;
-  if (!SETTINGS.koSyncOnBookClose) {
-    return false;
-  }
-  if (!KOREADER_STORE.hasCredentials()) {
-    return false;
-  }
-  if (sessionPagesAdvanced < MIN_SESSION_PAGES) {
-    return false;
-  }
-  if (!epub) {
-    return false;
-  }
-
-  const int spineCount = epub->getSpineItemsCount();
-  if (spineCount == 0 || currentSpineIndex >= spineCount || !section) {
-    LOG_DBG("ERS", "Skipping AUTO_PUSH on end-of-book sentinel: spine=%d section=%s", currentSpineIndex,
-            section ? "present" : "null");
-    return false;
-  }
-
-  // exitToHomeAfterSync flag is set inside launchKOReaderSync for AUTO_PUSH mode.
-  launchKOReaderSync(SyncLaunchMode::AUTO_PUSH);
-  return true;
-}
-
-void EpubReaderActivity::applyPendingSyncSession() {
-  auto& sync = APP_STATE.koReaderSyncSession;
-  if (!sync.active || !epub || sync.epubPath != epub->getPath()) {
-    return;
-  }
-
-  LOG_DBG("ERS", "Applying pending sync session outcome=%d path=%s", static_cast<int>(sync.outcome),
-          sync.epubPath.c_str());
-
-  // Upload-complete returns to the same local position the reader already persisted
-  // before sync launched, so there is no need to rewrite progress.bin here.
-  if (sync.outcome == KOReaderSyncOutcomeState::UPLOAD_COMPLETE) {
-    LOG_DBG("ERS", "Upload-complete resume keeps existing local progress.bin unchanged");
-    sync.clear();
-    APP_STATE.saveToFile();
-    logReaderMemSnapshot("after_apply_pending_sync_session");
-    return;
-  }
-
-  // AUTO_PULL handed off zeroed local state (the reader was not yet running when sync started),
-  // so on cancel/fail we must NOT restore those zeros to progress.bin — they would clobber the
-  // user's real local progress. Just clear the session and let the normal startup load progress.bin.
-  if (sync.intent == KOReaderSyncIntentState::AUTO_PULL && sync.outcome != KOReaderSyncOutcomeState::APPLIED_REMOTE) {
-    LOG_DBG("ERS", "AUTO_PULL non-success outcome=%d: leaving progress.bin untouched", static_cast<int>(sync.outcome));
-    sync.clear();
-    APP_STATE.saveToFile();
-    logReaderMemSnapshot("after_apply_pending_sync_session");
-    return;
-  }
-
-  int restoreSpineIndex = sync.spineIndex;
-  int restorePage = sync.page;
-
-  if (restoreSpineIndex < 0 || restoreSpineIndex >= epub->getSpineItemsCount()) {
-    LOG_ERR("ERS", "Invalid sync restore spine index %d, resetting to 0", restoreSpineIndex);
-    restoreSpineIndex = 0;
-    restorePage = 0;
-  }
-
-  // Build the navigation target from the sync result. For LUT-anchored targets the
-  // estimated restorePage is plumbed through as fallbackPage so a LUT miss in the
-  // target spine still lands the user on a sensible page rather than page 0.
-  NavigationTarget restoreTarget;
-  if (sync.outcome == KOReaderSyncOutcomeState::APPLIED_REMOTE) {
-    const int spineCount = epub->getSpineItemsCount();
-    if (sync.resultSpineIndex < 0 || sync.resultSpineIndex >= spineCount) {
-      LOG_ERR("ERS", "Sync resultSpineIndex %d out of range [0,%d), clamping to previous %d", sync.resultSpineIndex,
-              spineCount, restoreSpineIndex);
-      // Keep restoreSpineIndex / restorePage from the pre-validation block above.
-    } else {
-      restoreSpineIndex = sync.resultSpineIndex;
-      restorePage = sync.resultPage;
-    }
-    if (sync.resultHasListItemIndex) {
-      restoreTarget = NavigationTarget::makeListItem(sync.resultListItemIndex, restorePage);
-      LOG_DBG("ERS", "Applied synced remote position: spine=%d page=%d li[%u]", restoreSpineIndex, restorePage,
-              sync.resultListItemIndex);
-    } else if (sync.resultHasParagraphIndex) {
-      restoreTarget = NavigationTarget::makeParagraph(sync.resultParagraphIndex, restorePage);
-      LOG_DBG("ERS", "Applied synced remote position: spine=%d page=%d p[%u]", restoreSpineIndex, restorePage,
-              sync.resultParagraphIndex);
-    } else {
-      restoreTarget = NavigationTarget::makePage(restorePage);
-      LOG_DBG("ERS", "Applied synced remote position: spine=%d page=%d (no LUT)", restoreSpineIndex, restorePage);
-    }
-  } else {
-    restoreTarget = NavigationTarget::makePage(restorePage);
-    LOG_DBG("ERS", "Restored local pre-sync position: spine=%d page=%d", restoreSpineIndex, restorePage);
-  }
-
-  // sync.totalPagesInSpine is the page count of the local spine at launch time.
-  // When the restore targets a different spine, that count is meaningless for
-  // rescaling the fallbackPage estimate (which was estimated from cross-spine
-  // density anyway). Store 0 to disable rescaling — the LUT lookup is the precise
-  // path, and the cross-spine fallback can't usefully be rescaled here.
-  const int restorePageCount = (restoreSpineIndex == sync.spineIndex) ? sync.totalPagesInSpine : 0;
-  restoreTarget.cachedPageCount = restorePageCount;
-  restoreTarget.cachedSpineIdx = restoreSpineIndex;
-
-  // Seed live state directly — the previous write-then-reload-from-disk pattern relied
-  // on progress.bin being read after this function ran, which clobbered the LUT target.
-  // Live-state seeding is authoritative; the persistent write below is just for crash
-  // recovery so a power loss before the next saveProgress() doesn't lose the synced
-  // spine/page. The next render's saveProgress() supplies the real percent before
-  // the user can return to the home screen.
-  currentSpineIndex = restoreSpineIndex;
-  navTarget = restoreTarget;
-  if (!writeReaderProgressCache(epub->getCachePath(), restoreSpineIndex, restorePage, restorePageCount, 0)) {
-    LOG_ERR("ERS", "Failed to persist sync restore to progress.bin; live state still seeded");
-  } else {
-    LOG_DBG("ERS", "Prepared progress.bin for sync restore: spine=%d page=%d/%d", restoreSpineIndex, restorePage,
-            sync.totalPagesInSpine);
-  }
-
-  sync.clear();
-  APP_STATE.saveToFile();
-  logReaderMemSnapshot("after_apply_pending_sync_session");
 }
 
 void EpubReaderActivity::applyPendingBookmarkJump() {
@@ -3293,6 +2875,27 @@ bool EpubReaderActivity::maybeRestartForFragmentedHeap(const uint32_t freeHeap, 
   }
   LOG_ERR("ERS", "Heap recovery restart blocked by safety latch; staying in degraded mode");
   return false;
+}
+
+bool EpubReaderActivity::writeReaderProgressCache(const std::string& cachePath, const int spineIndex,
+                                                  const int currentPage, const int pageCount, const uint8_t percent) {
+  FsFile f;
+  if (!Storage.openFileForWrite("ERS", cachePath + "/progress.bin", f)) {
+    LOG_ERR("ERS", "Failed to open progress cache: %s", cachePath.c_str());
+    return false;
+  }
+
+  uint8_t data[7];
+  data[0] = spineIndex & 0xFF;
+  data[1] = (spineIndex >> 8) & 0xFF;
+  data[2] = currentPage & 0xFF;
+  data[3] = (currentPage >> 8) & 0xFF;
+  data[4] = pageCount & 0xFF;
+  data[5] = (pageCount >> 8) & 0xFF;
+  data[6] = percent;
+  f.write(data, 7);
+  f.close();
+  return true;
 }
 
 void EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -1,4 +1,13 @@
 #pragma once
+
+// On-device render-benchmark harness (reader menu "Render benchmark" entry). Off by default —
+// enable with -DENABLE_BENCHMARKS=1 in a platformio.ini environment for perf investigation
+// builds only; the harness and its report-building code have no value for end users and are
+// worth keeping out of release flash budgets.
+#ifndef ENABLE_BENCHMARKS
+#define ENABLE_BENCHMARKS 0
+#endif
+
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
 #include <Epub/Section.h>
@@ -254,6 +263,7 @@ class EpubReaderActivity final : public Activity {
     uint32_t fontGetBitmapTimeUs = 0;
     uint32_t fontGetBitmapCalls = 0;
   };
+#if ENABLE_BENCHMARKS
   struct BenchmarkAggregate {
     int renderCount = 0;
     int imagePageCount = 0;
@@ -276,6 +286,7 @@ class EpubReaderActivity final : public Activity {
     uint32_t minFreeHeapAfter = 0;
     uint32_t maxFreeHeapAfter = 0;
   };
+#endif  // ENABLE_BENCHMARKS
   LastRenderStats lastRenderStats;
   // Pre-rendered next page: frame buffer holds page content (no status bar) ready to display.
   // Set by the pre-render pass in render(); consumed and cleared by the fast path in pageTurn().
@@ -559,6 +570,12 @@ class EpubReaderActivity final : public Activity {
   mutable int lastStatusBarClockMinute = -1;
   bool maybeRestartForFragmentedHeap(uint32_t freeHeap, uint32_t contigHeap);
   void saveProgress(int spineIndex, int currentPage, int pageCount);
+  // Writes the canonical EPUB progress.bin layout: spine(2) + page(2) + pageCount(2) + percent(1).
+  // Used by the per-page saveProgress() and by transient writers (sync restore, bookmark jump) so
+  // the on-disk format stays consistent regardless of caller. Static (and shared across the split
+  // EpubReaderActivity/EpubReaderSync translation units) since it needs no instance state.
+  static bool writeReaderProgressCache(const std::string& cachePath, int spineIndex, int currentPage, int pageCount,
+                                       uint8_t percent);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);
   void onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action);
@@ -603,10 +620,12 @@ class EpubReaderActivity final : public Activity {
   float getEffectiveReaderLineCompression() const;
   bool stepPageState(bool isForwardTurn);
   void pageTurn(bool isForwardTurn);
+#if ENABLE_BENCHMARKS
   void runRenderBenchmark();
   std::string buildRenderBenchmarkReport(const LastRenderStats& startSnapshot, const BenchmarkAggregate& aggregate,
                                          int forwardTurns, unsigned long forwardMs, int backwardTurns,
                                          unsigned long backwardMs) const;
+#endif  // ENABLE_BENCHMARKS
 
   // Footnote navigation
   void navigateToHref(const std::string& href, bool savePosition = false);

--- a/src/activities/reader/EpubReaderBenchmark.cpp
+++ b/src/activities/reader/EpubReaderBenchmark.cpp
@@ -1,0 +1,224 @@
+// Render-benchmark harness for EpubReaderActivity: drives a scripted forward/backward page-turn
+// sweep and produces a diagnostic report shown via EpubRenderBenchmarkActivity. Split out of
+// EpubReaderActivity.cpp because it has no coupling to the render-pass state machine that
+// dominates that file — it only calls the activity's existing public-to-the-class navigation
+// and stats surface (stepPageState, requestUpdateAndWait, lastRenderStats).
+#include "EpubReaderActivity.h"
+
+#if ENABLE_BENCHMARKS
+
+#include <GfxRenderer.h>
+
+#include "EpubRenderBenchmarkActivity.h"
+
+namespace {
+const char* orientationToString(const GfxRenderer::Orientation orientation) {
+  switch (orientation) {
+    case GfxRenderer::Portrait:
+      return "Portrait";
+    case GfxRenderer::LandscapeClockwise:
+      return "Landscape CW";
+    case GfxRenderer::PortraitInverted:
+      return "Portrait Inverted";
+    case GfxRenderer::LandscapeCounterClockwise:
+      return "Landscape CCW";
+  }
+  return "Unknown";
+}
+}  // namespace
+
+void EpubReaderActivity::runRenderBenchmark() {
+  if (!epub) {
+    return;
+  }
+
+  if (!section) {
+    requestUpdateAndWait();
+    if (!section) {
+      return;
+    }
+  }
+
+  const LastRenderStats startSnapshot = lastRenderStats;
+  BenchmarkAggregate aggregate;
+  auto recordRender = [&aggregate](const LastRenderStats& snapshot) {
+    if (!snapshot.valid) {
+      return;
+    }
+
+    aggregate.renderCount++;
+    aggregate.imagePageCount += snapshot.hadImages ? 1 : 0;
+    aggregate.cacheRebuildCount += snapshot.cacheRebuilt ? 1 : 0;
+    if (snapshot.footnoteCount > aggregate.maxFootnotes) {
+      aggregate.maxFootnotes = snapshot.footnoteCount;
+    }
+
+    aggregate.totalRequestRenderMs += snapshot.requestRenderMs;
+    if (aggregate.renderCount == 1 || snapshot.requestRenderMs < aggregate.minRequestRenderMs) {
+      aggregate.minRequestRenderMs = snapshot.requestRenderMs;
+    }
+    if (snapshot.requestRenderMs > aggregate.maxRequestRenderMs) {
+      aggregate.maxRequestRenderMs = snapshot.requestRenderMs;
+    }
+
+    aggregate.totalRenderMs += snapshot.phases.totalMs;
+    if (aggregate.renderCount == 1 || snapshot.phases.totalMs < aggregate.minRenderMs) {
+      aggregate.minRenderMs = snapshot.phases.totalMs;
+    }
+    if (snapshot.phases.totalMs > aggregate.maxRenderMs) {
+      aggregate.maxRenderMs = snapshot.phases.totalMs;
+    }
+
+    aggregate.totalSectionLoadMs += snapshot.sectionLoadMs;
+    aggregate.totalPageLoadMs += snapshot.pageLoadMs;
+    aggregate.totalPhases.prewarmMs += snapshot.phases.prewarmMs;
+    aggregate.totalPhases.bwRenderMs += snapshot.phases.bwRenderMs;
+    aggregate.totalPhases.displayMs += snapshot.phases.displayMs;
+    aggregate.totalPhases.bwStoreMs += snapshot.phases.bwStoreMs;
+    aggregate.totalPhases.grayLsbMs += snapshot.phases.grayLsbMs;
+    aggregate.totalPhases.grayMsbMs += snapshot.phases.grayMsbMs;
+    aggregate.totalPhases.grayDisplayMs += snapshot.phases.grayDisplayMs;
+    aggregate.totalPhases.bwRestoreMs += snapshot.phases.bwRestoreMs;
+    aggregate.totalPhases.totalMs += snapshot.phases.totalMs;
+
+    aggregate.totalFontCacheHits += snapshot.fontCacheHits;
+    aggregate.totalFontCacheMisses += snapshot.fontCacheMisses;
+    aggregate.totalFontDecompressMs += snapshot.fontDecompressMs;
+    aggregate.totalFontGetBitmapTimeUs += snapshot.fontGetBitmapTimeUs;
+    aggregate.totalFontGetBitmapCalls += snapshot.fontGetBitmapCalls;
+
+    if (aggregate.renderCount == 1 || snapshot.freeHeapAfter < aggregate.minFreeHeapAfter) {
+      aggregate.minFreeHeapAfter = snapshot.freeHeapAfter;
+    }
+    if (snapshot.freeHeapAfter > aggregate.maxFreeHeapAfter) {
+      aggregate.maxFreeHeapAfter = snapshot.freeHeapAfter;
+    }
+  };
+  const unsigned long startTime = millis();
+  int forwardTurns = 0;
+  int backwardTurns = 0;
+
+  for (int i = 0; i < 10; i++) {
+    if (!stepPageState(true)) {
+      break;
+    }
+    requestUpdateAndWait();
+    recordRender(lastRenderStats);
+    forwardTurns++;
+  }
+
+  const unsigned long forwardMs = millis() - startTime;
+  const unsigned long backwardStart = millis();
+
+  for (int i = 0; i < 10; i++) {
+    if (!stepPageState(false)) {
+      break;
+    }
+    requestUpdateAndWait();
+    recordRender(lastRenderStats);
+    backwardTurns++;
+  }
+
+  const unsigned long backwardMs = millis() - backwardStart;
+
+  startActivityForResult(
+      std::make_unique<EpubRenderBenchmarkActivity>(
+          renderer, mappedInput,
+          buildRenderBenchmarkReport(startSnapshot, aggregate, forwardTurns, forwardMs, backwardTurns, backwardMs)),
+      [this](const ActivityResult&) { requestUpdate(); });
+}
+
+std::string EpubReaderActivity::buildRenderBenchmarkReport(const LastRenderStats& startSnapshot,
+                                                           const BenchmarkAggregate& aggregate, const int forwardTurns,
+                                                           const unsigned long forwardMs, const int backwardTurns,
+                                                           const unsigned long backwardMs) const {
+  const LastRenderStats& endSnapshot = lastRenderStats.valid ? lastRenderStats : startSnapshot;
+
+  std::string report;
+  report.reserve(768);
+
+  auto appendLine = [&report](const std::string& line) {
+    if (!report.empty()) {
+      report += '\n';
+    }
+    report += line;
+  };
+
+  appendLine("Forward 10: " + std::to_string(forwardTurns) + " turns in " + std::to_string(forwardMs) + " ms");
+  if (forwardTurns > 0) {
+    appendLine("Forward avg: " + std::to_string(forwardMs / static_cast<unsigned long>(forwardTurns)) + " ms/turn");
+  }
+  appendLine("Backward 10: " + std::to_string(backwardTurns) + " turns in " + std::to_string(backwardMs) + " ms");
+  if (backwardTurns > 0) {
+    appendLine("Backward avg: " + std::to_string(backwardMs / static_cast<unsigned long>(backwardTurns)) + " ms/turn");
+  }
+  appendLine("Measured renders: " + std::to_string(aggregate.renderCount) + ", image pages " +
+             std::to_string(aggregate.imagePageCount) + ", cache rebuilds " +
+             std::to_string(aggregate.cacheRebuildCount));
+
+  appendLine("Start: spine " + std::to_string(startSnapshot.spineIndex) + ", page " +
+             std::to_string(startSnapshot.pageIndex + 1) + "/" + std::to_string(startSnapshot.pageCount));
+  appendLine("End: spine " + std::to_string(endSnapshot.spineIndex) + ", page " +
+             std::to_string(endSnapshot.pageIndex + 1) + "/" + std::to_string(endSnapshot.pageCount));
+  appendLine("Orientation: " +
+             std::string(orientationToString(static_cast<GfxRenderer::Orientation>(endSnapshot.orientation))));
+  appendLine("Viewport: " + std::to_string(endSnapshot.viewportWidth) + "x" +
+             std::to_string(endSnapshot.viewportHeight) + " px, margins T/R/B/L " +
+             std::to_string(endSnapshot.marginTop) + "/" + std::to_string(endSnapshot.marginRight) + "/" +
+             std::to_string(endSnapshot.marginBottom) + "/" + std::to_string(endSnapshot.marginLeft));
+  appendLine("Font: " + std::to_string(endSnapshot.effectiveFontId) + ", embedded CSS " +
+             std::string(endSnapshot.embeddedStyle ? "on" : "off") + ", images " +
+             std::to_string(endSnapshot.imageRendering) + ", AA " +
+             std::string(endSnapshot.textAntiAliasing ? "on" : "off"));
+  appendLine("Last page: images " + std::string(endSnapshot.hadImages ? "yes" : "no") + ", footnotes " +
+             std::to_string(endSnapshot.footnoteCount) + ", cache rebuilt " +
+             std::string(endSnapshot.cacheRebuilt ? "yes" : "no"));
+  if (aggregate.renderCount > 0) {
+    appendLine("Render avg/min/max: request " +
+               std::to_string(aggregate.totalRequestRenderMs / static_cast<unsigned long>(aggregate.renderCount)) +
+               "/" + std::to_string(aggregate.minRequestRenderMs) + "/" + std::to_string(aggregate.maxRequestRenderMs) +
+               " ms, core " +
+               std::to_string(aggregate.totalRenderMs / static_cast<unsigned long>(aggregate.renderCount)) + "/" +
+               std::to_string(aggregate.minRenderMs) + "/" + std::to_string(aggregate.maxRenderMs) + " ms");
+    appendLine("Aggregate loads: section " + std::to_string(aggregate.totalSectionLoadMs) + " ms, page " +
+               std::to_string(aggregate.totalPageLoadMs) + " ms, max footnotes " +
+               std::to_string(aggregate.maxFootnotes));
+    appendLine("Aggregate phases: prewarm " + std::to_string(aggregate.totalPhases.prewarmMs) + ", bw " +
+               std::to_string(aggregate.totalPhases.bwRenderMs) + ", display " +
+               std::to_string(aggregate.totalPhases.displayMs) + ", planes " +
+               std::to_string(aggregate.totalPhases.grayLsbMs) + ", gray display " +
+               std::to_string(aggregate.totalPhases.grayDisplayMs) + ", restore " +
+               std::to_string(aggregate.totalPhases.bwRestoreMs));
+    appendLine("Aggregate font: hits " + std::to_string(aggregate.totalFontCacheHits) + ", misses " +
+               std::to_string(aggregate.totalFontCacheMisses) + ", decompress " +
+               std::to_string(aggregate.totalFontDecompressMs) + " ms");
+    appendLine("Aggregate glyph lookups: " + std::to_string(aggregate.totalFontGetBitmapCalls) + " calls, " +
+               std::to_string(aggregate.totalFontGetBitmapTimeUs) + " us total");
+    appendLine("Heap after render min/max: " + std::to_string(aggregate.minFreeHeapAfter) + "/" +
+               std::to_string(aggregate.maxFreeHeapAfter));
+  }
+  appendLine("Last render: request " + std::to_string(endSnapshot.requestRenderMs) + " ms, section load " +
+             std::to_string(endSnapshot.sectionLoadMs) + " ms, page load " + std::to_string(endSnapshot.pageLoadMs) +
+             " ms, render total " + std::to_string(endSnapshot.phases.totalMs) + " ms");
+  appendLine("Phases: prewarm " + std::to_string(endSnapshot.phases.prewarmMs) + ", bw " +
+             std::to_string(endSnapshot.phases.bwRenderMs) + ", display " +
+             std::to_string(endSnapshot.phases.displayMs) + ", planes " + std::to_string(endSnapshot.phases.grayLsbMs) +
+             ", gray display " + std::to_string(endSnapshot.phases.grayDisplayMs) + ", restore " +
+             std::to_string(endSnapshot.phases.bwRestoreMs));
+  appendLine("Font cache: hits " + std::to_string(endSnapshot.fontCacheHits) + ", misses " +
+             std::to_string(endSnapshot.fontCacheMisses) + ", decompress " +
+             std::to_string(endSnapshot.fontDecompressMs) + " ms, groups " +
+             std::to_string(endSnapshot.fontUniqueGroups));
+  appendLine("Font buffers: page " + std::to_string(endSnapshot.fontPageBufferBytes) + ", glyph table " +
+             std::to_string(endSnapshot.fontPageGlyphsBytes) + ", peak temp " +
+             std::to_string(endSnapshot.fontPeakTempBytes));
+  appendLine("Glyph lookups: " + std::to_string(endSnapshot.fontGetBitmapCalls) + " calls, " +
+             std::to_string(endSnapshot.fontGetBitmapTimeUs) + " us total");
+  appendLine("Heap: before " + std::to_string(endSnapshot.freeHeapBefore) + "/" +
+             std::to_string(endSnapshot.largestFreeBlockBefore) + ", after " +
+             std::to_string(endSnapshot.freeHeapAfter) + "/" + std::to_string(endSnapshot.largestFreeBlockAfter));
+
+  return report;
+}
+
+#endif  // ENABLE_BENCHMARKS

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -10,6 +10,11 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 
+// Keep in sync with the default in EpubReaderActivity.h — see the comment there for rationale.
+#ifndef ENABLE_BENCHMARKS
+#define ENABLE_BENCHMARKS 0
+#endif
+
 namespace {
 // Three-state cycle helper for overrides represented as int8_t with -1 = default.
 // Mirrors the helpers in QuickOverridesActivity.cpp; kept duplicated rather
@@ -319,11 +324,11 @@ void EpubReaderMenuActivity::buildMenuItems(bool hasFootnotes, bool hasStarredPa
   menuItems.push_back(
       SettingInfo::Action(StrId::STR_DISPLAY_QR, SettingAction::None).withSubmenu(StrId::STR_READER_TOOLS));
   menuItems.push_back(SettingInfo::Action(StrId::STR_GO_HOME_BUTTON, SettingAction::None));
-#ifdef ENABLE_BENCHMARKS
+#if ENABLE_BENCHMARKS
   menuItems.push_back(SettingInfo::Separator(StrId::STR_NONE_OPT).withSubmenu(StrId::STR_READER_TOOLS));
   menuItems.push_back(
       SettingInfo::Action(StrId::STR_RENDER_BENCHMARK, SettingAction::None).withSubmenu(StrId::STR_READER_TOOLS));
-#endif
+#endif  // ENABLE_BENCHMARKS
 }
 
 EpubReaderMenuActivity::MenuAction EpubReaderMenuActivity::actionForNameId(StrId nameId) {

--- a/src/activities/reader/EpubReaderSync.cpp
+++ b/src/activities/reader/EpubReaderSync.cpp
@@ -1,0 +1,216 @@
+// KOReader sync handoff for EpubReaderActivity: launching a sync session (compare / pull / push /
+// auto-push-on-close) and applying a completed session's result back into live reader state. Split
+// out of EpubReaderActivity.cpp because this has almost no coupling to the render-pass state
+// machine that dominates that file — it only touches navigation/position state and APP_STATE's
+// koReaderSyncSession.
+#include <HalStorage.h>
+#include <Logging.h>
+#include <esp_heap_caps.h>
+#include <esp_system.h>
+
+#include "CrossPointState.h"
+#include "EpubReaderActivity.h"
+#include "KOReaderCredentialStore.h"
+
+#ifndef DEBUG_MEMORY_CONSUMPTION
+#define DEBUG_MEMORY_CONSUMPTION 0
+#endif
+
+namespace {
+#if DEBUG_MEMORY_CONSUMPTION
+void logReaderMemSnapshot(const char* stage) {
+  const uint32_t freeHeap = esp_get_free_heap_size();
+  const uint32_t contigHeap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
+  LOG_DBG("ERS", "Reader mem[%s]: free=%lu contig=%lu", stage, freeHeap, contigHeap);
+}
+#else
+inline void logReaderMemSnapshot(const char*) {}
+#endif
+}  // namespace
+
+void EpubReaderActivity::launchKOReaderSync(const SyncLaunchMode mode) {
+  if (!epub) {
+    return;
+  }
+
+  const int currentPage = section ? section->currentPage : 0;
+  const int totalPages = section ? section->pageCount : 0;
+  KOReaderSyncIntentState syncIntent = KOReaderSyncIntentState::COMPARE;
+  if (mode == SyncLaunchMode::PULL_REMOTE) {
+    syncIntent = KOReaderSyncIntentState::PULL_REMOTE;
+  } else if (mode == SyncLaunchMode::PUSH_LOCAL) {
+    syncIntent = KOReaderSyncIntentState::PUSH_LOCAL;
+  } else if (mode == SyncLaunchMode::AUTO_PUSH) {
+    syncIntent = KOReaderSyncIntentState::AUTO_PUSH;
+  }
+
+  auto& sync = APP_STATE.koReaderSyncSession;
+  sync.active = true;
+  sync.epubPath = epub->getPath();
+  sync.spineIndex = currentSpineIndex;
+  sync.page = currentPage;
+  sync.totalPagesInSpine = totalPages;
+  // Populate paragraph index and XHTML seek hint from section LUT if available.
+  if (section) {
+    if (const auto pIdx = section->getParagraphIndexForPage(static_cast<uint16_t>(currentPage))) {
+      sync.paragraphIndex = *pIdx;
+      sync.hasParagraphIndex = true;
+      if (const auto hint = section->getXhtmlByteOffsetForPage(static_cast<uint16_t>(currentPage))) {
+        sync.xhtmlSeekHint = *hint;
+      } else {
+        sync.xhtmlSeekHint = 0;
+      }
+    } else {
+      sync.paragraphIndex = 0;
+      sync.hasParagraphIndex = false;
+      sync.xhtmlSeekHint = 0;
+    }
+  } else {
+    sync.paragraphIndex = 0;
+    sync.hasParagraphIndex = false;
+    sync.xhtmlSeekHint = 0;
+  }
+  sync.intent = syncIntent;
+  sync.outcome = KOReaderSyncOutcomeState::PENDING;
+  sync.resultSpineIndex = 0;
+  sync.resultPage = 0;
+  sync.resultParagraphIndex = 0;
+  sync.resultHasParagraphIndex = false;
+  // Only auto-push-on-close should bypass the reader on resume; explicit syncs from the
+  // reader menu always come back to the reader. Reset here so a stale flag from a prior
+  // run cannot steal the user back to home.
+  sync.exitToHomeAfterSync = (mode == SyncLaunchMode::AUTO_PUSH);
+  APP_STATE.saveToFile();
+
+  LOG_DBG("ERS", "Standalone sync handoff: spine=%d page=%d/%d", currentSpineIndex, currentPage, totalPages);
+  logReaderMemSnapshot("before_replace_with_sync");
+  activityManager.goToKOReaderSync();
+}
+
+bool EpubReaderActivity::tryAutoPushOnClose() {
+  // Three-page minimum filters out brief inspections — opening to check the cover or
+  // skim the TOC shouldn't burn a network round-trip. Counter is per-activity-instance.
+  constexpr int MIN_SESSION_PAGES = 3;
+  if (!SETTINGS.koSyncOnBookClose) {
+    return false;
+  }
+  if (!KOREADER_STORE.hasCredentials()) {
+    return false;
+  }
+  if (sessionPagesAdvanced < MIN_SESSION_PAGES) {
+    return false;
+  }
+  if (!epub) {
+    return false;
+  }
+
+  const int spineCount = epub->getSpineItemsCount();
+  if (spineCount == 0 || currentSpineIndex >= spineCount || !section) {
+    LOG_DBG("ERS", "Skipping AUTO_PUSH on end-of-book sentinel: spine=%d section=%s", currentSpineIndex,
+            section ? "present" : "null");
+    return false;
+  }
+
+  // exitToHomeAfterSync flag is set inside launchKOReaderSync for AUTO_PUSH mode.
+  launchKOReaderSync(SyncLaunchMode::AUTO_PUSH);
+  return true;
+}
+
+void EpubReaderActivity::applyPendingSyncSession() {
+  auto& sync = APP_STATE.koReaderSyncSession;
+  if (!sync.active || !epub || sync.epubPath != epub->getPath()) {
+    return;
+  }
+
+  LOG_DBG("ERS", "Applying pending sync session outcome=%d path=%s", static_cast<int>(sync.outcome),
+          sync.epubPath.c_str());
+
+  // Upload-complete returns to the same local position the reader already persisted
+  // before sync launched, so there is no need to rewrite progress.bin here.
+  if (sync.outcome == KOReaderSyncOutcomeState::UPLOAD_COMPLETE) {
+    LOG_DBG("ERS", "Upload-complete resume keeps existing local progress.bin unchanged");
+    sync.clear();
+    APP_STATE.saveToFile();
+    logReaderMemSnapshot("after_apply_pending_sync_session");
+    return;
+  }
+
+  // AUTO_PULL handed off zeroed local state (the reader was not yet running when sync started),
+  // so on cancel/fail we must NOT restore those zeros to progress.bin — they would clobber the
+  // user's real local progress. Just clear the session and let the normal startup load progress.bin.
+  if (sync.intent == KOReaderSyncIntentState::AUTO_PULL && sync.outcome != KOReaderSyncOutcomeState::APPLIED_REMOTE) {
+    LOG_DBG("ERS", "AUTO_PULL non-success outcome=%d: leaving progress.bin untouched", static_cast<int>(sync.outcome));
+    sync.clear();
+    APP_STATE.saveToFile();
+    logReaderMemSnapshot("after_apply_pending_sync_session");
+    return;
+  }
+
+  int restoreSpineIndex = sync.spineIndex;
+  int restorePage = sync.page;
+
+  if (restoreSpineIndex < 0 || restoreSpineIndex >= epub->getSpineItemsCount()) {
+    LOG_ERR("ERS", "Invalid sync restore spine index %d, resetting to 0", restoreSpineIndex);
+    restoreSpineIndex = 0;
+    restorePage = 0;
+  }
+
+  // Build the navigation target from the sync result. For LUT-anchored targets the
+  // estimated restorePage is plumbed through as fallbackPage so a LUT miss in the
+  // target spine still lands the user on a sensible page rather than page 0.
+  NavigationTarget restoreTarget;
+  if (sync.outcome == KOReaderSyncOutcomeState::APPLIED_REMOTE) {
+    const int spineCount = epub->getSpineItemsCount();
+    if (sync.resultSpineIndex < 0 || sync.resultSpineIndex >= spineCount) {
+      LOG_ERR("ERS", "Sync resultSpineIndex %d out of range [0,%d), clamping to previous %d", sync.resultSpineIndex,
+              spineCount, restoreSpineIndex);
+      // Keep restoreSpineIndex / restorePage from the pre-validation block above.
+    } else {
+      restoreSpineIndex = sync.resultSpineIndex;
+      restorePage = sync.resultPage;
+    }
+    if (sync.resultHasListItemIndex) {
+      restoreTarget = NavigationTarget::makeListItem(sync.resultListItemIndex, restorePage);
+      LOG_DBG("ERS", "Applied synced remote position: spine=%d page=%d li[%u]", restoreSpineIndex, restorePage,
+              sync.resultListItemIndex);
+    } else if (sync.resultHasParagraphIndex) {
+      restoreTarget = NavigationTarget::makeParagraph(sync.resultParagraphIndex, restorePage);
+      LOG_DBG("ERS", "Applied synced remote position: spine=%d page=%d p[%u]", restoreSpineIndex, restorePage,
+              sync.resultParagraphIndex);
+    } else {
+      restoreTarget = NavigationTarget::makePage(restorePage);
+      LOG_DBG("ERS", "Applied synced remote position: spine=%d page=%d (no LUT)", restoreSpineIndex, restorePage);
+    }
+  } else {
+    restoreTarget = NavigationTarget::makePage(restorePage);
+    LOG_DBG("ERS", "Restored local pre-sync position: spine=%d page=%d", restoreSpineIndex, restorePage);
+  }
+
+  // sync.totalPagesInSpine is the page count of the local spine at launch time.
+  // When the restore targets a different spine, that count is meaningless for
+  // rescaling the fallbackPage estimate (which was estimated from cross-spine
+  // density anyway). Store 0 to disable rescaling — the LUT lookup is the precise
+  // path, and the cross-spine fallback can't usefully be rescaled here.
+  const int restorePageCount = (restoreSpineIndex == sync.spineIndex) ? sync.totalPagesInSpine : 0;
+  restoreTarget.cachedPageCount = restorePageCount;
+  restoreTarget.cachedSpineIdx = restoreSpineIndex;
+
+  // Seed live state directly — the previous write-then-reload-from-disk pattern relied
+  // on progress.bin being read after this function ran, which clobbered the LUT target.
+  // Live-state seeding is authoritative; the persistent write below is just for crash
+  // recovery so a power loss before the next saveProgress() doesn't lose the synced
+  // spine/page. The next render's saveProgress() supplies the real percent before
+  // the user can return to the home screen.
+  currentSpineIndex = restoreSpineIndex;
+  navTarget = restoreTarget;
+  if (!writeReaderProgressCache(epub->getCachePath(), restoreSpineIndex, restorePage, restorePageCount, 0)) {
+    LOG_ERR("ERS", "Failed to persist sync restore to progress.bin; live state still seeded");
+  } else {
+    LOG_DBG("ERS", "Prepared progress.bin for sync restore: spine=%d page=%d/%d", restoreSpineIndex, restorePage,
+            sync.totalPagesInSpine);
+  }
+
+  sync.clear();
+  APP_STATE.saveToFile();
+  logReaderMemSnapshot("after_apply_pending_sync_session");
+}


### PR DESCRIPTION
## Summary
- Extracted the render-benchmark harness (`runRenderBenchmark`/`buildRenderBenchmarkReport`) and the KOReader sync handoff (`launchKOReaderSync`/`tryAutoPushOnClose`/`applyPendingSyncSession`) out of `EpubReaderActivity.cpp` into their own translation units (`EpubReaderBenchmark.cpp`, `EpubReaderSync.cpp`). Pure mechanical split — no declarations changed, no behavior change. `writeReaderProgressCache` was promoted from a file-local free function to a shared `private static` member since both the main file and the new sync file need it.
- Gated the entire render-benchmark feature (harness, report builder, `EpubRenderBenchmarkActivity` usage, and the reader-menu entry) behind a new `ENABLE_BENCHMARKS` compile flag, defaulting to off. Saves ~7KB flash on a build that's already at ~95% flash usage; opt in with `-DENABLE_BENCHMARKS=1`.

## Test plan
- [x] `pio run -e default` builds successfully with the default (benchmark off) config
- [x] `PLATFORMIO_BUILD_FLAGS="-DENABLE_BENCHMARKS=1" pio run -e default` builds successfully with the benchmark compiled back in, flash usage matches pre-split baseline
- [x] Confirmed no other call sites reference the moved/removed symbols