### PR TITLE
refactor: Flatten TextBlock word storage into a single arena allocation

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -1168,7 +1168,13 @@ ParsedText::LineProcessResult ParsedText::extractLine(
     }
   }
 
-  return processLine(std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
-                                                 blockStyle, std::move(lineWordSizes)),
-                     lineEndsWithHyphenatedWord, suppressHyphenationRetry);
+  // TextBlock flattens the vectors into its arena on construct; on arena OOM the
+  // block is invalid, so drop the line rather than render/serialize garbage.
+  auto block = std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
+                                           blockStyle, std::move(lineWordSizes));
+  if (!block->valid()) {
+    LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
+    return LineProcessResult::Accepted;
+  }
+  return processLine(std::move(block), lineEndsWithHyphenatedWord, suppressHyphenationRetry);
 }

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -17,7 +17,10 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 59;  // bumped: FontSizeLadder residual dead zone (±3% renders native) changes
+constexpr uint8_t SECTION_FILE_VERSION = 60;  // bumped: TextBlock word data now serialized as one flat arena
+                                              // (offset table + NUL-terminated text blob) instead of
+                                              // length-prefixed strings and per-field arrays (v60)
+                                              // v59: FontSizeLadder residual dead zone (±3% renders native) changes
                                               // near-rung block metrics from v58
                                               // (v58: block sizes snap to the FontSizeLadder, uniform spans fold;
                                               //  v57: sup/sub scaling moved into the per-word size channel)

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -16,7 +16,7 @@ TextBlock::ArenaOffsets TextBlock::arenaOffsets(const uint16_t wordCount, const 
   ArenaOffsets o{};
   o.xpos = wc * sizeof(uint16_t);
   o.styles = o.xpos + wc * sizeof(int16_t);
-  o.sizes = o.styles + wc * sizeof(uint8_t);            // only meaningful when hasSizes
+  o.sizes = o.styles + wc * sizeof(uint8_t);  // only meaningful when hasSizes
   o.text = o.sizes + (hasSizes ? wc * sizeof(uint8_t) : 0);
   return o;
 }

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -2,14 +2,125 @@
 
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Serialization.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+TextBlock::ArenaOffsets TextBlock::arenaOffsets(const uint16_t wordCount, const bool hasSizes) {
+  // Layout documented in TextBlock.h: 16-bit arrays first (textOff, xpos), then
+  // 8-bit arrays (styles, optional sizes), then the text blob. textOff sits at 0.
+  const size_t wc = wordCount;
+  ArenaOffsets o{};
+  o.xpos = wc * sizeof(uint16_t);
+  o.styles = o.xpos + wc * sizeof(int16_t);
+  o.sizes = o.styles + wc * sizeof(uint8_t);            // only meaningful when hasSizes
+  o.text = o.sizes + (hasSizes ? wc * sizeof(uint8_t) : 0);
+  return o;
+}
+
+size_t TextBlock::arenaSize(const uint16_t wordCount, const bool hasSizes, const uint16_t textBytes) {
+  return arenaOffsets(wordCount, hasSizes).text + textBytes;
+}
+
+void TextBlock::bindArenaPointers() {
+  const uint8_t* base = arena.get();
+  const ArenaOffsets o = arenaOffsets(numWords, sizesPresent);
+  textOffArr = reinterpret_cast<const uint16_t*>(base);
+  xposArr = reinterpret_cast<const int16_t*>(base + o.xpos);
+  stylesArr = base + o.styles;
+  sizesArr = sizesPresent ? base + o.sizes : nullptr;
+  textArr = reinterpret_cast<const char*>(base + o.text);
+}
+
+TextBlock::TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
+                     std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle,
+                     std::vector<uint8_t> word_sizes)
+    : blockStyle(blockStyle) {
+  // Normalize the all-100% case to no sizes so uniform lines (the common case)
+  // keep the zero-cost fast paths in render/serialize/line-height.
+  if (std::all_of(word_sizes.begin(), word_sizes.end(), [](const uint8_t s) { return s == 100; })) {
+    word_sizes.clear();
+  }
+  const bool hasSizes = !word_sizes.empty();
+
+  if (words.size() != word_xpos.size() || words.size() != word_styles.size() || words.size() > 10000 ||
+      (hasSizes && words.size() != word_sizes.size())) {
+    LOG_ERR("TXB", "Construction failed: size mismatch (words=%u, xpos=%u, styles=%u, sizes=%u)",
+            static_cast<uint32_t>(words.size()), static_cast<uint32_t>(word_xpos.size()),
+            static_cast<uint32_t>(word_styles.size()), static_cast<uint32_t>(word_sizes.size()));
+    isValid = false;
+    return;
+  }
+
+  numWords = static_cast<uint16_t>(words.size());
+  sizesPresent = hasSizes;
+  if (numWords == 0) {
+    return;  // valid empty block, no arena
+  }
+
+  // Pass 1: total text size, one NUL per word. A line is at most a physical row
+  // of the page, so uint16_t offsets are ample; reject anything larger.
+  size_t totalText = 0;
+  for (const auto& w : words) totalText += w.size() + 1;
+  if (totalText > UINT16_MAX) {
+    LOG_ERR("TXB", "Construction failed: text size %u exceeds arena limit", static_cast<uint32_t>(totalText));
+    numWords = 0;
+    sizesPresent = false;
+    isValid = false;
+    return;
+  }
+  textBytes = static_cast<uint16_t>(totalText);
+
+  const size_t size = arenaSize(numWords, sizesPresent, textBytes);
+  arena = makeUniqueNoThrow<uint8_t[]>(size);
+  if (!arena) {
+    LOG_ERR("TXB", "OOM: arena %u bytes", static_cast<uint32_t>(size));
+    numWords = 0;
+    textBytes = 0;
+    sizesPresent = false;
+    isValid = false;
+    return;
+  }
+
+  // Pass 2: fill through mutable pointers derived from the same layout offsets
+  // that bindArenaPointers() uses for the const views (bound below for reads).
+  uint8_t* base = arena.get();
+  const ArenaOffsets o = arenaOffsets(numWords, sizesPresent);
+  auto* textOff = reinterpret_cast<uint16_t*>(base);
+  auto* xpos = reinterpret_cast<int16_t*>(base + o.xpos);
+  uint8_t* styles = base + o.styles;
+  char* text = reinterpret_cast<char*>(base + o.text);
+  uint16_t off = 0;
+  for (uint16_t i = 0; i < numWords; i++) {
+    textOff[i] = off;
+    xpos[i] = word_xpos[i];
+    styles[i] = static_cast<uint8_t>(word_styles[i]);
+    memcpy(text + off, words[i].data(), words[i].size());
+    off += static_cast<uint16_t>(words[i].size());
+    text[off++] = '\0';
+  }
+  if (sizesPresent) {
+    uint8_t* sizes = base + o.sizes;
+    for (uint16_t i = 0; i < numWords; i++) sizes[i] = word_sizes[i];
+  }
+  bindArenaPointers();
+}
+
+uint8_t TextBlock::maxSizePct() const {
+  if (!sizesPresent) {
+    return 100;
+  }
+  uint8_t m = 0;
+  for (uint16_t i = 0; i < numWords; i++) m = std::max(m, sizesArr[i]);
+  return m;
+}
+
 void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int x, const int y) const {
-  // Validate iterator bounds before rendering
-  if (words.size() != wordXpos.size() || words.size() != wordStyles.size() ||
-      (!wordSizes.empty() && words.size() != wordSizes.size())) {
-    LOG_ERR("TXB", "Render skipped: size mismatch (words=%u, xpos=%u, styles=%u, sizes=%u)\n", (uint32_t)words.size(),
-            (uint32_t)wordXpos.size(), (uint32_t)wordStyles.size(), (uint32_t)wordSizes.size());
+  if (!isValid) {
+    LOG_ERR("TXB", "Render skipped: invalid block");
     return;
   }
 
@@ -22,15 +133,16 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
   const int blockAscender = (blockScale == 1.0f) ? renderer.getFontAscenderSize(effFontId)
                                                  : renderer.getFontAscenderSizeScaled(effFontId, blockScale);
   // Mixed-size lines are baseline-aligned: every word's baseline sits at y + lineAscender,
-  // where lineAscender is the tallest word's ascender. Uniform lines (wordSizes empty)
-  // keep lineAscender == blockAscender, i.e. the historical single-scale layout.
+  // where lineAscender is the tallest word's ascender. Uniform lines (no sizes) keep
+  // lineAscender == blockAscender, i.e. the historical single-scale layout.
   int lineAscender = blockAscender;
-  if (!wordSizes.empty()) {
+  if (sizesPresent) {
     lineAscender = renderer.getFontAscenderSizeScaled(effFontId, blockScale * (maxSizePct() / 100.0f));
   }
-  for (size_t i = 0; i < words.size(); i++) {
-    const int wordX = wordXpos[i] + x;
-    const EpdFontFamily::Style currentStyle = wordStyles[i];
+  for (uint16_t i = 0; i < numWords; i++) {
+    const char* word = wordText(i);
+    const int wordX = xposArr[i] + x;
+    const EpdFontFamily::Style currentStyle = wordStyle(i);
     const float scale = wordScale(i);
     const int ascender = (scale == blockScale) ? blockAscender : renderer.getFontAscenderSizeScaled(effFontId, scale);
     // Baseline alignment: shift smaller words down so all baselines meet at y + lineAscender.
@@ -47,17 +159,16 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
       wordY += blockAscender / 4;
     }
     if (scale == 1.0f) {
-      renderer.drawText(effFontId, wordX, wordY, words[i].c_str(), true, currentStyle);
+      renderer.drawText(effFontId, wordX, wordY, word, true, currentStyle);
     } else {
-      renderer.drawTextScaled(effFontId, wordX, wordY, words[i].c_str(), true, currentStyle, scale);
+      renderer.drawTextScaled(effFontId, wordX, wordY, word, true, currentStyle, scale);
     }
 
     const bool hasDecoration =
         !scanning && (currentStyle & (EpdFontFamily::UNDERLINE | EpdFontFamily::STRIKETHROUGH)) != 0;
     if (hasDecoration) {
-      const std::string& w = words[i];
-      const int lineWidth = (scale == 1.0f) ? renderer.getTextWidth(effFontId, w.c_str(), currentStyle)
-                                            : renderer.getTextWidthScaled(effFontId, w.c_str(), currentStyle, scale);
+      const int lineWidth = (scale == 1.0f) ? renderer.getTextWidth(effFontId, word, currentStyle)
+                                            : renderer.getTextWidthScaled(effFontId, word, currentStyle, scale);
 
       if ((currentStyle & EpdFontFamily::UNDERLINE) != 0) {
         const int underlineY = y + lineAscender + 3;
@@ -73,24 +184,23 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
 }
 
 bool TextBlock::serialize(FsFile& file) const {
-  if (words.size() != wordXpos.size() || words.size() != wordStyles.size() ||
-      (!wordSizes.empty() && words.size() != wordSizes.size())) {
-    LOG_ERR("TXB", "Serialization failed: size mismatch (words=%u, xpos=%u, styles=%u, sizes=%u)\n", words.size(),
-            wordXpos.size(), wordStyles.size(), wordSizes.size());
+  if (!isValid) {
+    LOG_ERR("TXB", "Serialization failed: invalid block");
     return false;
   }
 
-  // Word data
-  serialization::writePod(file, static_cast<uint16_t>(words.size()));
-  for (const auto& w : words) serialization::writeString(file, w);
-  for (auto x : wordXpos) serialization::writePod(file, x);
-  for (auto s : wordStyles) serialization::writePod(file, s);
-  // Per-word sizes: one flag byte, then one byte per word only when any word
-  // deviates from 100% — uniform lines (the common case) cost a single byte.
-  const uint8_t hasSizes = wordSizes.empty() ? 0 : 1;
-  serialization::writePod(file, hasSizes);
-  if (hasSizes) {
-    for (auto sz : wordSizes) serialization::writePod(file, sz);
+  // Word data: scalars, then the arena verbatim -- its in-memory layout is
+  // exactly the on-disk layout (see TextBlock.h), so one write covers all
+  // per-word arrays and the text blob.
+  serialization::writePod(file, numWords);
+  serialization::writePod(file, static_cast<uint8_t>(sizesPresent ? 1 : 0));
+  serialization::writePod(file, textBytes);
+  if (numWords > 0) {
+    const size_t size = arenaSize(numWords, sizesPresent, textBytes);
+    if (file.write(arena.get(), size) != size) {
+      LOG_ERR("TXB", "Serialization failed: arena write (%u bytes)", static_cast<uint32_t>(size));
+      return false;
+    }
   }
 
   // Style (alignment + margins/padding/indent)
@@ -114,36 +224,64 @@ bool TextBlock::serialize(FsFile& file) const {
 
 std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
   uint16_t wc;
-  std::vector<std::string> words;
-  std::vector<int16_t> wordXpos;
-  std::vector<EpdFontFamily::Style> wordStyles;
-  std::vector<uint8_t> wordSizes;
-  BlockStyle blockStyle;
-
-  // Word count
+  uint8_t hasSizes;
+  uint16_t textBytes;
   serialization::readPod(file, wc);
+  serialization::readPod(file, hasSizes);
+  serialization::readPod(file, textBytes);
 
-  // Sanity check: prevent allocation of unreasonably large vectors (max 10000 words per block)
+  // Sanity checks: cap the arena allocation and reject impossible geometry
+  // (every word carries at least its NUL terminator).
   if (wc > 10000) {
     LOG_ERR("TXB", "Deserialization failed: word count %u exceeds maximum", wc);
     return nullptr;
   }
+  if ((wc == 0 && textBytes != 0) || (wc > 0 && textBytes < wc)) {
+    LOG_ERR("TXB", "Deserialization failed: bad text size %u for %u words", textBytes, wc);
+    return nullptr;
+  }
 
-  // Word data
-  words.resize(wc);
-  wordXpos.resize(wc);
-  wordStyles.resize(wc);
-  for (auto& w : words) serialization::readString(file, w);
-  for (auto& x : wordXpos) serialization::readPod(file, x);
-  for (auto& s : wordStyles) serialization::readPod(file, s);
-  uint8_t hasSizes = 0;
-  serialization::readPod(file, hasSizes);
-  if (hasSizes) {
-    wordSizes.resize(wc);
-    for (auto& sz : wordSizes) serialization::readPod(file, sz);
+  std::unique_ptr<TextBlock> block(new (std::nothrow) TextBlock());
+  if (!block) {
+    LOG_ERR("TXB", "OOM: TextBlock");
+    return nullptr;
+  }
+  block->numWords = wc;
+  block->textBytes = textBytes;
+  block->sizesPresent = hasSizes != 0;
+
+  if (wc > 0) {
+    const size_t size = arenaSize(wc, block->sizesPresent, textBytes);
+    block->arena = makeUniqueNoThrow<uint8_t[]>(size);
+    if (!block->arena) {
+      LOG_ERR("TXB", "OOM: arena %u bytes", static_cast<uint32_t>(size));
+      return nullptr;
+    }
+    if (file.read(block->arena.get(), size) != static_cast<int>(size)) {
+      LOG_ERR("TXB", "Deserialization failed: arena read (%u bytes)", static_cast<uint32_t>(size));
+      return nullptr;
+    }
+    block->bindArenaPointers();
+
+    // Validate offsets before anything dereferences wordText(): offset 0 first,
+    // strictly increasing, in bounds, and every word NUL-terminated (word i ends
+    // at the byte before offset i+1; the last word at the last text byte).
+    const uint16_t* textOff = block->textOffArr;
+    const char* text = block->textArr;
+    if (textOff[0] != 0 || text[textBytes - 1] != '\0') {
+      LOG_ERR("TXB", "Deserialization failed: corrupt text layout");
+      return nullptr;
+    }
+    for (uint16_t i = 1; i < wc; i++) {
+      if (textOff[i] <= textOff[i - 1] || textOff[i] >= textBytes || text[textOff[i] - 1] != '\0') {
+        LOG_ERR("TXB", "Deserialization failed: corrupt word offset %u", i);
+        return nullptr;
+      }
+    }
   }
 
   // Style (alignment + margins/padding/indent)
+  BlockStyle& blockStyle = block->blockStyle;
   serialization::readPod(file, blockStyle.alignment);
   serialization::readPod(file, blockStyle.textAlignDefined);
   serialization::readPod(file, blockStyle.marginTop);
@@ -159,6 +297,5 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
   serialization::readPod(file, blockStyle.fontSizeMultiplier);
   serialization::readPod(file, blockStyle.headingFontId);
 
-  return std::unique_ptr<TextBlock>(
-      new TextBlock(std::move(words), std::move(wordXpos), std::move(wordStyles), blockStyle, std::move(wordSizes)));
+  return block;
 }

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -2,7 +2,7 @@
 #include <EpdFontFamily.h>
 #include <HalStorage.h>
 
-#include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -10,54 +10,106 @@
 #include "Block.h"
 #include "BlockStyle.h"
 
-// Represents a line of text on a page
+// Represents a line of text on a page.
+//
+// All per-word data lives in ONE flat heap allocation (the arena) instead of
+// four parallel vectors (words, xpos, styles, sizes). A resident page holds
+// ~25-30 of these blocks, and the vector-of-string layout cost ~250 throwing
+// allocations per page load -- the primary driver of heap fragmentation on the
+// ESP32-C3 (~380 KB heap, no compaction).
+//
+// Ported from the sibling crosspoint-reader project's PR #2547 ("Flatten
+// TextBlock word storage into single allocation"), which flattens the same
+// structure but carries focus-reading annotations; adapted here to carry this
+// fork's optional per-word inline font-size array instead.
+//
+// Arena layout, in order (2-byte alignment holds by construction: the two 16-bit
+// arrays come first and the arena base is allocator-aligned; RISC-V faults on
+// unaligned multi-byte access):
+//   uint16_t textOff[wordCount]   byte offset of word i's text within text[]
+//   int16_t  xpos[wordCount]
+//   uint8_t  styles[wordCount]
+//   uint8_t  sizes[wordCount]     present only when sizesPresent
+//   char     text[textBytes]      all words back to back, each NUL-terminated
+//
+// Each word is stored NUL-terminated so render() can hand `text + textOff[i]`
+// straight to C APIs (drawText) with no std::string materialization.
+//
+// Per-word sizes are the inline CSS font-size percent of the block size. The
+// array is omitted from the arena entirely when every word is at 100% (the
+// overwhelmingly common case), so ordinary lines pay zero per-word RAM or
+// section-cache cost.
 class TextBlock final : public Block {
  private:
-  std::vector<std::string> words;
-  std::vector<int16_t> wordXpos;
-  std::vector<EpdFontFamily::Style> wordStyles;
-  // Per-word font size, percent of the block font size (inline CSS font-size).
-  // Empty means every word is at 100% — the overwhelmingly common case, kept empty
-  // so ordinary lines pay no RAM or section-cache cost. Non-empty vectors always
-  // match words.size().
-  std::vector<uint8_t> wordSizes;
   BlockStyle blockStyle;
+  uint16_t numWords = 0;
+  uint16_t textBytes = 0;  // total size of the text region, including one NUL per word
+  bool sizesPresent = false;
+  bool isValid = true;
+  // The ONLY allocation: makeUniqueNoThrow, so OOM yields an invalid block
+  // instead of abort() (bare new is not nothrow with -fno-exceptions).
+  std::unique_ptr<uint8_t[]> arena;
+  // Typed views into the arena, bound once after the arena is filled. All
+  // 16-bit bases sit at even offsets, so direct dereference is alignment-safe.
+  const uint16_t* textOffArr = nullptr;
+  const int16_t* xposArr = nullptr;
+  const uint8_t* stylesArr = nullptr;
+  const uint8_t* sizesArr = nullptr;  // null when !sizesPresent
+  const char* textArr = nullptr;
 
-  // Effective render scale of words[i]: block multiplier × the word's size percent.
-  float wordScale(const size_t i) const {
-    return wordSizes.empty() ? blockStyle.fontSizeMultiplier : blockStyle.fontSizeMultiplier * (wordSizes[i] / 100.0f);
+  // Byte offsets of each arena region from the arena base. Single source of
+  // truth for the layout, shared by the fill path, bindArenaPointers() and
+  // arenaSize() so the in-RAM and on-disk layouts can never drift apart.
+  struct ArenaOffsets {
+    size_t xpos, styles, sizes, text;
+  };
+  static ArenaOffsets arenaOffsets(uint16_t wordCount, bool hasSizes);
+
+  TextBlock() = default;  // deserialize() fills the fields directly
+  static size_t arenaSize(uint16_t wordCount, bool hasSizes, uint16_t textBytes);
+  void bindArenaPointers();
+
+  // Effective render scale of word i: block multiplier x the word's size percent.
+  float wordScale(const uint16_t i) const {
+    return sizesPresent ? blockStyle.fontSizeMultiplier * (sizesArr[i] / 100.0f) : blockStyle.fontSizeMultiplier;
   }
 
  public:
+  // Flatten-on-construct: copies the layout-time vectors into the arena; the
+  // vectors die with the caller. An all-100% sizes vector is normalized to "no
+  // sizes". On arena OOM the block is empty and valid() is false -- callers must
+  // check and drop the line instead of using it.
   explicit TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
                      std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle = BlockStyle(),
-                     std::vector<uint8_t> word_sizes = {})
-      : words(std::move(words)),
-        wordXpos(std::move(word_xpos)),
-        wordStyles(std::move(word_styles)),
-        wordSizes(std::move(word_sizes)),
-        blockStyle(blockStyle) {
-    // Normalize the all-100% case to an empty vector so uniform lines keep the
-    // zero-cost fast paths in render/serialize/line-height.
-    if (std::all_of(wordSizes.begin(), wordSizes.end(), [](const uint8_t s) { return s == 100; })) {
-      wordSizes.clear();
-      wordSizes.shrink_to_fit();
-    }
-  }
+                     std::vector<uint8_t> word_sizes = {});
   ~TextBlock() override = default;
+  TextBlock(const TextBlock&) = delete;
+  TextBlock& operator=(const TextBlock&) = delete;
+
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
   const BlockStyle& getBlockStyle() const { return blockStyle; }
-  const std::vector<std::string>& getWords() const { return words; }
-  bool isEmpty() override { return words.empty(); }
-  size_t wordCount() const { return words.size(); }
-  bool hasWordSizes() const { return !wordSizes.empty(); }
-  const std::vector<uint8_t>& getWordSizes() const { return wordSizes; }
+  bool isEmpty() override { return numWords == 0; }
+  bool valid() const { return isValid; }
+  uint16_t wordCount() const { return numWords; }
+  // NUL-terminated by construction; safe to pass to C APIs directly.
+  const char* wordText(const uint16_t i) const { return textArr + textOffArr[i]; }
+  uint16_t wordTextLen(const uint16_t i) const {
+    const uint16_t end = (i + 1 < numWords) ? textOffArr[i + 1] : textBytes;
+    return end - textOffArr[i] - 1;  // exclude the NUL
+  }
+  int16_t wordXpos(const uint16_t i) const { return xposArr[i]; }
+  EpdFontFamily::Style wordStyle(const uint16_t i) const { return static_cast<EpdFontFamily::Style>(stylesArr[i]); }
+  bool hasWordSizes() const { return sizesPresent; }
+  uint8_t wordSizePct(const uint16_t i) const { return sizesPresent ? sizesArr[i] : 100; }
+  // Diagnostic/test helper: materializes the per-word size vector (empty when uniform).
+  std::vector<uint8_t> getWordSizes() const {
+    return sizesPresent ? std::vector<uint8_t>(sizesArr, sizesArr + numWords) : std::vector<uint8_t>{};
+  }
   // Largest per-word size percent on this line (100 when uniform). The line's
   // vertical advance scales with this so an enlarged inline word doesn't collide
   // with the next line.
-  uint8_t maxSizePct() const {
-    return wordSizes.empty() ? static_cast<uint8_t>(100) : *std::max_element(wordSizes.begin(), wordSizes.end());
-  }
+  uint8_t maxSizePct() const;
+
   // given a renderer works out where to break the words into lines
   void render(const GfxRenderer& renderer, int fontId, int x, int y) const;
   BlockType getType() override { return TEXT_BLOCK; }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -174,12 +174,12 @@ std::string buildTextBlockPreview(const std::shared_ptr<TextBlock>& line, const 
   }
 
   std::string preview;
-  const auto& words = line->getWords();
-  for (size_t i = 0; i < words.size(); ++i) {
+  const uint16_t wordCount = line->wordCount();
+  for (uint16_t i = 0; i < wordCount; ++i) {
     if (i > 0) {
       preview.push_back(' ');
     }
-    preview += words[i];
+    preview += line->wordText(i);
     if (preview.size() >= maxLen) {
       preview.resize(maxLen);
       preview += "...";
@@ -2729,8 +2729,9 @@ void ChapterHtmlSlimParser::emitTableAsFragments(BufferedTable& table) {
         fbc.isHeader = cell.isHeader;
         fbc.text = std::unique_ptr<ParsedText>(new ParsedText(false, false));
         for (const auto& line : cell.lines) {
-          for (const auto& word : line->getWords()) {
-            fbc.text->addWord(word, EpdFontFamily::REGULAR, false, false);
+          const uint16_t wordCount = line->wordCount();
+          for (uint16_t i = 0; i < wordCount; ++i) {
+            fbc.text->addWord(line->wordText(i), EpdFontFamily::REGULAR, false, false);
           }
         }
         fbRow.cells.push_back(std::move(fbc));

--- a/lib/Memory/Memory.h
+++ b/lib/Memory/Memory.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+// Nothrow versions of std::make_unique. Return nullptr on allocation failure
+// instead of calling abort() (the default when exceptions are disabled on ESP32).
+//
+// Adapted from the sibling crosspoint-reader project (lib/Memory/Memory.h),
+// introduced here alongside the flat-TextBlock port (crosspoint-reader PR #2547).
+//
+// Single object:
+//   auto obj = makeUniqueNoThrow<PNG>();
+//   if (!obj) { LOG_ERR("TAG", "OOM"); return false; }
+//
+// Array:
+//   auto buf = makeUniqueNoThrow<uint8_t[]>(size);
+//   if (!buf) { LOG_ERR("TAG", "OOM"); return false; }
+//   buf[0] = 0xFF;
+//   someApi(buf.get(), size);
+//
+
+template <typename T, typename... Args>
+  requires(!std::is_array_v<T>)
+std::unique_ptr<T> makeUniqueNoThrow(Args&&... args) {
+  return std::unique_ptr<T>(new (std::nothrow) T(std::forward<Args>(args)...));
+}
+
+template <typename T>
+  requires std::is_unbounded_array_v<T>
+std::unique_ptr<T> makeUniqueNoThrow(size_t count) {
+  using Elem = std::remove_extent_t<T>;
+  return std::unique_ptr<T>(new (std::nothrow) Elem[count]());
+}

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1272,10 +1272,11 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
             if (el->getTag() == TAG_PageLine) {
               const auto& line = static_cast<const PageLine&>(*el);
               if (line.getBlock()) {
-                const auto& words = line.getBlock()->getWords();
-                for (const auto& w : words) {
+                const auto& block = *line.getBlock();
+                const uint16_t wordCount = block.wordCount();
+                for (uint16_t i = 0; i < wordCount; ++i) {
                   if (!fullText.empty()) fullText += " ";
-                  fullText += w;
+                  fullText += block.wordText(i);
                 }
               }
             }

--- a/test/word_size_layout/CMakeLists.txt
+++ b/test/word_size_layout/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(WordSizeLayoutTest PRIVATE
   ${REPO_ROOT}/lib/EpdFont
   ${REPO_ROOT}/lib/Utf8
   ${REPO_ROOT}/lib/Logging
+  ${REPO_ROOT}/lib/Memory
   ${REPO_ROOT}/lib/Serialization
 )
 

--- a/test/word_size_layout/WordSizeLayoutTest.cpp
+++ b/test/word_size_layout/WordSizeLayoutTest.cpp
@@ -191,7 +191,7 @@ TEST(WordSizeSerialization, RoundTripsMixedSizes) {
   ASSERT_EQ(restored->wordCount(), 3u);
   ASSERT_TRUE(restored->hasWordSizes());
   EXPECT_EQ(restored->getWordSizes(), (std::vector<uint8_t>{100, 80, 150}));
-  EXPECT_EQ(restored->getWords()[1], "two");
+  EXPECT_EQ(std::string(restored->wordText(1)), "two");
 }
 
 TEST(WordSizeSerialization, UniformBlockCostsOneFlagByte) {
@@ -209,6 +209,69 @@ TEST(WordSizeSerialization, UniformBlockCostsOneFlagByte) {
   const auto restored = TextBlock::deserialize(uniformFile);
   ASSERT_NE(restored, nullptr);
   EXPECT_FALSE(restored->hasWordSizes());
+}
+
+// The flat arena packs word text, offsets, xpos and styles into one allocation;
+// verify every per-word field survives a serialize/deserialize round-trip and
+// that wordText() stays NUL-terminated with the right length.
+TEST(WordSizeSerialization, ArenaRoundTripPreservesPerWordFields) {
+  const std::vector<std::string> words = {"Hello", "wörld", "!", "a"};
+  const std::vector<int16_t> xpos = {0, 60, 120, 140};
+  const std::vector<EpdFontFamily::Style> styles = {EpdFontFamily::REGULAR, EpdFontFamily::BOLD,
+                                                    EpdFontFamily::UNDERLINE, EpdFontFamily::ITALIC};
+  TextBlock original(words, xpos, styles, BlockStyle());
+  ASSERT_TRUE(original.valid());
+
+  FsFile file = HalFile::forReadWrite();
+  ASSERT_TRUE(original.serialize(file));
+  ASSERT_TRUE(file.seek(0));
+
+  const auto restored = TextBlock::deserialize(file);
+  ASSERT_NE(restored, nullptr);
+  ASSERT_EQ(restored->wordCount(), words.size());
+  EXPECT_FALSE(restored->hasWordSizes());
+  for (uint16_t i = 0; i < words.size(); ++i) {
+    EXPECT_EQ(std::string(restored->wordText(i)), words[i]);
+    EXPECT_EQ(restored->wordTextLen(i), words[i].size());
+    EXPECT_EQ(restored->wordXpos(i), xpos[i]);
+    EXPECT_EQ(restored->wordStyle(i), styles[i]);
+  }
+}
+
+// An empty word ("") is stored as a bare NUL; the offset table must still be
+// strictly increasing and validation must accept it.
+TEST(WordSizeSerialization, EmptyStringWordRoundTrips) {
+  TextBlock original({"", "x", ""}, {0, 10, 20},
+                     {EpdFontFamily::REGULAR, EpdFontFamily::REGULAR, EpdFontFamily::REGULAR}, BlockStyle());
+  ASSERT_TRUE(original.valid());
+
+  FsFile file = HalFile::forReadWrite();
+  ASSERT_TRUE(original.serialize(file));
+  ASSERT_TRUE(file.seek(0));
+
+  const auto restored = TextBlock::deserialize(file);
+  ASSERT_NE(restored, nullptr);
+  ASSERT_EQ(restored->wordCount(), 3u);
+  EXPECT_EQ(std::string(restored->wordText(0)), "");
+  EXPECT_EQ(restored->wordTextLen(0), 0u);
+  EXPECT_EQ(std::string(restored->wordText(1)), "x");
+  EXPECT_EQ(std::string(restored->wordText(2)), "");
+}
+
+// A zero-word block carries no arena; it must round-trip as a valid empty block.
+TEST(WordSizeSerialization, EmptyBlockRoundTrips) {
+  TextBlock original({}, {}, {}, BlockStyle());
+  ASSERT_TRUE(original.valid());
+  EXPECT_TRUE(original.isEmpty());
+
+  FsFile file = HalFile::forReadWrite();
+  ASSERT_TRUE(original.serialize(file));
+  ASSERT_TRUE(file.seek(0));
+
+  const auto restored = TextBlock::deserialize(file);
+  ASSERT_NE(restored, nullptr);
+  EXPECT_EQ(restored->wordCount(), 0u);
+  EXPECT_TRUE(restored->isEmpty());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Replace `TextBlock`'s per-word `std::vector<std::string>` plus parallel vectors (xpos, styles, inline sizes) with **one flat heap allocation** (the "arena"): a per-word offset/xpos/style/size table followed by all word text back to back, each NUL-terminated.

## Why

A rendered page is held in RAM as ~25–30 `TextBlock`s (one per line), and the old layout stored each block's words as `vector<string>` plus parallel arrays — ~250 throwing allocations per page load. On the ESP32-C3 (~380 KB heap, no compaction) this was the primary driver of heap fragmentation as you turn pages. The original change measured worst mid-session free heap going from <1 KB to ~56 KB.

The in-RAM arena layout mirrors the on-disk layout, so a block now serializes/deserializes with a single write/read.

## What changed

- **`TextBlock.{h,cpp}`** — arena storage, flatten-on-construct, arena-verbatim serialize/deserialize with offset validation. A single `arenaOffsets()` helper is the one source of truth for the layout (fill path, read-view binding, and size calc all share it).
- **`lib/Memory/Memory.h`** (new) — `makeUniqueNoThrow`: OOM yields `nullptr` instead of `abort()` (bare `new` is not nothrow under `-fno-exceptions`).
- **`ParsedText.cpp`** — drops a line if the arena allocation fails (`valid()` check) instead of rendering garbage.
- **`ChapterHtmlSlimParser.cpp`, `EpubReaderActivity.cpp`** — switched off the removed `getWords()` to index-based `wordText(i)`.
- **`Section.cpp`** — section cache version 59 → 60 (stale sections auto-rebuild; no migration needed).
- **Tests** — 3 new arena round-trip tests (per-word fields, empty-string words, zero-word block). Full `WordSizeLayoutTest` suite passes (22/22).

## Attribution

Ported from the sibling **crosspoint-reader** project's PR [#2547](https://github.com/crosspoint-reader/crosspoint-reader/pull/2547) ("Flatten TextBlock word storage into single allocation"), which flattens the same structure but carries focus-reading annotations. Adapted here to carry this fork's optional per-word **inline font-size** array instead. Original author credited in the commit and in code comments.

