### PR TITLE
fix: resolve printed-page menu OOM reboot; slim the image manifest

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1428,15 +1428,14 @@ bool Epub::getPrintedPageLabelRange(int& minLabel, int& maxLabel) const {
 
 std::optional<Epub::PrintedPageEntry> Epub::findPrintedPageByLabel(int target) const {
   std::optional<PrintedPageEntry> match;
-  streamPrintedPageEntries(
-      getCachePath() + "/pagelist.bin",
-      [&](const std::string& href, const std::string& anchor, const std::string& label) {
-        if (const auto n = parseNumericPageLabel(label); n && *n == target) {
-          match = PrintedPageEntry{href, anchor, label};
-          return false;  // first match wins (file order)
-        }
-        return true;
-      });
+  streamPrintedPageEntries(getCachePath() + "/pagelist.bin",
+                           [&](const std::string& href, const std::string& anchor, const std::string& label) {
+                             if (const auto n = parseNumericPageLabel(label); n && *n == target) {
+                               match = PrintedPageEntry{href, anchor, label};
+                               return false;  // first match wins (file order)
+                             }
+                             return true;
+                           });
   return match;
 }
 

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -13,6 +13,8 @@
 
 #include <cctype>
 #include <cstring>
+#include <limits>
+#include <optional>
 
 #include "Epub/ImageFormatDetector.h"
 #include "Epub/parsers/ContainerParser.h"
@@ -1354,28 +1356,88 @@ float Epub::calculateProgress(const int currentSpineIndex, const float currentSp
   return totalProgress / static_cast<float>(bookSize);
 }
 
-std::vector<Epub::PrintedPageEntry> Epub::loadPrintedPageList() const {
-  std::vector<PrintedPageEntry> entries;
-  const auto pageListPath = getCachePath() + "/pagelist.bin";
-  if (!Storage.exists(pageListPath.c_str())) {
-    return entries;
+void Epub::streamPrintedPageEntries(
+    const std::string& path,
+    const std::function<bool(const std::string&, const std::string&, const std::string&)>& visit) {
+  if (!Storage.exists(path.c_str())) {
+    return;
   }
   FsFile f;
-  if (!Storage.openFileForRead("EBP", pageListPath, f)) {
-    return entries;
+  if (!Storage.openFileForRead("EBP", path, f)) {
+    return;
   }
   uint16_t count = 0;
   serialization::readPod(f, count);
-  entries.reserve(count);
+  // Reused across iterations — labels/hrefs are short, so this never grows into the ~200 KB block
+  // the full list would reserve. count is never used to pre-size anything: a corrupt/oversized
+  // count simply runs the loop until readString hits EOF or a malformed field and we stop.
+  std::string href, anchor, label;
   for (uint16_t i = 0; i < count; i++) {
-    PrintedPageEntry e;
-    serialization::readString(f, e.href);
-    serialization::readString(f, e.anchor);
-    serialization::readString(f, e.label);
-    entries.push_back(std::move(e));
+    if (!serialization::readString(f, href) || !serialization::readString(f, anchor) ||
+        !serialization::readString(f, label)) {
+      break;  // malformed / oversized field: stop rather than risk desync
+    }
+    if (!visit(href, anchor, label)) {
+      break;
+    }
   }
   f.close();
-  return entries;
+}
+
+// Mirror of parsePrintedPageLabel (EpubReaderActivity): non-empty, all digits, <= 999999.
+static std::optional<int> parseNumericPageLabel(const std::string& label) {
+  if (label.empty()) return std::nullopt;
+  int value = 0;
+  for (char c : label) {
+    if (c < '0' || c > '9') return std::nullopt;
+    value = value * 10 + (c - '0');
+    if (value > 999999) return std::nullopt;
+  }
+  return value;
+}
+
+bool Epub::hasNumericPrintedPages() const {
+  bool found = false;
+  streamPrintedPageEntries(getCachePath() + "/pagelist.bin",
+                           [&](const std::string&, const std::string&, const std::string& label) {
+                             if (parseNumericPageLabel(label)) {
+                               found = true;
+                               return false;  // short-circuit
+                             }
+                             return true;
+                           });
+  return found;
+}
+
+bool Epub::getPrintedPageLabelRange(int& minLabel, int& maxLabel) const {
+  int lo = std::numeric_limits<int>::max();
+  int hi = std::numeric_limits<int>::min();
+  streamPrintedPageEntries(getCachePath() + "/pagelist.bin",
+                           [&](const std::string&, const std::string&, const std::string& label) {
+                             if (const auto n = parseNumericPageLabel(label)) {
+                               if (*n < lo) lo = *n;
+                               if (*n > hi) hi = *n;
+                             }
+                             return true;
+                           });
+  if (hi < lo) return false;  // no numeric labels
+  minLabel = lo;
+  maxLabel = hi;
+  return true;
+}
+
+std::optional<Epub::PrintedPageEntry> Epub::findPrintedPageByLabel(int target) const {
+  std::optional<PrintedPageEntry> match;
+  streamPrintedPageEntries(
+      getCachePath() + "/pagelist.bin",
+      [&](const std::string& href, const std::string& anchor, const std::string& label) {
+        if (const auto n = parseNumericPageLabel(label); n && *n == target) {
+          match = PrintedPageEntry{href, anchor, label};
+          return false;  // first match wins (file order)
+        }
+        return true;
+      });
+  return match;
 }
 
 int Epub::resolveHrefToSpineIndex(const std::string& href) const {

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -2,7 +2,9 @@
 
 #include <Print.h>
 
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -147,7 +149,27 @@ class Epub {
     std::string anchor;
     std::string label;
   };
-  // Reads <cachePath>/pagelist.bin. Returns empty vector when the book has no printed-page data.
-  // Inexpensive — only invoked from menu paths, not page-turn hot paths.
-  std::vector<PrintedPageEntry> loadPrintedPageList() const;
+  // Printed-page navigation accessors, all reading <cachePath>/pagelist.bin. They STREAM the file
+  // one entry at a time rather than materialising the list: the full list is ~72 B/entry (~200 KB
+  // for a long book), and reserving that as a single contiguous block aborts the firmware (uncaught
+  // bad_alloc, -fno-exceptions) when a menu is opened while the heap is fragmented by an in-flight
+  // section build — the tag 2.05 "Confirm reboots on a huge chapter" crash. Numeric labels match
+  // the reader's parsePrintedPageLabel rule (non-empty, all digits, <= 999999).
+
+  // True when at least one entry has a numeric label. Short-circuits on the first match — used to
+  // decide whether the reader menu offers "Go to printed page".
+  bool hasNumericPrintedPages() const;
+  // Fills [minLabel, maxLabel] with the numeric-label range (inclusive). Returns false and leaves
+  // the outputs untouched when the book has no numeric labels.
+  bool getPrintedPageLabelRange(int& minLabel, int& maxLabel) const;
+  // Returns the first entry whose numeric label equals target (file order), or nullopt.
+  std::optional<PrintedPageEntry> findPrintedPageByLabel(int target) const;
+
+ private:
+  // Streams pagelist.bin at path into visit(href, anchor, label) per entry; visit returns false to
+  // stop early. The single place that knows the on-disk format, so no caller reserves the whole
+  // list. Silently no-ops when the file is absent or unreadable.
+  static void streamPrintedPageEntries(
+      const std::string& path,
+      const std::function<bool(const std::string&, const std::string&, const std::string&)>& visit);
 };

--- a/lib/Epub/Epub/EpubImageManifest.cpp
+++ b/lib/Epub/Epub/EpubImageManifest.cpp
@@ -17,13 +17,6 @@ constexpr const char* kImagesBinFile = "/images.bin";
 // Enough to find any JPEG SOF marker, PNG IHDR chunk, or GIF logical-screen header.
 constexpr size_t kHeaderBufSize = 4 * 1024;
 
-std::string extractedPathFor(const std::string& cachePath, const std::string& epubEntryPath) {
-  // Use only the basename so the path stays short and is spine-agnostic.
-  const size_t slash = epubEntryPath.rfind('/');
-  const std::string basename = (slash != std::string::npos) ? epubEntryPath.substr(slash + 1) : epubEntryPath;
-  return cachePath + "/img/" + basename;
-}
-
 // Parse image dimensions by detecting format and delegating to the appropriate converter.
 bool parseImageDimensions(const uint8_t* buf, size_t n, ImageDimensions& dims) {
   const auto fmt = ImageFormatDetector::detect(buf, n);
@@ -71,13 +64,13 @@ bool EpubImageManifest::load(const std::string& cachePath) {
   uint16_t count = 0;
   serialization::readPod(f, count);
   // A corrupt/truncated images.bin must not steer reserve() into a multi-MB allocation that aborts
-  // the firmware (uncaught bad_alloc, -fno-exceptions). The smallest possible on-disk entry is two
-  // u32 string-length prefixes (empty strings) + 18 B of fixed PODs = 26 B, so a count that can't
-  // fit in the bytes left in the file is garbage. A bad header means the rest is untrustworthy too:
-  // drop the whole cache and start empty — ensureResolved() refills it and the next persist
-  // overwrites the corrupt file.
+  // the firmware (uncaught bad_alloc, -fno-exceptions). The smallest possible on-disk entry is one
+  // u32 string-length prefix (empty key) + 18 B of fixed PODs = 22 B, so a count that can't fit in
+  // the bytes left in the file is garbage. A bad header means the rest is untrustworthy too: drop
+  // the whole cache and start empty — ensureResolved() refills it and the next persist overwrites
+  // the corrupt file.
   const int remaining = f.available();
-  const uint32_t maxPlausible = remaining > 0 ? static_cast<uint32_t>(remaining) / 26u : 0u;
+  const uint32_t maxPlausible = remaining > 0 ? static_cast<uint32_t>(remaining) / 22u : 0u;
   if (count > maxPlausible) {
     LOG_ERR("IMF", "images.bin count %u exceeds file capacity %u; ignoring cache", count, maxPlausible);
     f.close();
@@ -96,7 +89,6 @@ bool EpubImageManifest::load(const std::string& cachePath) {
     serialization::readPod(f, e.compressedSize);
     serialization::readPod(f, e.uncompressedSize);
     serialization::readPod(f, e.localHeaderOffset);
-    if (!serialization::readString(f, e.extractedPath)) break;
     entries_.push_back(std::move(e));
   }
 
@@ -158,7 +150,6 @@ const ImageManifestEntry* EpubImageManifest::ensureResolved(const std::string& e
       e.compressedSize = stat.compressedSize;
       e.uncompressedSize = stat.uncompressedSize;
       e.localHeaderOffset = stat.localHeaderOffset;
-      e.extractedPath = extractedPathFor(cachePath_, epubEntryPath);
 
       // Insert keeping entries_ sorted so find()'s binary search stays valid.
       auto it = std::lower_bound(entries_.begin(), entries_.end(), epubEntryPath,
@@ -219,7 +210,6 @@ void EpubImageManifest::persistIfDirty() {
     serialization::writePod(f, e.compressedSize);
     serialization::writePod(f, e.uncompressedSize);
     serialization::writePod(f, e.localHeaderOffset);
-    serialization::writeString(f, e.extractedPath);
   }
   f.flush();
   f.close();

--- a/lib/Epub/Epub/EpubImageManifest.cpp
+++ b/lib/Epub/Epub/EpubImageManifest.cpp
@@ -65,12 +65,12 @@ bool EpubImageManifest::load(const std::string& cachePath) {
   serialization::readPod(f, count);
   // A corrupt/truncated images.bin must not steer reserve() into a multi-MB allocation that aborts
   // the firmware (uncaught bad_alloc, -fno-exceptions). The smallest possible on-disk entry is one
-  // u32 string-length prefix (empty key) + 18 B of fixed PODs = 22 B, so a count that can't fit in
-  // the bytes left in the file is garbage. A bad header means the rest is untrustworthy too: drop
-  // the whole cache and start empty — ensureResolved() refills it and the next persist overwrites
-  // the corrupt file.
+  // u32 string-length prefix (empty key) + width + height (two int16) = 8 B, so a count that can't
+  // fit in the bytes left in the file is garbage. A bad header means the rest is untrustworthy too:
+  // drop the whole cache and start empty — ensureResolved() refills it and the next persist
+  // overwrites the corrupt file.
   const int remaining = f.available();
-  const uint32_t maxPlausible = remaining > 0 ? static_cast<uint32_t>(remaining) / 22u : 0u;
+  const uint32_t maxPlausible = remaining > 0 ? static_cast<uint32_t>(remaining) / 8u : 0u;
   if (count > maxPlausible) {
     LOG_ERR("IMF", "images.bin count %u exceeds file capacity %u; ignoring cache", count, maxPlausible);
     f.close();
@@ -85,10 +85,6 @@ bool EpubImageManifest::load(const std::string& cachePath) {
     if (!serialization::readString(f, e.epubEntryPath)) break;
     serialization::readPod(f, e.width);
     serialization::readPod(f, e.height);
-    serialization::readPod(f, e.method);
-    serialization::readPod(f, e.compressedSize);
-    serialization::readPod(f, e.uncompressedSize);
-    serialization::readPod(f, e.localHeaderOffset);
     entries_.push_back(std::move(e));
   }
 
@@ -146,10 +142,6 @@ const ImageManifestEntry* EpubImageManifest::ensureResolved(const std::string& e
       e.epubEntryPath = epubEntryPath;  // caller passes the normalised key
       e.width = dims.width;
       e.height = dims.height;
-      e.method = stat.method;
-      e.compressedSize = stat.compressedSize;
-      e.uncompressedSize = stat.uncompressedSize;
-      e.localHeaderOffset = stat.localHeaderOffset;
 
       // Insert keeping entries_ sorted so find()'s binary search stays valid.
       auto it = std::lower_bound(entries_.begin(), entries_.end(), epubEntryPath,
@@ -206,10 +198,6 @@ void EpubImageManifest::persistIfDirty() {
     serialization::writeString(f, e.epubEntryPath);
     serialization::writePod(f, e.width);
     serialization::writePod(f, e.height);
-    serialization::writePod(f, e.method);
-    serialization::writePod(f, e.compressedSize);
-    serialization::writePod(f, e.uncompressedSize);
-    serialization::writePod(f, e.localHeaderOffset);
   }
   f.flush();
   f.close();

--- a/lib/Epub/Epub/EpubImageManifest.cpp
+++ b/lib/Epub/Epub/EpubImageManifest.cpp
@@ -70,6 +70,21 @@ bool EpubImageManifest::load(const std::string& cachePath) {
 
   uint16_t count = 0;
   serialization::readPod(f, count);
+  // A corrupt/truncated images.bin must not steer reserve() into a multi-MB allocation that aborts
+  // the firmware (uncaught bad_alloc, -fno-exceptions). The smallest possible on-disk entry is two
+  // u32 string-length prefixes (empty strings) + 18 B of fixed PODs = 26 B, so a count that can't
+  // fit in the bytes left in the file is garbage. A bad header means the rest is untrustworthy too:
+  // drop the whole cache and start empty — ensureResolved() refills it and the next persist
+  // overwrites the corrupt file.
+  const int remaining = f.available();
+  const uint32_t maxPlausible = remaining > 0 ? static_cast<uint32_t>(remaining) / 26u : 0u;
+  if (count > maxPlausible) {
+    LOG_ERR("IMF", "images.bin count %u exceeds file capacity %u; ignoring cache", count, maxPlausible);
+    f.close();
+    entries_.clear();
+    loaded_ = true;
+    return true;
+  }
   entries_.reserve(count);
 
   for (uint16_t i = 0; i < count; ++i) {

--- a/lib/Epub/Epub/EpubImageManifest.h
+++ b/lib/Epub/Epub/EpubImageManifest.h
@@ -6,17 +6,14 @@
 #include <string>
 #include <vector>
 
-// Per-image entry: dimensions (needed at section-build pagination time) plus the ZIP
-// location, cached so the parser never re-reads a header it has seen before.
+// Per-image entry: just the normalised key and its pixel dimensions. Dimensions are the only
+// thing any consumer reads (pagination needs them; the parser reads width/height and nothing
+// else). Render-time extraction re-resolves the ZIP entry by path via ImageBlock::ensureExtracted,
+// so no ZIP-stat fields are cached here.
 struct ImageManifestEntry {
   std::string epubEntryPath;  // normalised key, e.g. "OEBPS/images/foo.jpg"
   int16_t width = 0;
   int16_t height = 0;
-  // ZipFile stat — avoids re-scanning the central directory at render time
-  uint16_t method = 0;
-  uint32_t compressedSize = 0;
-  uint32_t uncompressedSize = 0;
-  uint32_t localHeaderOffset = 0;
 };
 
 // Incremental, persisted image-dimension cache. The book is NOT scanned up front: the
@@ -27,10 +24,11 @@ struct ImageManifestEntry {
 // the heap on image-heavy books — see git history.)
 class EpubImageManifest {
  public:
-  // v3: dropped the unused per-entry extractedPath (the render path computes its own image-cache
-  // filename, so it was written and persisted but never read). Bumping invalidates older caches,
-  // which then refill incrementally. (v2 added normalised keys.)
-  static constexpr uint8_t VERSION = 3;
+  // v4: entries are now just {key, width, height}. Dropped the unused per-entry extractedPath and
+  // the unused ZIP-stat fields (method/compressed/uncompressed/localHeaderOffset) — all were
+  // written and persisted but never read. Bumping invalidates older caches, which then refill
+  // incrementally. (v2 added normalised keys; v3 dropped extractedPath.)
+  static constexpr uint8_t VERSION = 4;
 
   // Load images.bin from cachePath into memory. A missing (or stale-version) file is NOT an
   // error: it yields an empty but loaded manifest that ensureResolved() fills incrementally.

--- a/lib/Epub/Epub/EpubImageManifest.h
+++ b/lib/Epub/Epub/EpubImageManifest.h
@@ -17,9 +17,6 @@ struct ImageManifestEntry {
   uint32_t compressedSize = 0;
   uint32_t uncompressedSize = 0;
   uint32_t localHeaderOffset = 0;
-  // Stable extracted path shared across all spines and render configs:
-  // {cachePath}/img/{basename}  e.g. "/.crosspoint/epub_HASH/img/foo.jpg"
-  std::string extractedPath;
 };
 
 // Incremental, persisted image-dimension cache. The book is NOT scanned up front: the
@@ -30,8 +27,10 @@ struct ImageManifestEntry {
 // the heap on image-heavy books — see git history.)
 class EpubImageManifest {
  public:
-  // v2: normalised keys. Bump invalidates v1 caches (raw keys), which then refill incrementally.
-  static constexpr uint8_t VERSION = 2;
+  // v3: dropped the unused per-entry extractedPath (the render path computes its own image-cache
+  // filename, so it was written and persisted but never read). Bumping invalidates older caches,
+  // which then refill incrementally. (v2 added normalised keys.)
+  static constexpr uint8_t VERSION = 3;
 
   // Load images.bin from cachePath into memory. A missing (or stale-version) file is NOT an
   // error: it yields an empty but loaded manifest that ensureResolved() fills incrementally.

--- a/lib/Epub/Epub/parsers/PageListSink.h
+++ b/lib/Epub/Epub/parsers/PageListSink.h
@@ -10,7 +10,7 @@
 // entries × 3 std::string each is enough to throw std::bad_alloc).
 //
 // File format matches the legacy writePageListBin() in Epub.cpp so the reader
-// side (Epub::loadPrintedPageList) is unchanged: u16 count, then per entry
+// side (Epub::streamPrintedPageEntries) is unchanged: u16 count, then per entry
 // writeString(href), writeString(anchor), writeString(label).
 //
 // Lifecycle: construct (opens the file and writes a placeholder count of 0),

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1204,18 +1204,13 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     }
     case EpubReaderMenuActivity::MenuAction::GO_TO_PRINTED_PAGE: {
       if (!epub) break;
-      auto entries = epub->loadPrintedPageList();
-      // Compute the integer label range from parseable entries; non-integer labels are
-      // ignored (the dialog is numeric-only).
-      int minLabel = std::numeric_limits<int>::max();
-      int maxLabel = std::numeric_limits<int>::min();
-      for (const auto& entry : entries) {
-        if (const auto n = parsePrintedPageLabel(entry.label)) {
-          if (*n < minLabel) minLabel = *n;
-          if (*n > maxLabel) maxLabel = *n;
-        }
+      // Integer label range for the numeric input's bounds. Streamed (not loadPrintedPageList) so
+      // the whole list is never held in RAM — see Epub::hasNumericPrintedPages for why.
+      int minLabel = 0;
+      int maxLabel = 0;
+      if (!epub->getPrintedPageLabelRange(minLabel, maxLabel)) {
+        break;  // no integer labels — shouldn't happen if the menu item was shown
       }
-      if (maxLabel < minLabel) break;  // no integer labels — shouldn't happen if menu item was shown
 
       // Pre-fill with the printed page the reader is currently on (or the nearest one before
       // it — rendered device pages rarely carry an anchor themselves, but they sit between
@@ -1233,33 +1228,31 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
 
       startActivityForResult(
           std::make_unique<EpubReaderPrintedPageInputActivity>(renderer, mappedInput, initialValue, minLabel, maxLabel),
-          [this, entries = std::move(entries)](const ActivityResult& result) {
+          [this](const ActivityResult& result) {
             if (result.isCancelled) return;
             const auto& pick = std::get<PrintedPageResult>(result.data);
-            // Resolve the typed label back to a (href, anchor) by linear scan. Entries are
-            // small (typically <500 even for long books) and this fires once per user action.
-            for (const auto& entry : entries) {
-              const auto entryLabelValue = parsePrintedPageLabel(entry.label);
-              const auto pickLabelValue = parsePrintedPageLabel(pick.label);
-              if (entry.label == pick.label ||
-                  (entryLabelValue && pickLabelValue && *entryLabelValue == *pickLabelValue)) {
-                const int spineIdx = epub->resolveHrefToSpineIndex(entry.href);
-                if (spineIdx < 0) {
-                  LOG_DBG("ERS", "printed-page jump: could not resolve spine for href=%s", entry.href.c_str());
-                  return;
-                }
-                {
-                  RenderLock lock(*this);
-                  currentSpineIndex = spineIdx;
-                  navTarget =
-                      entry.anchor.empty() ? NavigationTarget::makePage(0) : NavigationTarget::makeAnchor(entry.anchor);
-                  section.reset();
-                }
-                requestUpdate();
-                return;
-              }
+            // pick.label is always a numeric string (std::to_string of the picked value). Resolve it
+            // back to a (href, anchor) by streaming the list again — no full-list vector retained.
+            const auto value = parsePrintedPageLabel(pick.label);
+            if (!value) return;
+            const auto entry = epub->findPrintedPageByLabel(*value);
+            if (!entry) {
+              LOG_DBG("ERS", "printed-page jump: label '%s' not found in pagelist", pick.label.c_str());
+              return;
             }
-            LOG_DBG("ERS", "printed-page jump: label '%s' not found in pagelist", pick.label.c_str());
+            const int spineIdx = epub->resolveHrefToSpineIndex(entry->href);
+            if (spineIdx < 0) {
+              LOG_DBG("ERS", "printed-page jump: could not resolve spine for href=%s", entry->href.c_str());
+              return;
+            }
+            {
+              RenderLock lock(*this);
+              currentSpineIndex = spineIdx;
+              navTarget =
+                  entry->anchor.empty() ? NavigationTarget::makePage(0) : NavigationTarget::makeAnchor(entry->anchor);
+              section.reset();
+            }
+            requestUpdate();
           });
       break;
     }
@@ -3617,11 +3610,11 @@ void EpubReaderActivity::openReaderMenu() {
 
   // Show the "Go to printed page" item only when this book has at least one integer-labelled
   // entry in pagelist.bin. Roman-only or empty page lists are excluded — the numeric input
-  // dialog can't address them anyway.
-  const auto printedPageList = epub->loadPrintedPageList();
-  const bool hasPrintedPages = std::any_of(printedPageList.begin(), printedPageList.end(), [](const auto& entry) {
-    return parsePrintedPageLabel(entry.label).has_value();
-  });
+  // dialog can't address them anyway. Streamed (not loadPrintedPageList) so opening the menu never
+  // reserves the whole list: that ~200 KB contiguous allocation aborts the firmware via uncaught
+  // bad_alloc when the menu is opened mid section-build on a long book (heap fragmented to tens of
+  // KB) — the tag 2.05 "Confirm reboots" crash.
+  const bool hasPrintedPages = epub->hasNumericPrintedPages();
 
   ReaderUtils::enforceExitFullRefresh(renderer);
   startActivityForResult(


### PR DESCRIPTION
## Summary

Fixes a reboot reported on tag 2.05: opening the reader menu (Confirm) on a book with a long printed-page list, while a large chapter's section build was still resident, rebooted the device instead of showing the menu. Symbolising the crash against the 2.05 release ELF pinned it to an uncaught `std::bad_alloc`:

```
operator new -> std::vector<PrintedPageEntry>::reserve -> __terminate -> abort
```

`openReaderMenu()` called `loadPrintedPageList()`, which reserved the whole printed-page list up front (~72 B/entry, ~200 KB for the reported book) as one contiguous block. With `-fno-exceptions` a failed allocation calls `abort()`, and while a resident section build has fragmented the heap to a ~40 KB largest free block, that reserve can't be satisfied → reboot.

While in this code, the PR also audits and hardens the sibling pattern (unbounded/oversized allocations driven by file data) and slims the resident image manifest.

## Commits

1. **Stream the printed-page list instead of loading it whole.** `openReaderMenu` only needed a boolean ("does any entry have a numeric label"), and the Go-to-printed-page flow only needed a label range + one lookup. Replaced `loadPrintedPageList()` with streaming accessors (`hasNumericPrintedPages`, `getPrintedPageLabelRange`, `findPrintedPageByLabel`) built on one `streamPrintedPageEntries()` primitive that reads `pagelist.bin` one entry at a time. `loadPrintedPageList()` is removed — no code path reserves the full list any more.

2. **Clamp the image-manifest entry count.** `EpubImageManifest::load()` fed a file-read `count` straight into `entries_.reserve(count)` with no validation — the last unguarded instance of this shape (Page.cpp, Section.cpp, TxtReaderActivity already cap their counts). A corrupt/truncated `images.bin` could request megabytes → abort. Now rejects a count that can't fit the remaining file bytes and starts empty (self-heals via `ensureResolved`).

3. **Drop the unused `extractedPath` string from manifest entries.** Written, persisted, and read by nobody (the render path computes its own image-cache filename). Removes one always-heap-allocated `std::string` per resident entry.

4. **Drop the unused ZIP-stat PODs** (`method`/`compressedSize`/`uncompressedSize`/`localHeaderOffset`). Also written/persisted/never read — verified `ImageBlock::ensureExtracted` re-resolves the ZIP by path and never uses a precomputed stat.

After 3+4, `ImageManifestEntry` is `{key, width, height}` — per-entry size roughly halved (tens of KB on image-heavy books), the guarded `entries_` block is smaller, and `images.bin` shrinks on disk. Cache `VERSION` bumped 2 → 4; older caches drop and refill incrementally.
