### PR TITLE
fix: font manager heap exhaustion during TLS handshake

### DIFF
--- a/src/SilentRestart.h
+++ b/src/SilentRestart.h
@@ -9,6 +9,7 @@
 void silentRestart();                 // home screen
 void silentRestartToReader();         // currently-open EPUB (APP_STATE.openEpubPath)
 void silentRestartToClockSettings();  // clock / time settings screen
+void silentRestartToFontManager();    // font download manager (needs pristine heap for TLS)
 
 // One-shot guarded variant for heap-fragmentation recovery: allows only one
 // restart attempt across consecutive silent boots until a non-silent boot

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -24,6 +24,7 @@
 #include "reader/KOReaderSyncActivity.h"
 #include "reader/ReaderActivity.h"
 #include "settings/ClockSettingsActivity.h"
+#include "settings/FontDownloadActivity.h"
 #include "settings/OpdsServerListActivity.h"
 #include "settings/SettingsActivity.h"
 #include "util/FullScreenMessageActivity.h"
@@ -344,6 +345,12 @@ void ActivityManager::goToSettings() { replaceActivity(std::make_unique<Settings
 
 void ActivityManager::goToClockSettings() {
   replaceActivity(std::make_unique<ClockSettingsActivity>(renderer, mappedInput));
+}
+
+void ActivityManager::goToFontManager() {
+  // Only reached via the silent-restart boot target: the freshBoot flag tells
+  // the activity it already has a pristine heap and must not restart again.
+  replaceActivity(std::make_unique<FontDownloadActivity>(renderer, mappedInput, /*freshBoot=*/true));
 }
 
 void ActivityManager::goToFileBrowser(std::string path, std::string focusName) {

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -115,6 +115,7 @@ class ActivityManager {
   void goToSerialTransfer();  // direct entry (also used by the boot-into-transfer path)
   void goToSettings();
   void goToClockSettings();
+  void goToFontManager();  // boot-target entry with pristine heap (see silentRestartToFontManager)
   void goToFileBrowser(std::string path = {}, std::string focusName = {});
   void goToRecentBooks(int focusIndex = -1);
   void goToGlobalBookmarks();

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -19,13 +19,26 @@
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
 
-FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-    : Activity("FontDownload", renderer, mappedInput), fontInstaller_(sdFontSystem.registry()) {}
+FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, bool freshBoot)
+    : Activity("FontDownload", renderer, mappedInput), fontInstaller_(sdFontSystem.registry()), freshBoot_(freshBoot) {}
 
 // --- Lifecycle ---
 
 void FontDownloadActivity::onEnter() {
   Activity::onEnter();
+  if (!freshBoot_) {
+    // Entered from settings: the session heap is too fragmented for the
+    // manifest TLS handshake (observed largest-block ~26KB vs ~36KB needed).
+    // Reboot into the dedicated boot target and re-enter with a clean heap.
+    silentRestartToFontManager();
+    return;  // unreachable after restart; guards the deepSleepInProgress no-op path
+  }
+  if (tryResumeFromMarker()) {
+    // Coming back from a network phase (manifest fetch or download) that ran
+    // with the framebuffer released — show the recorded state directly.
+    requestUpdate();
+    return;
+  }
   WiFi.mode(WIFI_STA);
   startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
                          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
@@ -47,29 +60,68 @@ void FontDownloadActivity::onExit() {
 }
 
 void FontDownloadActivity::onWifiSelectionComplete(const bool success) {
+  wifiUp_ = success;
+
+  if (afterWifi_) {
+    // A list action was confirmed while WiFi was down (post-resume boot).
+    auto continuation = std::move(afterWifi_);
+    afterWifi_ = nullptr;
+    if (success) continuation();
+    // On cancel, stay on the restored family list.
+    return;
+  }
+
   if (!success) {
     finish();
     return;
   }
 
+  runManifestPhase();
+}
+
+void FontDownloadActivity::runManifestPhase() {
   {
     RenderLock lock(*this);
     state_ = LOADING_MANIFEST;
   }
   requestUpdateAndWait();
 
+  // Everything from here on runs without a framebuffer; both branches end in
+  // finishNetworkPhase(), which restarts back into this activity.
+  releaseFramebufferForNetwork();
+
   if (!fetchAndParseManifest()) {
+    downloadingFamilyIndex_ = -1;  // manifest error: nothing to retry per-family
+    pendingErrorAction_ = PendingFontAction::None;
     RenderLock lock(*this);
     state_ = ERROR;
+    finishNetworkPhase(ResumePhase::Error);
     return;
   }
 
-  {
-    RenderLock lock(*this);
-    state_ = FAMILY_LIST;
-    selectedIndex_ = 0;
-    previousActionCount_ = actionCount();
+  selectedIndex_ = 0;
+  finishNetworkPhase(ResumePhase::List);
+}
+
+void FontDownloadActivity::startNetworkAction(std::function<void()> action) {
+  if (wifiUp_) {
+    action();
+    return;
   }
+  afterWifi_ = std::move(action);
+  WiFi.mode(WIFI_STA);
+  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
+                         [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
+}
+
+void FontDownloadActivity::releaseFramebufferForNetwork() {
+  if (framebufferReleased_) return;
+  // The e-ink panel physically retains the frame that displayBuffer() last
+  // committed, so the UI stays visible while the ~48KB buffer is lent to the
+  // TLS stack. No rendering allowed until the finishNetworkPhase() restart.
+  renderer.releaseFrameBuffers();
+  framebufferReleased_ = true;
+  LOG_INF("FONT", "Framebuffer released for network phase");
 }
 
 // --- Manifest fetching ---
@@ -85,6 +137,14 @@ bool FontDownloadActivity::fetchAndParseManifest() {
   if (result != HttpDownloader::OK) {
     LOG_ERR("FONT", "Failed to fetch manifest from %s", FONT_MANIFEST_URL);
     errorMessage_ = "Failed to fetch font list";
+    // Surface the transport failure trail on screen — devices with unusable
+    // USB serial have no other way to report why the fetch failed.
+    const char* detail = HttpDownloader::lastErrorDetail();
+    if (detail[0] != '\0') {
+      errorMessage_ += " [";
+      errorMessage_ += detail;
+      errorMessage_ += "]";
+    }
     Storage.remove(MANIFEST_TMP);
     return false;
   }
@@ -345,23 +405,124 @@ bool FontDownloadActivity::restoreFamiliesFromSd() {
   return true;
 }
 
+// --- Network-phase resume marker ---
+//
+// Network phases run with the framebuffer released (TLS needs the heap) and
+// end in a silent restart back into this activity. The marker carries the UI
+// state across that reboot; families_ travel in the existing stash file.
+//
+// Format (little-endian): u32 magic 'CPFR', u8 phase, u8 pendingErrorAction,
+// u32 selectedIndex, u32 downloadingFamilyIndex, u8 hasResumable,
+// str errorMessage, str downloadingFamilyName (str = u8 len + bytes).
+
+static constexpr const char* RESUME_MARKER_PATH = "/fonts_resume.bin";
+static constexpr uint32_t RESUME_MARKER_MAGIC = 0x52465043;  // 'CPFR'
+
+void FontDownloadActivity::finishNetworkPhase(ResumePhase phase) {
+  // Persist the family list for the fresh instance. stashFamiliesToSd()
+  // clears families_, which is fine — we are about to reboot.
+  if (!families_.empty()) {
+    stashFamiliesToSd();
+  }
+
+  Storage.remove(RESUME_MARKER_PATH);
+  FsFile file;
+  if (Storage.openFileForWrite("FONT", RESUME_MARKER_PATH, file)) {
+    bool ok = writeU32(file, RESUME_MARKER_MAGIC);
+    ok = ok && writeU8(file, static_cast<uint8_t>(phase));
+    ok = ok && writeU8(file, static_cast<uint8_t>(pendingErrorAction_));
+    ok = ok && writeU32(file, static_cast<uint32_t>(selectedIndex_));
+    ok = ok && writeU32(file, static_cast<uint32_t>(downloadingFamilyIndex_));
+    ok = ok && writeU8(file, downloadingFamilyHasResumable_ ? 1 : 0);
+    // writeStr caps at 255 bytes; keep headroom for the u8 length.
+    ok = ok && writeStr(file, errorMessage_.substr(0, 200));
+    ok = ok && writeStr(file, downloadingFamilyName_);
+    // baseUrl_ comes from the manifest and must survive into the boot that
+    // runs the downloads — the file URLs are baseUrl_ + file.name.
+    ok = ok && writeStr(file, baseUrl_);
+    file.flush();
+    file.close();
+    if (!ok) Storage.remove(RESUME_MARKER_PATH);
+  }
+  // Without a marker the fresh instance falls back to the normal WiFi +
+  // manifest flow — degraded but functional, so a failed write is tolerable.
+  silentRestartToFontManager();
+}
+
+bool FontDownloadActivity::tryResumeFromMarker() {
+  FsFile file;
+  if (!Storage.openFileForRead("FONT", RESUME_MARKER_PATH, file)) return false;
+
+  uint32_t magic = 0, sel = 0, dlIdx = 0;
+  uint8_t phase = 0, pending = 0, resumable = 0;
+  std::string err, famName, baseUrl;
+  bool ok = readU32(file, magic) && magic == RESUME_MARKER_MAGIC;
+  ok = ok && readU8(file, phase) && readU8(file, pending);
+  ok = ok && readU32(file, sel) && readU32(file, dlIdx) && readU8(file, resumable);
+  ok = ok && readStr(file, err) && readStr(file, famName);
+  ok = ok && readStr(file, baseUrl);
+  file.close();
+  Storage.remove(RESUME_MARKER_PATH);  // one-shot: never resume twice
+
+  if (!ok || phase == 0 || phase > static_cast<uint8_t>(ResumePhase::Error)) return false;
+
+  // A missing/corrupt stash degrades to an empty list ("No fonts available");
+  // the marker state is still worth showing (e.g. a manifest fetch error).
+  restoreFamiliesFromSd();
+
+  selectedIndex_ = static_cast<int>(sel);
+  downloadingFamilyIndex_ = static_cast<int>(dlIdx);
+  downloadingFamilyHasResumable_ = resumable != 0;
+  pendingErrorAction_ = pending <= static_cast<uint8_t>(PendingFontAction::Delete)
+                            ? static_cast<PendingFontAction>(pending)
+                            : PendingFontAction::None;
+  errorMessage_ = std::move(err);
+  downloadingFamilyName_ = std::move(famName);
+  baseUrl_ = std::move(baseUrl);
+  previousActionCount_ = actionCount();
+  if (selectedIndex_ >= listItemCount()) selectedIndex_ = std::max(0, listItemCount() - 1);
+
+  RenderLock lock(*this);
+  switch (static_cast<ResumePhase>(phase)) {
+    case ResumePhase::List:
+      state_ = FAMILY_LIST;
+      break;
+    case ResumePhase::Complete:
+      state_ = COMPLETE;
+      break;
+    case ResumePhase::Error:
+      state_ = ERROR;
+      break;
+    default:
+      return false;
+  }
+  LOG_DBG("FONT", "Resumed post-network phase %u with %zu families", phase, families_.size());
+  return true;
+}
+
 // --- Download ---
 
 void FontDownloadActivity::downloadAll() {
   cancelRequested_ = false;
-  // Snapshot indices upfront because downloadFamily() stashes/restores
-  // families_ — indices remain valid as long as we don't sort or splice it.
   std::vector<int> targetIndices;
   for (size_t i = 0; i < families_.size(); i++) {
     if (!families_[i].installed) targetIndices.push_back(static_cast<int>(i));
   }
+  if (targetIndices.empty()) return;
+
   for (int idx : targetIndices) {
-    downloadFamily(idx);
-    if (state_ == ERROR || cancelRequested_) return;
+    if (!downloadOne(idx)) {
+      // ERROR keeps its state for the marker; cancel goes back to the list.
+      finishNetworkPhase(state_ == ERROR ? ResumePhase::Error : ResumePhase::List);
+      return;
+    }
   }
 
-  RenderLock lock(*this);
-  state_ = COMPLETE;
+  {
+    RenderLock lock(*this);
+    state_ = COMPLETE;
+  }
+  finishNetworkPhase(ResumePhase::Complete);
 }
 
 void FontDownloadActivity::updateAll() {
@@ -370,13 +531,20 @@ void FontDownloadActivity::updateAll() {
   for (size_t i = 0; i < families_.size(); i++) {
     if (families_[i].installed && families_[i].hasUpdate) targetIndices.push_back(static_cast<int>(i));
   }
+  if (targetIndices.empty()) return;
+
   for (int idx : targetIndices) {
-    downloadFamily(idx);
-    if (state_ == ERROR || cancelRequested_) return;
+    if (!downloadOne(idx)) {
+      finishNetworkPhase(state_ == ERROR ? ResumePhase::Error : ResumePhase::List);
+      return;
+    }
   }
 
-  RenderLock lock(*this);
-  state_ = COMPLETE;
+  {
+    RenderLock lock(*this);
+    state_ = COMPLETE;
+  }
+  finishNetworkPhase(ResumePhase::Complete);
 }
 
 size_t FontDownloadActivity::totalUninstalledSize() const {
@@ -431,17 +599,16 @@ bool FontDownloadActivity::hasUpdateCandidates() const {
   return false;
 }
 
-void FontDownloadActivity::downloadFamily(int familyIdx) {
+bool FontDownloadActivity::downloadOne(int familyIdx) {
   if (familyIdx < 0 || familyIdx >= static_cast<int>(families_.size())) {
-    LOG_ERR("FONT", "downloadFamily: invalid index %d (size %zu)", familyIdx, families_.size());
-    return;
+    LOG_ERR("FONT", "downloadOne: invalid index %d (size %zu)", familyIdx, families_.size());
+    return false;
   }
 
-  // Snapshot the target family by value, then stash + free families_ so the
-  // ~10 KB of scattered std::string allocations don't fragment the heap
-  // during the TLS handshake. Render-path caches (downloadingFamilyName_,
-  // downloadingFamilyHasResumable_) cover the family-name and Resume-label
-  // accesses that previously read families_ during DOWNLOADING/ERROR.
+  // Snapshot the target family by value: the impl mutates the copy and the
+  // results are merged back below. With the framebuffer released there is no
+  // need to stash families_ for heap headroom — the freed ~48KB dwarfs the
+  // ~10KB the list occupies.
   ManifestFamily family = families_[familyIdx];
   downloadingFamilyName_ = family.name;
   downloadingFamilyHasResumable_ = family.hasResumableDownload;
@@ -456,42 +623,43 @@ void FontDownloadActivity::downloadFamily(int familyIdx) {
     fileProgress_ = 0;
     fileTotal_ = 0;
   }
-  requestUpdateAndWait();
+  // The last render before the buffer is lent to TLS: the progress screen
+  // stays on the panel for the whole download (e-ink retains it for free).
+  if (!framebufferReleased_) requestUpdateAndWait();
+  releaseFramebufferForNetwork();
 
-  if (!stashFamiliesToSd()) {
-    RenderLock lock(*this);
-    state_ = ERROR;
-    pendingErrorAction_ = PendingFontAction::Download;
-    errorMessage_ = "Failed to stash manifest";
-    return;
-  }
-
-  // Run the actual download with families_ empty (defragmented heap).
   downloadFamilyImpl(family, familyIdx);
 
-  // Update cached render state from the impl's mutations.
   downloadingFamilyHasResumable_ = family.hasResumableDownload;
+  families_[familyIdx].installed = family.installed;
+  families_[familyIdx].hasUpdate = family.hasUpdate;
+  families_[familyIdx].hasResumableDownload = family.hasResumableDownload;
+  syncSelectedIndexForNewActionCount();
 
-  // Restore families_ regardless of success/error/abort outcome, then merge
-  // back the mutations the impl made on the local family copy. Without the
-  // restored manifest the activity can't render the family list, so a failed
-  // restore is fatal — drop to ERROR rather than continuing with empty state.
-  if (!restoreFamiliesFromSd()) {
-    RenderLock lock(*this);
-    state_ = ERROR;
-    pendingErrorAction_ = PendingFontAction::Download;
-    errorMessage_ = "Failed to restore manifest";
+  return state_ != ERROR && !cancelRequested_;
+}
+
+void FontDownloadActivity::downloadFamily(int familyIdx) {
+  if (!downloadOne(familyIdx)) {
+    finishNetworkPhase(state_ == ERROR ? ResumePhase::Error : ResumePhase::List);
     return;
   }
-  if (familyIdx >= 0 && familyIdx < static_cast<int>(families_.size())) {
-    families_[familyIdx].installed = family.installed;
-    families_[familyIdx].hasUpdate = family.hasUpdate;
-    families_[familyIdx].hasResumableDownload = family.hasResumableDownload;
-  }
-  syncSelectedIndexForNewActionCount();
+  // impl leaves state_ == COMPLETE on success.
+  finishNetworkPhase(state_ == COMPLETE ? ResumePhase::Complete : ResumePhase::List);
 }
 
 void FontDownloadActivity::downloadFamilyImpl(ManifestFamily& family, int familyIdx) {
+  if (baseUrl_.empty()) {
+    // Guards a resume marker written before baseUrl_ was persisted (or a
+    // corrupt one): without the prefix every file URL would be relative junk.
+    LOG_ERR("FONT", "downloadFamilyImpl: empty baseUrl");
+    RenderLock lock(*this);
+    state_ = ERROR;
+    pendingErrorAction_ = PendingFontAction::Download;
+    downloadingFamilyIndex_ = familyIdx;
+    errorMessage_ = "Missing base URL - reopen font manager";
+    return;
+  }
   // httpSession_ does the TLS handshake on its first downloadToFile call;
   // subsequent files reuse the open keep-alive connection. If the server
   // dropped the connection during the idle gap (user browsing the family
@@ -528,7 +696,7 @@ void FontDownloadActivity::downloadFamilyImpl(ManifestFamily& family, int family
       lastProgressPercent_ = -1;
       lastProgressUpdateMs_ = 0;
     }
-    requestUpdateAndWait();
+    if (!framebufferReleased_) requestUpdateAndWait();
 
     std::string localFilename = file.name;
     std::string familyPrefix = family.name + "/";
@@ -589,7 +757,7 @@ void FontDownloadActivity::downloadFamilyImpl(ManifestFamily& family, int family
           }
           const bool percentChanged = percent != lastProgressPercent_;
           const bool timeElapsed = lastProgressUpdateMs_ == 0 || now - lastProgressUpdateMs_ > 2000;
-          if ((percentChanged && timeElapsed) || downloaded == total) {
+          if (((percentChanged && timeElapsed) || downloaded == total) && !framebufferReleased_) {
             requestUpdate(true);
             lastProgressPercent_ = percent;
             lastProgressUpdateMs_ = now;
@@ -620,6 +788,12 @@ void FontDownloadActivity::downloadFamilyImpl(ManifestFamily& family, int family
       pendingErrorAction_ = PendingFontAction::Download;
       downloadingFamilyIndex_ = familyIdx;
       errorMessage_ = "Download failed: " + file.name;
+      const char* detail = HttpDownloader::lastErrorDetail();
+      if (detail[0] != '\0') {
+        errorMessage_ += " [";
+        errorMessage_ += detail;
+        errorMessage_ += "]";
+      }
       return;
     }
 
@@ -776,6 +950,28 @@ std::string FontDownloadActivity::confirmButtonLabel() const {
 
 // --- Input handling ---
 
+void FontDownloadActivity::onConfirmFromList() {
+  if (families_.empty()) return;
+
+  if (isDownloadAllSelected()) {
+    startNetworkAction([this] { downloadAll(); });
+    return;
+  }
+  if (isUpdateAllSelected()) {
+    startNetworkAction([this] { updateAll(); });
+    return;
+  }
+
+  const int familyIndex = familyIndexFromList(selectedIndex_);
+  const auto& family = families_[familyIndex];
+  if (family.installed && !family.hasUpdate) {
+    // Deleting is SD-only — no WiFi, no framebuffer gymnastics.
+    promptDeleteFamily(familyIndex);
+    return;
+  }
+  startNetworkAction([this, familyIndex] { downloadFamily(familyIndex); });
+}
+
 void FontDownloadActivity::loop() {
   if (state_ == FAMILY_LIST) {
     syncSelectedIndexForNewActionCount();
@@ -788,24 +984,7 @@ void FontDownloadActivity::loop() {
     buttonNavigator_.onPreviousList(selectedIndex_, listItemCount(), [this] { requestUpdate(); });
 
     if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-      if (!families_.empty()) {
-        if (isDownloadAllSelected()) {
-          downloadAll();
-          requestUpdateAndWait();
-        } else if (isUpdateAllSelected()) {
-          updateAll();
-          requestUpdateAndWait();
-        } else {
-          const int familyIndex = familyIndexFromList(selectedIndex_);
-          const auto& family = families_[familyIndex];
-          if (family.installed && !family.hasUpdate) {
-            promptDeleteFamily(familyIndex);
-          } else {
-            downloadFamily(familyIndex);
-            requestUpdateAndWait();
-          }
-        }
-      }
+      onConfirmFromList();
     }
   } else if (state_ == COMPLETE) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
@@ -827,10 +1006,14 @@ void FontDownloadActivity::loop() {
       if (downloadingFamilyIndex_ >= 0 && downloadingFamilyIndex_ < static_cast<int>(families_.size())) {
         if (pendingErrorAction_ == PendingFontAction::Delete) {
           deleteFamilyAtIndex(downloadingFamilyIndex_);
+          requestUpdateAndWait();
         } else {
-          downloadFamily(downloadingFamilyIndex_);
+          const int retryIndex = downloadingFamilyIndex_;
+          startNetworkAction([this, retryIndex] { downloadFamily(retryIndex); });
         }
-        requestUpdateAndWait();
+      } else if (families_.empty() && pendingErrorAction_ == PendingFontAction::None) {
+        // Manifest fetch failed: retry the whole fetch (reconnecting WiFi first).
+        startNetworkAction([this] { runManifestPhase(); });
       } else {
         {
           RenderLock lock(*this);
@@ -857,6 +1040,11 @@ std::string FontDownloadActivity::formatSize(size_t bytes) {
 }
 
 void FontDownloadActivity::render(RenderLock&&) {
+  // The framebuffer is lent to the TLS stack during network phases; any
+  // render attempt would dereference a null buffer. Phases end in a restart,
+  // so this can only trigger on a stray update request — drop it.
+  if (framebufferReleased_) return;
+
   const auto& metrics = UITheme::getInstance().getMetrics();
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
@@ -956,7 +1144,30 @@ void FontDownloadActivity::render(RenderLock&&) {
     renderer.drawCenteredText(UI_10_FONT_ID, centerY - lineHeight, tr(STR_FONT_INSTALL_FAILED), true,
                               EpdFontFamily::BOLD);
     if (!errorMessage_.empty()) {
-      renderer.drawCenteredText(UI_10_FONT_ID, centerY + metrics.verticalSpacing, errorMessage_.c_str());
+      // Greedy word-wrap: the message can carry a transport-failure trail
+      // (see HttpDownloader::lastErrorDetail) that overflows one line, and a
+      // truncated error code is useless for remote diagnosis.
+      const int maxWidth = pageWidth - metrics.contentSidePadding * 2;
+      int y = centerY + metrics.verticalSpacing;
+      std::string line;
+      size_t pos = 0;
+      while (pos < errorMessage_.size()) {
+        size_t space = errorMessage_.find(' ', pos);
+        if (space == std::string::npos) space = errorMessage_.size();
+        const std::string word = errorMessage_.substr(pos, space - pos);
+        const std::string candidate = line.empty() ? word : line + " " + word;
+        if (!line.empty() && renderer.getTextWidth(UI_10_FONT_ID, candidate.c_str()) > maxWidth) {
+          renderer.drawCenteredText(UI_10_FONT_ID, y, line.c_str());
+          y += lineHeight;
+          line = word;
+        } else {
+          line = candidate;
+        }
+        pos = space + 1;
+      }
+      if (!line.empty()) {
+        renderer.drawCenteredText(UI_10_FONT_ID, y, line.c_str());
+      }
     }
     // Use the cached value: families_ may have just been restored (post-impl)
     // or still empty (if the failure was in the stash itself); either way the

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -693,10 +693,7 @@ void FontDownloadActivity::downloadFamilyImpl(ManifestFamily& family, int family
       currentFileIndex_ = i;
       fileProgress_ = 0;
       fileTotal_ = file.size;
-      lastProgressPercent_ = -1;
-      lastProgressUpdateMs_ = 0;
     }
-    if (!framebufferReleased_) requestUpdateAndWait();
 
     std::string localFilename = file.name;
     std::string familyPrefix = family.name + "/";
@@ -744,25 +741,14 @@ void FontDownloadActivity::downloadFamilyImpl(ManifestFamily& family, int family
 
     std::string url = baseUrl_ + file.name;
 
+    // No rendering from here: the framebuffer is lent to the TLS stack. The
+    // callback only tracks progress for logs and polls the Back button so
+    // the user can still cancel mid-transfer.
     auto result = HttpDownloader::downloadToFile(
         httpSession_, url, stagedPath, [this](unsigned int downloaded, unsigned int total) {
           mappedInput.update();
           fileProgress_ = downloaded;
           fileTotal_ = total;
-
-          const unsigned long now = millis();
-          int percent = 0;
-          if (total > 0) {
-            percent = static_cast<int>((static_cast<unsigned long long>(downloaded) * 100ULL + total / 2) / total);
-          }
-          const bool percentChanged = percent != lastProgressPercent_;
-          const bool timeElapsed = lastProgressUpdateMs_ == 0 || now - lastProgressUpdateMs_ > 2000;
-          if (((percentChanged && timeElapsed) || downloaded == total) && !framebufferReleased_) {
-            requestUpdate(true);
-            lastProgressPercent_ = percent;
-            lastProgressUpdateMs_ = now;
-          }
-
           return !mappedInput.wasPressed(MappedInputManager::Button::Back);
         });
 
@@ -1113,26 +1099,12 @@ void FontDownloadActivity::render(RenderLock&&) {
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     }
   } else if (state_ == DOWNLOADING) {
-    // families_ is stashed to SD during downloadFamily(); read the cached
-    // name instead of indexing families_.
-    std::string statusText = std::string(tr(STR_DOWNLOADING)) + " " + downloadingFamilyName_ + " (" +
-                             std::to_string(currentFileIndex_ + 1) + "/" + std::to_string(currentFileTotal_) + ")";
+    // This screen renders exactly once: the framebuffer is released for the
+    // TLS/download work right after, so the panel holds this frame until the
+    // post-download restart. No progress bar — a bar frozen at 0% reads as a
+    // hang, a static message reads as work in progress.
+    std::string statusText = std::string(tr(STR_DOWNLOADING)) + " " + downloadingFamilyName_;
     renderer.drawCenteredText(UI_10_FONT_ID, centerY - lineHeight, statusText.c_str());
-
-    float progress = 0;
-    if (fileTotal_ > 0) {
-      progress = static_cast<float>(fileProgress_) / static_cast<float>(fileTotal_);
-    }
-
-    int barY = centerY + metrics.verticalSpacing;
-    GUI.drawProgressBar(
-        renderer,
-        Rect{metrics.contentSidePadding, barY, pageWidth - metrics.contentSidePadding * 2, metrics.progressBarHeight},
-        static_cast<int>(progress * 100), 100);
-
-    int percentY = barY + metrics.progressBarHeight + metrics.verticalSpacing;
-    renderer.drawCenteredText(UI_10_FONT_ID, percentY,
-                              (std::to_string(static_cast<int>(progress * 100)) + "%").c_str());
 
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -15,7 +16,11 @@
 
 class FontDownloadActivity : public Activity {
  public:
-  explicit FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput);
+  // freshBoot: true only when entered via the silent-restart boot target
+  // (ActivityManager::goToFontManager). Any other entry restarts into that
+  // target first — the manifest TLS handshake needs ~36KB contiguous heap,
+  // which only a fresh boot reliably provides. Mirrors the onExit restart.
+  explicit FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, bool freshBoot = false);
 
   void onEnter() override;
   void onExit() override;
@@ -92,20 +97,59 @@ class FontDownloadActivity : public Activity {
   PendingFontAction pendingErrorAction_ = PendingFontAction::None;
   std::string errorMessage_;
   bool cancelRequested_ = false;
+  bool freshBoot_ = false;
+  // True while the display framebuffer is lent to the TLS stack. The RSA
+  // handshake peaks around ~50KB against ~54KB free-after-WiFi on low-heap
+  // devices; the released 48KB buffer is the difference between
+  // MBEDTLS_ERR_X509_*ALLOC failures and a clean handshake. The e-ink panel
+  // physically retains the last frame, so the UI stays visible. While set,
+  // nothing may render, and every code path must end in finishNetworkPhase()
+  // (which reboots to re-arm the display).
+  bool framebufferReleased_ = false;
+  // WiFi only survives within one boot; after a marker resume it is down
+  // until the next network action re-runs WifiSelectionActivity.
+  bool wifiUp_ = false;
+  // One-shot continuation invoked after a successful WiFi (re)connect, set
+  // when a network action is confirmed while WiFi is down.
+  std::function<void()> afterWifi_;
   int previousActionCount_ = 0;
   int lastProgressPercent_ = -1;
   unsigned long lastProgressUpdateMs_ = 0;
 
+  // Phase persisted across the mid-flow silent restarts. Network work runs
+  // with the framebuffer released; the restart re-arms the display and the
+  // fresh instance resumes into the recorded state via tryResumeFromMarker().
+  enum class ResumePhase : uint8_t { None = 0, List = 1, Complete = 2, Error = 3 };
+
   void onWifiSelectionComplete(bool success);
   bool fetchAndParseManifest();
-  // Download a single family by its index into families_. Internally stashes
-  // families_ to SD so the TLS handshake runs on a defragmented heap; the
-  // selected family's state mutations (installed/hasUpdate/hasResumableDownload)
-  // are merged back into families_ on return.
+  // Render the loading screen, release the framebuffer, fetch + stash the
+  // manifest, then restart into the family list (or the error screen).
+  void runManifestPhase();
+  // Run `action` now if WiFi is up, otherwise after WifiSelectionActivity.
+  void startNetworkAction(std::function<void()> action);
+  // Confirm dispatch for the family list (delete needs no network).
+  void onConfirmFromList();
+  // Release both display buffers to give the TLS stack the ~48KB it is short
+  // of. No rendering allowed afterwards; ends with a finishNetworkPhase().
+  void releaseFramebufferForNetwork();
+  // Stash families_ + write the resume marker, then silent-restart back into
+  // the font manager. Never returns during normal operation.
+  void finishNetworkPhase(ResumePhase phase);
+  // Restore state from a resume marker left by finishNetworkPhase().
+  // Returns false when there is no (valid) marker.
+  bool tryResumeFromMarker();
+  // Download a single family by its index into families_, with the
+  // framebuffer released for TLS heap headroom. Ends in finishNetworkPhase()
+  // (i.e. a restart); never returns to the caller's flow.
   void downloadFamily(int familyIdx);
-  // Internal: the body of downloadFamily after the stash. Operates only on
-  // the local family copy and constants like familyIdx; never touches
-  // families_ (which is empty during this call).
+  // Shared per-family body for downloadFamily/downloadAll/updateAll: sets up
+  // progress state (rendering only while the framebuffer is still armed),
+  // releases the framebuffer, runs the impl and merges the family's mutations
+  // back into families_. Returns false on error/cancel (state_ tells which).
+  bool downloadOne(int familyIdx);
+  // Internal: the download/verify/activate body. Operates on the local family
+  // copy; runs with the framebuffer released, so it must not render.
   void downloadFamilyImpl(ManifestFamily& family, int familyIdx);
   void downloadAll();
   void updateAll();

--- a/src/activities/settings/FontDownloadActivity.h
+++ b/src/activities/settings/FontDownloadActivity.h
@@ -113,8 +113,6 @@ class FontDownloadActivity : public Activity {
   // when a network action is confirmed while WiFi is down.
   std::function<void()> afterWifi_;
   int previousActionCount_ = 0;
-  int lastProgressPercent_ = -1;
-  unsigned long lastProgressUpdateMs_ = 0;
 
   // Phase persisted across the mid-flow silent restarts. Network work runs
   // with the framebuffer released; the restart re-arms the display and the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,6 +158,12 @@ constexpr uint32_t SILENT_REBOOT_TARGET_SERIAL_TRANSFER = 2;
 // Boot into the clock settings screen after a timezone-detection WiFi session
 // (WiFi teardown fragments the heap; need a clean reboot before re-entering the UI).
 constexpr uint32_t SILENT_REBOOT_TARGET_CLOCK_SETTINGS = 3;
+// Boot straight into the font manager. Entered-from-settings sessions restart
+// into this target first: the TLS handshake for the manifest fetch needs ~36KB
+// of contiguous heap, which a session that has been through settings/home
+// navigation can no longer offer (observed largest-block ~26KB →
+// MBEDTLS_ERR_SSL_ALLOC_FAILED). A fresh boot makes the handshake reliable.
+constexpr uint32_t SILENT_REBOOT_TARGET_FONT_MANAGER = 4;
 constexpr uint32_t HEAP_RECOVERY_RESTART_LATCH_MAGIC = 0x48EA9C01;
 
 // How the device is coming back to life, resolved once at boot. Both resume
@@ -205,6 +211,16 @@ void silentRestartToClockSettings() {
   silentRebootTarget = SILENT_REBOOT_TARGET_CLOCK_SETTINGS;
   silentRebootMagic = SILENT_REBOOT_MAGIC;
   LOG_DBG("MAIN", "Silent restart (target=clock-settings)");
+  delay(50);
+  ESP.restart();
+}
+
+void silentRestartToFontManager() {
+  if (deepSleepInProgress) return;
+  globalReadingSessionTracker().end();
+  silentRebootTarget = SILENT_REBOOT_TARGET_FONT_MANAGER;
+  silentRebootMagic = SILENT_REBOOT_MAGIC;
+  LOG_DBG("MAIN", "Silent restart (target=font-manager)");
   delay(50);
   ESP.restart();
 }
@@ -515,7 +531,7 @@ void setup() {
   // Bound the target range too — RTC_NOINIT memory is uninitialized on cold boot.
   const bool isSilentReboot = (silentRebootMagic == SILENT_REBOOT_MAGIC);
   const uint32_t silentRebootTargetSnapshot =
-      (isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_CLOCK_SETTINGS) ? silentRebootTarget : 0;
+      (isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_FONT_MANAGER) ? silentRebootTarget : 0;
   silentRebootMagic = 0;
   silentRebootTarget = 0;
   if (!isSilentReboot) {
@@ -741,6 +757,8 @@ void setup() {
     activityManager.goToReader(APP_STATE.openEpubPath);
   } else if (resume == BootResume::Silent && silentRebootTargetSnapshot == SILENT_REBOOT_TARGET_CLOCK_SETTINGS) {
     activityManager.goToClockSettings();
+  } else if (resume == BootResume::Silent && silentRebootTargetSnapshot == SILENT_REBOOT_TARGET_FONT_MANAGER) {
+    activityManager.goToFontManager();
   } else if (resume == BootResume::Silent) {
     // target == home (or reader with no open book): land on home — don't fall
     // through to the sleep-wake "resume reader" logic, which fires on stale

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -7,6 +7,7 @@
 #include <esp_heap_caps.h>
 #include <esp_http_client.h>
 
+#include <cstdarg>
 #include <cstring>
 #include <functional>
 #include <memory>
@@ -84,6 +85,26 @@ constexpr const char SECTIGO_GITHUB_DV_E36_PEM[] =
     "zzuqQhFkoJ2UOQIReVx7Hfpkue4WQrO/isIJxOzksU0CMQDpKmFHjFJKS04YcPbW\n"
     "RNZu9YO6bVi9JNlWSOrvxKJGgYhqOkbRqZtNyWHa0V1Xahg=\n"
     "-----END CERTIFICATE-----\n";
+
+// Short failure trail for the most recent one-shot/session download, e.g.
+// "open:0x7002 tls=-0x2700 f=0x0 H=54k L=47k". Static buffer: no heap, safe
+// to read from UI code after a failed call. Reset per download, appended to
+// by each failed attempt (primary + retries). Exists because some devices
+// have unusable USB serial — the on-screen trail is the only diagnostics.
+char s_lastErrorDetail[96] = {0};
+void resetLastErrorDetail() { s_lastErrorDetail[0] = '\0'; }
+void appendLastErrorDetail(const char* fmt, ...) {
+  size_t used = strlen(s_lastErrorDetail);
+  if (used > 0 && used < sizeof(s_lastErrorDetail) - 2) {
+    s_lastErrorDetail[used++] = ' ';
+    s_lastErrorDetail[used] = '\0';
+  }
+  if (used >= sizeof(s_lastErrorDetail) - 1) return;
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(s_lastErrorDetail + used, sizeof(s_lastErrorDetail) - used, fmt, args);
+  va_end(args);
+}
 
 std::string extractHostFromUrl(const std::string& url) {
   size_t schemeEnd = url.find("://");
@@ -263,6 +284,8 @@ HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& 
         "open failed: %s (tls_code=-0x%04x, tls_flags=0x%08x, t=%lums, heap=%u, largest=%u, minHeap=%u, minLargest=%u)",
         esp_err_to_name(err), -tlsCode, tlsFlags, millis() - startMs, esp_get_free_heap_size(),
         heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT), minFree, minLargest);
+    appendLastErrorDetail("open:0x%x tls=-0x%04x f=0x%x H=%uk L=%uk", err, -tlsCode, tlsFlags,
+                          static_cast<unsigned>(minFree / 1024), static_cast<unsigned>(minLargest / 1024));
     return HttpDownloader::HTTP_ERROR;
   }
   logPhase("open_ok");
@@ -276,6 +299,7 @@ HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& 
     err = esp_http_client_open(client, 0);
     if (err != ESP_OK) {
       LOG_ERR("HTTP", "redirect open failed: %s", esp_err_to_name(err));
+      appendLastErrorDetail("redir:0x%x", err);
       return HttpDownloader::HTTP_ERROR;
     }
     contentLength = esp_http_client_fetch_headers(client);
@@ -284,6 +308,7 @@ HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& 
 
   if (status != 200) {
     LOG_ERR("HTTP", "unexpected status: %d", status);
+    appendLastErrorDetail("status:%d", status);
     return HttpDownloader::HTTP_ERROR;
   }
 
@@ -301,6 +326,7 @@ HttpDownloader::DownloadError performGet(esp_http_client_handle_t client, Sink& 
     sampleHeap();
     if (read < 0) {
       LOG_ERR("HTTP", "read error after %zu bytes", sink.downloaded);
+      appendLastErrorDetail("read@%u", static_cast<unsigned>(sink.downloaded));
       return HttpDownloader::HTTP_ERROR;
     }
     if (read == 0) break;  // all data received
@@ -345,6 +371,7 @@ void logPreCallContext(const std::string& url) {
 // the reusable variant that keeps the TLS handshake alive across files.
 HttpDownloader::DownloadError runGet(const std::string& url, const std::string& username, const std::string& password,
                                      Sink& sink) {
+  resetLastErrorDetail();
   logPreCallContext(url);
 
   if (needsGithubComPin(url)) {
@@ -471,6 +498,7 @@ bool initSessionClient(HttpDownloader::Session::Impl* impl, const std::string& u
 
 HttpDownloader::DownloadError runGetOnSession(HttpDownloader::Session& session, const std::string& url,
                                               const std::string& username, const std::string& password, Sink& sink) {
+  resetLastErrorDetail();
   auto* impl = session.impl();
 
   if (impl->client == nullptr) {
@@ -622,3 +650,5 @@ HttpDownloader::DownloadError HttpDownloader::downloadToFile(Session& session, c
   const DownloadError result = runGetOnSession(session, url, username, password, sink);
   return finishFileDownload(result, destPath, file, sink.downloaded);
 }
+
+const char* HttpDownloader::lastErrorDetail() { return s_lastErrorDetail; }

--- a/src/network/HttpDownloader.h
+++ b/src/network/HttpDownloader.h
@@ -92,4 +92,13 @@ class HttpDownloader {
   static DownloadError downloadToFile(Session& session, const std::string& url, const std::string& destPath,
                                       ProgressCallback progress = nullptr, const std::string& username = "",
                                       const std::string& password = "");
+
+  /**
+   * Short failure trail of the most recent download call, e.g.
+   * "open:0x7002 tls=-0x2700 f=0x0 H=54k L=47k" (one segment per failed
+   * attempt, including retries). Empty string if the last call succeeded.
+   * Static storage — valid until the next download call. Lets activities
+   * surface a diagnosable code on screen when serial logs aren't reachable.
+   */
+  static const char* lastErrorDetail();
 };


### PR DESCRIPTION
The font manager kept failing with "Failed to fetch font list" on my X4 even after
#62 — that fixed a second, separate bug. The real cause here is heap, not
certificates: the TLS handshake to raw.githubusercontent.com peaks around ~50 KB,
and my device has ~54 KB free once WiFi is up (~100 KB at idle). mbedtls then dies
inside X509 with -0x2700 and empty verify flags, or -0x2880 / -0x3000 depending on
which allocation fails first,  the same "internal alloc failure" signature already
documented in the stash notes in FontDownloadActivity. I ruled out certs, clock and
hardware crypto by testing pinned ISRG X1, pinned Root YR, a pinned YR2
intermediate, the full crt_bundle, forced SNTP and a software-MPI build: all fail
identically. (USB is dead on my unit, so all of this was debugged with error codes
printed on the failure screen, that's the first commit.)

The fix: lend the display framebuffer (48 KB in one contiguous block) to the TLS
stack during the font manager's network phases. The e-ink panel retains the last
frame, so the UI stays visible. Each phase ends in a silent restart via a new boot
target (the activity already restarts on exit for the same heap reasons), with the
family list carried across the reboot in the existing stash file plus a small
resume marker (selection, error state, baseUrl). With the buffer released the
handshake gets ~100 KB instead of ~54 KB, and HttpDownloader's TLS setup needed no
changes at all, the stock X1 pin verifies fine once it has room.

UI consequence: since the panel can't update while the buffer is lent out, the
download screen now shows a static "Downloading... <family>" message instead of a
progress bar. A bar frozen at 0% for the whole transfer read as a hang; a static
message reads as work in progress. Cancel via Back still works mid-transfer (the
progress callback keeps polling input). No new strings,  STR_DOWNLOADING already
exists in all translations.

I did consider making this opt-in behind something like a "memory safe" setting,
so devices with more headroom keep the live progress bar. I decided against it:
it adds a second code path to maintain, and a toggle the user can only reason
about by understanding heap internals feels like exactly the kind of surface
SCOPE.md tries to avoid. One deterministic flow that works on every device seemed
more in the spirit of the project. Happy to revisit if you'd rather have the
toggle.

For the record, the unit I validated on is an X4 bought from AliExpress, they
supposedly can differ slightly from manufacturer-direct ones. I can't say whether
that's why mine sits closer to the heap limit, but whether the font manager works
today clearly depends on how much free heap a device happens to have, and this
makes the flow safe regardless.

Tested end to end on my device: manifest fetch, single download, download all,
resume after cancel, and the error paths.

The first commit adds HttpDownloader::lastErrorDetail(): a static, heap-free
failure trail ("open:0x7002 tls=-0x2700 f=0x0 H=54k L=47k") shown on the font
manager's failure screens. It's how this bug was found, and it makes future
reports diagnosable from devices without working serial.
