### PR TITLE
perf: buffer EPUB cache I/O to cut first-open time on large books

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -31,10 +31,18 @@ bool BookMetadataCache::beginContentOpfPass() {
   LOG_DBG("BMC", "Beginning content opf pass");
 
   // Open spine file for writing
-  return Storage.openFileForWrite("BMC", cachePath + tmpSpineBinFile, spineFile);
+  if (!Storage.openFileForWrite("BMC", cachePath + tmpSpineBinFile, spineFile)) {
+    return false;
+  }
+  spineWriter_.emplace(spineFile);
+  return true;
 }
 
 bool BookMetadataCache::endContentOpfPass() {
+  if (spineWriter_.has_value()) {
+    spineWriter_->flush();
+    spineWriter_.reset();
+  }
   spineFile.close();
   return true;
 }
@@ -49,14 +57,16 @@ bool BookMetadataCache::beginTocPass() {
     spineFile.close();
     return false;
   }
+  tocWriter_.emplace(tocFile);
 
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
     spineHrefIndex.clear();
     spineHrefIndex.resize(spineCount);
     spineFile.seek(0);
+    serialization::BufferedFileReader spineReader(spineFile);
     SpineEntry scratch;
     for (int i = 0; i < spineCount; i++) {
-      readSpineEntry(spineFile, scratch);
+      readSpineEntry(spineReader, scratch);
       SpineHrefIndexEntry idx;
       idx.hrefHash = HashUtils::fnvHash64(scratch.href);
       idx.hrefLen = static_cast<uint16_t>(scratch.href.size());
@@ -83,6 +93,7 @@ bool BookMetadataCache::resetTocPassOutput() {
     return false;
   }
 
+  tocWriter_.reset();  // discard buffered records from the abandoned parse
   if (tocFile) {
     tocFile.close();
   }
@@ -91,6 +102,7 @@ bool BookMetadataCache::resetTocPassOutput() {
     LOG_ERR("BMC", "Could not reopen TOC temp file for reset");
     return false;
   }
+  tocWriter_.emplace(tocFile);
 
   tocCount = 0;
   LOG_DBG("BMC", "Reset TOC temp output for fallback parse");
@@ -98,6 +110,10 @@ bool BookMetadataCache::resetTocPassOutput() {
 }
 
 bool BookMetadataCache::endTocPass() {
+  if (tocWriter_.has_value()) {
+    tocWriter_->flush();
+    tocWriter_.reset();
+  }
   tocFile.close();
   spineFile.close();
 
@@ -147,23 +163,32 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   const uint32_t lutSize = sizeof(uint32_t) * spineCount + sizeof(uint32_t) * tocCount;
   const uint32_t lutOffset = headerASize + metadataSize;
 
+  // Buffered views for the whole compile: the loops below issue tens of thousands of tiny
+  // field reads/writes (measured 22.6 s of pure FsFile call overhead for a 1732-spine book);
+  // batching them into 4 KB transfers is the entire fix. 3 x 4 KB heap for the duration of
+  // the build only — inside the first-open released-framebuffer window. Each wrapper
+  // degrades to pass-through if its buffer cannot be allocated.
+  serialization::BufferedFileWriter bookWriter(bookFile);
+  serialization::BufferedFileReader spineReader(spineFile);
+  serialization::BufferedFileReader tocReader(tocFile);
+
   // Header A. tocReliable is patched at the end once the TOC scan below has computed it.
   const uint32_t tocReliableHeaderPos =
       sizeof(BOOK_CACHE_VERSION) + sizeof(uint32_t) /* lutOffset */ + sizeof(spineCount) + sizeof(tocCount);
-  serialization::writePod(bookFile, BOOK_CACHE_VERSION);
-  serialization::writePod(bookFile, lutOffset);
-  serialization::writePod(bookFile, spineCount);
-  serialization::writePod(bookFile, tocCount);
-  serialization::writePod(bookFile, static_cast<uint8_t>(0));  // placeholder for tocReliable
+  bookWriter.writePod(BOOK_CACHE_VERSION);
+  bookWriter.writePod(lutOffset);
+  bookWriter.writePod(spineCount);
+  bookWriter.writePod(tocCount);
+  bookWriter.writePod(static_cast<uint8_t>(0));  // placeholder for tocReliable
   // Metadata
-  serialization::writeString(bookFile, metadata.title);
-  serialization::writeString(bookFile, metadata.author);
-  serialization::writeString(bookFile, metadata.language);
-  serialization::writeString(bookFile, metadata.coverItemHref);
-  serialization::writeString(bookFile, metadata.textReferenceHref);
-  serialization::writeString(bookFile, metadata.series);
-  serialization::writeString(bookFile, metadata.seriesIndex);
-  serialization::writeString(bookFile, metadata.description);
+  bookWriter.writeString(metadata.title);
+  bookWriter.writeString(metadata.author);
+  bookWriter.writeString(metadata.language);
+  bookWriter.writeString(metadata.coverItemHref);
+  bookWriter.writeString(metadata.textReferenceHref);
+  bookWriter.writeString(metadata.series);
+  bookWriter.writeString(metadata.seriesIndex);
+  bookWriter.writeString(metadata.description);
 
   // Scratch entries reused across all read loops below. Their internal
   // std::strings keep the capacity of the longest href/title encountered, so
@@ -173,19 +198,21 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   TocEntry tocScratch;
 
   // Loop through spine entries, writing LUT positions
-  spineFile.seek(0);
+  spineReader.seek(0);
   for (int i = 0; i < spineCount; i++) {
-    uint32_t pos = spineFile.position();
-    readSpineEntry(spineFile, spineScratch);
-    serialization::writePod(bookFile, pos + lutOffset + lutSize);
+    uint32_t pos = spineReader.position();
+    readSpineEntry(spineReader, spineScratch);
+    bookWriter.writePod(pos + lutOffset + lutSize);
   }
+  // Total bytes of spine records — the offset the TOC records start at in book.bin.
+  const uint32_t spineBytesTotal = spineReader.position();
 
   // Loop through toc entries, writing LUT positions
-  tocFile.seek(0);
+  tocReader.seek(0);
   for (int i = 0; i < tocCount; i++) {
-    uint32_t pos = tocFile.position();
-    readTocEntry(tocFile, tocScratch);
-    serialization::writePod(bookFile, pos + lutOffset + lutSize + static_cast<uint32_t>(spineFile.position()));
+    uint32_t pos = tocReader.position();
+    readTocEntry(tocReader, tocScratch);
+    bookWriter.writePod(pos + lutOffset + lutSize + spineBytesTotal);
   }
 
   // LUTs complete
@@ -197,9 +224,9 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   // seek-heavy scan in Epub::hasReliableToc().
   std::vector<int16_t> spineToTocIndex(spineCount, -1);
   int distinctSpinesReferenced = 0;
-  tocFile.seek(0);
+  tocReader.seek(0);
   for (int j = 0; j < tocCount; j++) {
-    readTocEntry(tocFile, tocScratch);
+    readTocEntry(tocReader, tocScratch);
     if (tocScratch.spineIndex >= 0 && tocScratch.spineIndex < spineCount) {
       if (spineToTocIndex[tocScratch.spineIndex] == -1) {
         spineToTocIndex[tocScratch.spineIndex] = static_cast<int16_t>(j);
@@ -247,9 +274,9 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     targets.resize(spineCount);
 
     std::string pathScratch;
-    spineFile.seek(0);
+    spineReader.seek(0);
     for (int i = 0; i < spineCount; i++) {
-      readSpineEntry(spineFile, spineScratch);
+      readSpineEntry(spineReader, spineScratch);
       // Cached hrefs are already decoded (see ContentOpfParser); decoding again would corrupt
       // filenames that legitimately contain '%' sequences.
       FsHelpers::normalisePath(spineScratch.href, pathScratch);
@@ -276,11 +303,11 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   }
 
   uint32_t cumSize = 0;
-  spineFile.seek(0);
+  spineReader.seek(0);
   int lastSpineTocIndex = -1;
   std::string pathScratch;
   for (int i = 0; i < spineCount; i++) {
-    readSpineEntry(spineFile, spineScratch);
+    readSpineEntry(spineReader, spineScratch);
 
     spineScratch.tocIndex = spineToTocIndex[i];
 
@@ -313,19 +340,21 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     spineScratch.cumulativeSize = cumSize;
 
     // Write out spine data to book.bin
-    writeSpineEntry(bookFile, spineScratch);
+    writeSpineEntry(bookWriter, spineScratch);
   }
   // Close opened zip file
   zip.close();
 
   // Loop through toc entries from toc file writing to book.bin
-  tocFile.seek(0);
+  tocReader.seek(0);
   for (int i = 0; i < tocCount; i++) {
-    readTocEntry(tocFile, tocScratch);
-    writeTocEntry(bookFile, tocScratch);
+    readTocEntry(tocReader, tocScratch);
+    writeTocEntry(bookWriter, tocScratch);
   }
 
-  // Patch tocReliable placeholder in header A
+  // Patch tocReliable placeholder in header A. Everything buffered must be on disk before the
+  // out-of-band seek writes through the raw file handle.
+  bookWriter.flush();
   bookFile.seek(tocReliableHeaderPos);
   serialization::writePod(bookFile, static_cast<uint8_t>(tocReliable ? 1 : 0));
 
@@ -369,22 +398,54 @@ uint32_t BookMetadataCache::writeTocEntry(FsFile& file, const TocEntry& entry) c
   return pos;
 }
 
+uint32_t BookMetadataCache::writeSpineEntry(serialization::BufferedFileWriter& out, const SpineEntry& entry) const {
+  const uint32_t pos = out.position();
+  out.writeString(entry.href);
+  out.writePod(entry.cumulativeSize);
+  out.writePod(entry.tocIndex);
+  return pos;
+}
+
+uint32_t BookMetadataCache::writeTocEntry(serialization::BufferedFileWriter& out, const TocEntry& entry) const {
+  const uint32_t pos = out.position();
+  out.writeString(entry.title);
+  out.writeString(entry.href);
+  out.writeString(entry.anchor);
+  out.writePod(entry.level);
+  out.writePod(entry.spineIndex);
+  return pos;
+}
+
+void BookMetadataCache::readSpineEntry(serialization::BufferedFileReader& in, SpineEntry& out) const {
+  in.readString(out.href);
+  in.readPod(out.cumulativeSize);
+  in.readPod(out.tocIndex);
+}
+
+void BookMetadataCache::readTocEntry(serialization::BufferedFileReader& in, TocEntry& out) const {
+  in.readString(out.title);
+  in.readString(out.href);
+  in.readString(out.anchor);
+  in.readPod(out.level);
+  in.readPod(out.spineIndex);
+}
+
 // Note: for the LUT to be accurate, this **MUST** be called for all spine items before `addTocEntry` is ever called
 // this is because in this function we're marking positions of the items
 void BookMetadataCache::createSpineEntry(const std::string& href) {
-  if (!buildMode || !spineFile) {
+  if (!buildMode || !spineFile || !spineWriter_.has_value()) {
     LOG_DBG("BMC", "createSpineEntry called but not in build mode");
     return;
   }
 
   const SpineEntry entry(href, 0, -1);
-  writeSpineEntry(spineFile, entry);
+  writeSpineEntry(*spineWriter_, entry);
   spineCount++;
 }
 
 void BookMetadataCache::createTocEntry(const std::string& title, const std::string& href, const std::string& anchor,
                                        const uint8_t level) {
-  if (!buildMode || !tocFile || !spineFile) {
+  if (!buildMode || !tocFile || !spineFile || !tocWriter_.has_value()) {
     LOG_DBG("BMC", "createTocEntry called but not in build mode");
     return;
   }
@@ -424,7 +485,7 @@ void BookMetadataCache::createTocEntry(const std::string& title, const std::stri
   }
 
   const TocEntry entry(title, href, anchor, level, spineIndex);
-  writeTocEntry(tocFile, entry);
+  writeTocEntry(*tocWriter_, entry);
   tocCount++;
 }
 

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -233,13 +233,17 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   // This is O(n*log(m)) instead of O(n*m) while avoiding memory exhaustion.
   // See: https://github.com/crosspoint-reader/crosspoint-reader/issues/134
 
-  std::vector<uint32_t> spineSizes;
+  // Deques, not vectors: at 1732 spines `targets` alone is ~28 KB, and a vector demands that as
+  // one contiguous block — observed aborting here at 51 KB free / 30 KB contig before the
+  // first-open framebuffer release widened the headroom. Chunked storage removes the failure
+  // class outright instead of relying on the released buffer's headroom.
+  std::deque<uint32_t> spineSizes;
   bool useBatchSizes = false;
 
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
     LOG_DBG("BMC", "Using batch size lookup for %d spine items", spineCount);
 
-    std::vector<ZipFile::SizeTarget> targets;
+    std::deque<ZipFile::SizeTarget> targets;
     targets.resize(spineCount);
 
     std::string pathScratch;

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -3,6 +3,7 @@
 #include <HalStorage.h>
 
 #include <algorithm>
+#include <deque>
 #include <string>
 #include <vector>
 
@@ -61,13 +62,17 @@ class BookMetadataCache {
   FsFile spineFile;
   FsFile tocFile;
 
-  // Index for fast href→spineIndex lookup (used only for large EPUBs)
+  // Index for fast href→spineIndex lookup (used only for large EPUBs).
+  // Deque, not vector: ~21 KB at 1732 spines, and a vector would demand that as one contiguous
+  // block on a possibly-fragmented heap (bare operator new aborts under -fno-exceptions).
+  // Deque's ~512-byte chunks remove the contiguity demand; its random-access iterators keep
+  // std::sort / lower_bound working.
   struct SpineHrefIndexEntry {
     uint64_t hrefHash;  // FNV-1a 64-bit hash
     uint16_t hrefLen;   // length for collision reduction
     int16_t spineIndex;
   };
-  std::vector<SpineHrefIndexEntry> spineHrefIndex;
+  std::deque<SpineHrefIndexEntry> spineHrefIndex;
   bool useSpineHrefIndex = false;
 
   // Batch ZIP size lookup and fast spine-href index are always better when N is

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <BufferedFileIO.h>
 #include <HalStorage.h>
 
 #include <algorithm>
 #include <deque>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -61,6 +63,12 @@ class BookMetadataCache {
   // Temp file handles during build
   FsFile spineFile;
   FsFile tocFile;
+  // Buffered views over the temp files during their write phases (createSpineEntry /
+  // createTocEntry stream one small record per manifest itemref / TOC entry — unbuffered,
+  // each field is a separate ~1.5 ms FsFile call). Engaged by the begin*Pass methods,
+  // flushed and dropped by the matching end*Pass. Degrade internally to pass-through on OOM.
+  std::optional<serialization::BufferedFileWriter> spineWriter_;
+  std::optional<serialization::BufferedFileWriter> tocWriter_;
 
   // Index for fast href→spineIndex lookup (used only for large EPUBs).
   // Deque, not vector: ~21 KB at 1732 spines, and a vector would demand that as one contiguous
@@ -89,6 +97,11 @@ class BookMetadataCache {
   // would otherwise fragment the heap during book.bin construction.
   void readSpineEntry(FsFile& file, SpineEntry& out) const;
   void readTocEntry(FsFile& file, TocEntry& out) const;
+  // Buffered counterparts for the build loops (identical wire format).
+  uint32_t writeSpineEntry(serialization::BufferedFileWriter& out, const SpineEntry& entry) const;
+  uint32_t writeTocEntry(serialization::BufferedFileWriter& out, const TocEntry& entry) const;
+  void readSpineEntry(serialization::BufferedFileReader& in, SpineEntry& out) const;
+  void readTocEntry(serialization::BufferedFileReader& in, TocEntry& out) const;
 
  public:
   BookMetadata coreMetadata;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -295,38 +295,33 @@ bool ContentOpfParser::resolveItemRefHrefWithIndex(const std::string& idref, std
                                return a.idHash < b.idHash || (a.idHash == b.idHash && a.idLen < b.idLen);
                              });
 
-  // Check for match (may need to check a few due to hash collisions).
-  while (it != itemIndex.end() && it->idHash == targetHash) {
-    tempItemStore.seek(it->fileOffset);
-    std::string itemId;
-    if (!serialization::readString(tempItemStore, itemId)) {
-      ++it;
-      continue;
-    }
-    if (itemId == idref) {
-      if (serialization::readString(tempItemStore, href)) {
-        return true;
-      }
-    }
-    ++it;
+  // Trust (hash, len): the duplicate scan at spine start guarantees the key is unique in this
+  // index, so the first match IS the item — seek straight to its href, skipping the id
+  // read-back-and-compare that used to cost a second string read per itemref (5.8 s of a
+  // 1732-itemref spine pass was this loop's SD traffic). The buffered reader makes the seek
+  // free when the href sits in the current window, which spine-follows-manifest order makes
+  // the common case.
+  if (it != itemIndex.end() && it->idHash == targetHash && it->idLen == targetLen) {
+    itemReader_->seek(it->hrefOffset);
+    return itemReader_->readString(href);
   }
 
   return false;
 }
 
 bool ContentOpfParser::resolveItemRefHrefLinearScan(const std::string& idref, std::string& href) {
-  tempItemStore.seek(0);
+  itemReader_->seek(0);
   const size_t itemStoreSize = tempItemStore.fileSize();
   std::string itemId;
 
-  while (tempItemStore.position() < itemStoreSize) {
-    const size_t beforeReadPos = tempItemStore.position();
-    if (!serialization::readString(tempItemStore, itemId) || !serialization::readString(tempItemStore, href)) {
+  while (itemReader_->position() < itemStoreSize) {
+    const size_t beforeReadPos = itemReader_->position();
+    if (!itemReader_->readString(itemId) || !itemReader_->readString(href)) {
       return false;
     }
 
     // Guard against malformed temp data or host shims that don't signal EOF via available().
-    if (tempItemStore.position() <= beforeReadPos) {
+    if (itemReader_->position() <= beforeReadPos) {
       return false;
     }
 
@@ -339,15 +334,17 @@ bool ContentOpfParser::resolveItemRefHrefLinearScan(const std::string& idref, st
 }
 
 bool ContentOpfParser::resolveSpineItemRefHref(const std::string& idref, std::string& href) {
+  if (!itemReader_.has_value()) {
+    return false;  // spine element never opened the item store — nothing to resolve against
+  }
   if (useItemIndex) {
     return resolveItemRefHrefWithIndex(idref, href);
   }
 
   // Slow path: linear scan (for small manifests, keeps original behavior).
-  // TODO: This lookup is slow as need to scan through all items each time.
-  //       It can take up to 200ms per item when getting to 1500 items.
   return resolveItemRefHrefLinearScan(idref, href);
 }
+
 
 void ContentOpfParser::handleSpineItemRefElement(const char** atts) {
   for (int i = 0; atts[i]; i += 2) {
@@ -407,6 +404,7 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
     if (!Storage.openFileForWrite("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
       LOG_ERR("COF", "Couldn't open temp items file for writing. This is probably going to be a fatal error.");
     }
+    self->itemWriter_.emplace(self->tempItemStore);
     return;
   }
 
@@ -415,14 +413,31 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
     if (!Storage.openFileForRead("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
       LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
     }
+    self->itemReader_.emplace(self->tempItemStore);
 
     // Sort item index for binary search if we have enough items
     if (self->itemIndex.size() >= LARGE_SPINE_THRESHOLD) {
       std::sort(self->itemIndex.begin(), self->itemIndex.end(), [](const ItemIndexEntry& a, const ItemIndexEntry& b) {
         return a.idHash < b.idHash || (a.idHash == b.idHash && a.idLen < b.idLen);
       });
-      self->useItemIndex = true;
-      LOG_DBG("COF", "Using fast index for %zu manifest items", self->itemIndex.size());
+      // Lookups trust (hash, len) without reading the id back, so a (hash, len) duplicate —
+      // a genuine 32-bit collision (~1e-4 odds per book) or a spec-invalid duplicated id —
+      // could resolve to the wrong href. Adjacent scan after the sort: any duplicate disables
+      // the index for this book and every idref falls back to the exact linear scan.
+      bool duplicateKeys = false;
+      for (size_t i = 1; i < self->itemIndex.size(); ++i) {
+        if (self->itemIndex[i].idHash == self->itemIndex[i - 1].idHash &&
+            self->itemIndex[i].idLen == self->itemIndex[i - 1].idLen) {
+          duplicateKeys = true;
+          break;
+        }
+      }
+      if (duplicateKeys) {
+        LOG_DBG("COF", "Manifest id hash collision; using exact linear idref lookup");
+      } else {
+        self->useItemIndex = true;
+        LOG_DBG("COF", "Using fast index for %zu manifest items", self->itemIndex.size());
+      }
     }
     return;
   }
@@ -530,18 +545,18 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
       }
     }
 
-    // Record index entry for fast lookup later
+    // Write items down to SD card (buffered — thousands of tiny field writes otherwise cost a
+    // full FsFile call each). The index entry records the position AFTER the id string:
+    // hash-trusted lookups seek straight to the href and never re-read the id.
+    self->itemWriter_->writeString(itemId);
     if (self->tempItemStore) {
       ItemIndexEntry entry;
       entry.idHash = fnvHash(itemId);
       entry.idLen = static_cast<uint16_t>(itemId.size());
-      entry.fileOffset = static_cast<uint32_t>(self->tempItemStore.position());
+      entry.hrefOffset = self->itemWriter_->position();
       self->itemIndex.push_back(entry);
     }
-
-    // Write items down to SD card
-    serialization::writeString(self->tempItemStore, itemId);
-    serialization::writeString(self->tempItemStore, href);
+    self->itemWriter_->writeString(href);
 
     if (itemId == self->coverItemId) {
       // Some EPUBs set meta name="cover" to an XHTML wrapper item.
@@ -676,6 +691,7 @@ void ContentOpfParser::endElement(void* userData, const char* name) {
 
   if (self->state == IN_SPINE && isSpineTag(name)) {
     self->state = IN_PACKAGE;
+    self->itemReader_.reset();
     self->tempItemStore.close();
     return;
   }
@@ -688,6 +704,11 @@ void ContentOpfParser::endElement(void* userData, const char* name) {
 
   if (self->state == IN_MANIFEST && isManifestTag(name)) {
     self->state = IN_PACKAGE;
+    // Flush buffered item records before the file closes; the spine pass reads them back.
+    if (self->itemWriter_.has_value()) {
+      self->itemWriter_->flush();
+      self->itemWriter_.reset();
+    }
     self->tempItemStore.close();
     return;
   }

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -34,20 +34,44 @@ inline bool isItemTag(const char* name) { return isTag(name, "item", "opf:item")
 inline bool isItemRefTag(const char* name) { return isTag(name, "itemref", "opf:itemref"); }
 inline bool isReferenceTag(const char* name) { return isTag(name, "reference", "opf:reference"); }
 
-bool startsWithImageMediaType(const std::string& mediaType) {
+bool startsWithImageMediaType(const char* mediaType) {
   constexpr size_t prefixLen = sizeof(MEDIA_TYPE_IMAGE_PREFIX) - 1;
-  if (mediaType.size() < prefixLen) {
-    return false;
-  }
-
   for (size_t i = 0; i < prefixLen; ++i) {
+    // A shorter string mismatches on its NUL before this reads past the end.
     const char c = static_cast<char>(std::tolower(static_cast<unsigned char>(mediaType[i])));
     if (c != MEDIA_TYPE_IMAGE_PREFIX[i]) {
       return false;
     }
   }
-
   return true;
+}
+
+// Everything the manifest handler needs to know about a media-type, computed once per
+// DISTINCT value: items are only ever routed by these classes, never by the raw string.
+enum class MediaClass : uint8_t { Other = 0, Image, Ncx, Css, PageMap };
+
+MediaClass classifyMediaType(const char* mediaType) {
+  if (mediaType == nullptr || *mediaType == '\0') return MediaClass::Other;
+  if (startsWithImageMediaType(mediaType)) return MediaClass::Image;
+  if (strcmp(mediaType, MEDIA_TYPE_NCX) == 0) return MediaClass::Ncx;
+  if (strcmp(mediaType, MEDIA_TYPE_CSS) == 0) return MediaClass::Css;
+  if (strcmp(mediaType, MEDIA_TYPE_PAGEMAP) == 0) return MediaClass::PageMap;
+  return MediaClass::Other;
+}
+
+// True when `word` appears as a whole space-separated token in `props` (the OPF
+// `properties` attribute format). Pointer scan — no std::string construction.
+bool hasPropertyWord(const char* props, const char* word) {
+  if (props == nullptr || *props == '\0') return false;
+  const size_t wordLen = strlen(word);
+  const char* p = props;
+  while ((p = strstr(p, word)) != nullptr) {
+    const bool startsToken = (p == props) || (p[-1] == ' ');
+    const char after = p[wordLen];
+    if (startsToken && (after == '\0' || after == ' ')) return true;
+    p += wordLen;
+  }
+  return false;
 }
 
 // Append the UTF-8 encoding of a Unicode code point.
@@ -469,8 +493,12 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
   if (self->state == IN_MANIFEST && isItemTag(name)) {
     std::string itemId;
     std::string href;
-    std::string mediaType;
-    std::string properties;
+    // media-type/properties are only INSPECTED, never stored: keep them as pointers into the
+    // parser's attribute array (valid for this callback) instead of copying to std::string.
+    // The dominant media type, application/xhtml+xml, is 21 chars — past SSO — so the old copy
+    // heap-allocated once per item (~1500 alloc/free pairs on a large Calibre manifest).
+    const char* mediaType = nullptr;
+    const char* properties = nullptr;
 
     for (int i = 0; atts[i]; i += 2) {
       if (strcmp(atts[i], "id") == 0) {
@@ -481,6 +509,24 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
         mediaType = atts[i + 1];
       } else if (strcmp(atts[i], "properties") == 0) {
         properties = atts[i + 1];
+      }
+    }
+
+    // Manifests group items of one media type together (all chapters, then all images, ...),
+    // so the previous item's classification almost always applies: one strcmp against the memo
+    // replaces the per-item prefix/equality chain. A distinct value is classified once and
+    // cached in the fixed member buffer (no heap; values longer than the buffer classify
+    // per-item, which no real media type triggers).
+    MediaClass mediaClass = MediaClass::Other;
+    if (mediaType != nullptr) {
+      if (strcmp(mediaType, self->lastMediaType_) == 0) {
+        mediaClass = static_cast<MediaClass>(self->lastMediaClass_);
+      } else {
+        mediaClass = classifyMediaType(mediaType);
+        if (strlen(mediaType) < sizeof(self->lastMediaType_)) {
+          strcpy(self->lastMediaType_, mediaType);
+          self->lastMediaClass_ = static_cast<uint8_t>(mediaClass);
+        }
       }
     }
 
@@ -500,52 +546,48 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
     if (itemId == self->coverItemId) {
       // Some EPUBs set meta name="cover" to an XHTML wrapper item.
       // Only treat it as a cover image when the manifest media-type is image/*.
-      if (startsWithImageMediaType(mediaType)) {
+      if (mediaClass == MediaClass::Image) {
         self->coverItemHref = href;
       } else {
         LOG_DBG("COF", "Ignoring meta cover item '%s' with non-image media type: %s", itemId.c_str(),
-                mediaType.c_str());
+                mediaType != nullptr ? mediaType : "(none)");
       }
     }
 
-    if (mediaType == MEDIA_TYPE_NCX) {
-      if (self->tocNcxPath.empty()) {
-        self->tocNcxPath = href;
-      } else {
-        LOG_DBG("COF", "Warning: Multiple NCX files found in manifest. Ignoring duplicate: %s", href.c_str());
-      }
+    switch (mediaClass) {
+      case MediaClass::Ncx:
+        if (self->tocNcxPath.empty()) {
+          self->tocNcxPath = href;
+        } else {
+          LOG_DBG("COF", "Warning: Multiple NCX files found in manifest. Ignoring duplicate: %s", href.c_str());
+        }
+        break;
+      // EPUB 2.01 page-map.xml — separate top-level file mapping printed page numbers to spine
+      // locations (e.g. <page name="1" href="OEBPS/c9_split_000.xhtml"/>). Spine references it
+      // via <spine page-map="..."> but only the manifest item carries the canonical href.
+      case MediaClass::PageMap:
+        if (self->pageMapPath.empty()) {
+          self->pageMapPath = href;
+          LOG_DBG("COF", "Found EPUB 2.01 page-map: %s", href.c_str());
+        }
+        break;
+      case MediaClass::Css:
+        self->cssFiles.push_back(href);
+        break;
+      case MediaClass::Image:
+      case MediaClass::Other:
+        break;
     }
 
-    // EPUB 2.01 page-map.xml — separate top-level file mapping printed page numbers to spine
-    // locations (e.g. <page name="1" href="OEBPS/c9_split_000.xhtml"/>). Spine references it
-    // via <spine page-map="..."> but only the manifest item carries the canonical href.
-    if (mediaType == MEDIA_TYPE_PAGEMAP) {
-      if (self->pageMapPath.empty()) {
-        self->pageMapPath = href;
-        LOG_DBG("COF", "Found EPUB 2.01 page-map: %s", href.c_str());
-      }
+    // EPUB 3: Check for nav document (properties contains "nav" as a whole token)
+    if (self->tocNavPath.empty() && hasPropertyWord(properties, "nav")) {
+      self->tocNavPath = href;
+      LOG_DBG("COF", "Found EPUB 3 nav document: %s", href.c_str());
     }
 
-    // Collect CSS files
-    if (mediaType == MEDIA_TYPE_CSS) {
-      self->cssFiles.push_back(href);
-    }
-
-    // EPUB 3: Check for nav document (properties contains "nav")
-    if (!properties.empty() && self->tocNavPath.empty()) {
-      // Properties is space-separated, check if "nav" is present as a word
-      if (properties == "nav" || properties.find("nav ") == 0 || properties.find(" nav") != std::string::npos) {
-        self->tocNavPath = href;
-        LOG_DBG("COF", "Found EPUB 3 nav document: %s", href.c_str());
-      }
-    }
-
-    // EPUB 3: Check for cover image (properties contains "cover-image")
-    if (!properties.empty() && self->coverItemHref.empty()) {
-      if (properties == "cover-image" || properties.find("cover-image ") == 0 ||
-          properties.find(" cover-image") != std::string::npos) {
-        self->coverItemHref = href;
-      }
+    // EPUB 3: Check for cover image (properties contains "cover-image" as a whole token)
+    if (self->coverItemHref.empty() && hasPropertyWord(properties, "cover-image")) {
+      self->coverItemHref = href;
     }
     return;
   }

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -345,7 +345,6 @@ bool ContentOpfParser::resolveSpineItemRefHref(const std::string& idref, std::st
   return resolveItemRefHrefLinearScan(idref, href);
 }
 
-
 void ContentOpfParser::handleSpineItemRefElement(const char** atts) {
   for (int i = 0; atts[i]; i += 2) {
     if (strcmp(atts[i], "idref") == 0) {

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -44,6 +44,14 @@ class ContentOpfParser final : public Print {
   std::deque<ItemIndexEntry> itemIndex;
   bool useItemIndex = false;
 
+  // Memo of the last manifest item's media-type and its classification (MediaClass enum in the
+  // .cpp, stored as its uint8_t value here). Manifest items overwhelmingly repeat one media type
+  // (all chapters share application/xhtml+xml, images share image/jpeg), so the common case is a
+  // single strcmp hit instead of re-classifying — and the raw attribute is never copied into a
+  // per-item std::string. Fixed buffer, zero heap; 48 covers every registered EPUB media type.
+  char lastMediaType_[48] = {};
+  uint8_t lastMediaClass_ = 0;
+
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 
   // FNV-1a hash function

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -1,9 +1,11 @@
 #pragma once
+#include <BufferedFileIO.h>
 #include <Print.h>
 #include <SaxParser/SaxParser.h>
 
 #include <algorithm>
 #include <deque>
+#include <optional>
 #include <vector>
 
 #include "Epub.h"
@@ -33,13 +35,26 @@ class ContentOpfParser final : public Print {
   ParserState state = START;
   BookMetadataCache* cache;
   FsFile tempItemStore;
+  // Buffered views over tempItemStore, alive one phase at a time: the writer during the
+  // manifest pass (thousands of tiny id/href field writes), the reader during the spine pass
+  // (one seek + string read per itemref, usually landing inside the current 4 KB window since
+  // spine order tracks manifest order). Each internally degrades to pass-through on OOM.
+  std::optional<serialization::BufferedFileWriter> itemWriter_;
+  std::optional<serialization::BufferedFileReader> itemReader_;
   std::string coverItemId;
 
-  // Index for fast idref→href lookup (used only for large EPUBs)
+  // Index for fast idref→href lookup (used only for large EPUBs).
+  // Lookups trust (idHash, idLen) alone and read the href directly — the id string is never
+  // read back for verification. Hash-trusted matching adapted from the FreeInk SDK's
+  // BookCatalog (github.com/Free-Ink/freeink-sdk, "Add SD-backed catalog for large EPUB
+  // containers" by Justin Mitchell), whose rationale applies verbatim: the strings a verify
+  // would need are exactly the RAM/IO this index exists to avoid. Correctness is guaranteed
+  // by a duplicate scan after the sort: if any two manifest ids share (hash, len), the index
+  // is disabled for the whole book and lookups fall back to the exact linear scan.
   struct ItemIndexEntry {
     uint32_t idHash;      // FNV-1a hash of itemId
     uint16_t idLen;       // length for collision reduction
-    uint32_t fileOffset;  // offset in .items.bin
+    uint32_t hrefOffset;  // offset of the href string in .items.bin (record's id skipped)
   };
   std::deque<ItemIndexEntry> itemIndex;
   bool useItemIndex = false;

--- a/lib/Serialization/BufferedFileIO.h
+++ b/lib/Serialization/BufferedFileIO.h
@@ -1,0 +1,173 @@
+#pragma once
+#include <HalStorage.h>
+#include <Serialization.h>
+
+#include <cstring>
+#include <memory>
+#include <string>
+
+// Buffered wrappers over FsFile for the record-stream files the book indexer uses
+// (.items.bin, spine/toc temp files, book.bin). Their access pattern is thousands of
+// tiny field reads/writes (a u32 length here, a 40-byte string there); issued directly
+// each one is a full FsFile call at ~1.5 ms on SD, which made a 1732-spine first-open
+// index spend ~28 s in I/O overhead alone. These classes batch the fields into
+// buffer-sized transfers (default 4 KB) — the wire format is exactly Serialization.h's,
+// so buffered writers/readers interoperate freely with the unbuffered functions.
+//
+// Allocation: one heap buffer per instance (default 4 KB; heap because the instances
+// live across parse callbacks and 4 KB exceeds the stack budget). On allocation failure
+// the instance degrades to unbuffered pass-through — never an error path for callers.
+//
+// Not general-purpose file abstractions: no interleaved read/write on one instance, and
+// the underlying FsFile must not be repositioned behind the wrapper's back while it is
+// in use (position()/seek() go through the wrapper).
+
+namespace serialization {
+
+class BufferedFileReader {
+ public:
+  static constexpr size_t DEFAULT_BUFFER_BYTES = 4096;
+
+  explicit BufferedFileReader(FsFile& file, const size_t bufferBytes = DEFAULT_BUFFER_BYTES) : file_(file) {
+    // nothrow new, owned by the unique_ptr: null means degrade to pass-through, never abort.
+    buf_.reset(new (std::nothrow) uint8_t[bufferBytes]);
+    cap_ = buf_ ? bufferBytes : 0;
+    windowStart_ = static_cast<uint32_t>(file_.position());
+  }
+
+  // Logical read position (the underlying file may be ahead by the buffered remainder).
+  uint32_t position() const { return windowStart_ + static_cast<uint32_t>(pos_); }
+
+  // Repositions the logical cursor. A target inside the current window is free (no I/O);
+  // anything else drops the window and seeks the file.
+  void seek(const uint32_t target) {
+    if (target >= windowStart_ && target <= windowStart_ + fill_) {
+      pos_ = target - windowStart_;
+      return;
+    }
+    file_.seek(target);
+    windowStart_ = target;
+    pos_ = 0;
+    fill_ = 0;
+  }
+
+  // Reads exactly n bytes; false on a short read (logical position still advances by the
+  // bytes actually consumed).
+  bool read(void* dst, size_t n) {
+    auto* out = static_cast<uint8_t*>(dst);
+    while (n > 0) {
+      const size_t avail = fill_ - pos_;
+      if (avail > 0) {
+        const size_t take = n < avail ? n : avail;
+        memcpy(out, buf_.get() + pos_, take);
+        pos_ += take;
+        out += take;
+        n -= take;
+        continue;
+      }
+      // Window exhausted. Serve large remainders directly (no point copying through the
+      // buffer); refill for small ones. cap_ == 0 (degraded) always takes the direct path.
+      windowStart_ += static_cast<uint32_t>(fill_);
+      pos_ = 0;
+      fill_ = 0;
+      if (n >= cap_) {
+        const int got = file_.read(out, n);
+        if (got > 0) windowStart_ += static_cast<uint32_t>(got);
+        return got == static_cast<int>(n);
+      }
+      const int got = file_.read(buf_.get(), cap_);
+      if (got <= 0) return false;
+      fill_ = static_cast<size_t>(got);
+    }
+    return true;
+  }
+
+  template <typename T>
+  bool readPod(T& value) {
+    return read(&value, sizeof(T));
+  }
+
+  // Wire-format and failure parity with serialization::readString(FsFile&, ...): an
+  // oversized length skips the payload (stream stays aligned) and returns false.
+  bool readString(std::string& s) {
+    uint32_t len = 0;
+    if (!readPod(len)) return false;
+    if (len > MAX_STRING_LENGTH) {
+      seek(position() + len);
+      return false;
+    }
+    s.resize(len);
+    return len == 0 || read(&s[0], len);
+  }
+
+ private:
+  FsFile& file_;
+  std::unique_ptr<uint8_t[]> buf_;
+  size_t cap_ = 0;
+  size_t fill_ = 0;          // valid bytes in buf_
+  size_t pos_ = 0;           // consumed bytes in buf_
+  uint32_t windowStart_ = 0;  // file offset of buf_[0]
+};
+
+class BufferedFileWriter {
+ public:
+  static constexpr size_t DEFAULT_BUFFER_BYTES = 4096;
+
+  explicit BufferedFileWriter(FsFile& file, const size_t bufferBytes = DEFAULT_BUFFER_BYTES) : file_(file) {
+    // nothrow new, owned by the unique_ptr: null means degrade to pass-through, never abort.
+    buf_.reset(new (std::nothrow) uint8_t[bufferBytes]);
+    cap_ = buf_ ? bufferBytes : 0;
+    base_ = static_cast<uint32_t>(file_.position());
+  }
+
+  // Callers are expected to flush() at the end of a write phase (and check its result);
+  // the destructor flush is a best-effort backstop only.
+  ~BufferedFileWriter() { flush(); }
+
+  // Logical write position (== what FsFile::position() would report after a flush).
+  uint32_t position() const { return base_ + static_cast<uint32_t>(fill_); }
+
+  bool write(const void* src, size_t n) {
+    const auto* in = static_cast<const uint8_t*>(src);
+    // Large payloads (or degraded mode) go straight to the file, after draining the buffer
+    // so ordering is preserved.
+    if (n >= cap_) {
+      if (!flush()) return false;
+      const size_t wrote = file_.write(in, n);
+      base_ += static_cast<uint32_t>(wrote);
+      return wrote == n;
+    }
+    if (fill_ + n > cap_ && !flush()) return false;
+    memcpy(buf_.get() + fill_, in, n);
+    fill_ += n;
+    return true;
+  }
+
+  template <typename T>
+  bool writePod(const T& value) {
+    return write(&value, sizeof(T));
+  }
+
+  bool writeString(const std::string& s) {
+    const uint32_t len = static_cast<uint32_t>(s.size());
+    return writePod(len) && write(s.data(), len);
+  }
+
+  bool flush() {
+    if (fill_ == 0) return true;
+    const size_t wrote = file_.write(buf_.get(), fill_);
+    base_ += static_cast<uint32_t>(wrote);
+    const bool ok = wrote == fill_;
+    fill_ = 0;
+    return ok;
+  }
+
+ private:
+  FsFile& file_;
+  std::unique_ptr<uint8_t[]> buf_;
+  size_t cap_ = 0;
+  size_t fill_ = 0;
+  uint32_t base_ = 0;  // file offset the buffer starts at
+};
+
+}  // namespace serialization

--- a/lib/Serialization/BufferedFileIO.h
+++ b/lib/Serialization/BufferedFileIO.h
@@ -104,8 +104,8 @@ class BufferedFileReader {
   FsFile& file_;
   std::unique_ptr<uint8_t[]> buf_;
   size_t cap_ = 0;
-  size_t fill_ = 0;          // valid bytes in buf_
-  size_t pos_ = 0;           // consumed bytes in buf_
+  size_t fill_ = 0;           // valid bytes in buf_
+  size_t pos_ = 0;            // consumed bytes in buf_
   uint32_t windowStart_ = 0;  // file offset of buf_[0]
 };
 

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -266,7 +266,7 @@ bool ZipFile::getInflatedFileSize(const char* filename, size_t* size) {
   return true;
 }
 
-int ZipFile::fillUncompressedSizes(const std::vector<SizeTarget>& targets, std::vector<uint32_t>& sizes) {
+int ZipFile::fillUncompressedSizes(const std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes) {
   if (targets.empty()) {
     return 0;
   }

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <HalStorage.h>
 
+#include <deque>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -75,8 +76,11 @@ class ZipFile {
   bool getInflatedFileSize(const char* filename, size_t* size);
   // Batch lookup: scan ZIP central dir once and fill sizes for matching targets.
   // targets must be sorted by (hash, len). sizes[target.index] receives uncompressedSize.
-  // Returns number of targets matched.
-  int fillUncompressedSizes(const std::vector<SizeTarget>& targets, std::vector<uint32_t>& sizes);
+  // Returns number of targets matched. Deques, not vectors: a 1700-spine book needs ~28 KB of
+  // targets, and demanding that as ONE contiguous block aborts on a fragmented heap (bare
+  // operator new under -fno-exceptions) — deque's ~512-byte chunks drop the contiguity
+  // requirement while keeping the random-access iterators lower_bound needs.
+  int fillUncompressedSizes(const std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes);
   // Due to the memory required to run each of these, it is recommended to not preopen the zip file for multiple
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -679,14 +679,46 @@ void ReaderActivity::onEnter() {
     // isn't a dead screen; skip it on a warm cache so cached re-opens don't add
     // an extra e-ink flash. The throwaway Epub only computes paths + does a few
     // file-existence checks (no parsing), so this is cheap.
-    if (Epub(initialBookPath, "/.crosspoint").needsFirstOpenIndexing()) {
+    const bool firstOpenIndexing = Epub(initialBookPath, "/.crosspoint").needsFirstOpenIndexing();
+    if (firstOpenIndexing) {
       RenderLock lock;
       // drawPopup() overlays the indexing box on the displayed frame (it resyncs the write buffer
       // from the screen first), so the box lands on the launcher screen — e.g. the recent-books grid
       // — without the stale-buffer diff toggling the old/new selection cells before the popup appears.
       GUI.drawPopup(renderer, tr(STR_INDEXING));
     }
+    // First-open indexing allocates per-spine transient state — the batch-size-lookup vectors
+    // (~28 KB contiguous for a 1700-spine book) and the TOC's 32 KB NCX inflate ring — while the
+    // ~48 KB secondary framebuffer sits unused. Observed on-device: buildBookBin aborted (bare
+    // operator new under -fno-exceptions) at 51 KB free / 30 KB contig, after the TOC pass had
+    // already lost its inflate ring and produced 0 TOC entries. Lend the buffer out for the build
+    // (the popup above is drawn BEFORE the release — drawPopup needs the active buffer — and
+    // load() performs no rendering) and restore it before the reader activity starts. Same
+    // pattern as HomeActivity cover loading. If the realloc fails, EpubReaderActivity::onEnter
+    // sees the missing buffer (secondaryBufferDegraded_) and recovers once heap allows.
+    bool releasedForIndexing = false;
+    if (firstOpenIndexing && renderer.hasSecondaryBuffer()) {
+      RenderLock lock;
+      if (renderer.releaseSecondaryBuffer()) {
+        releasedForIndexing = true;
+        // Keep X4 fast-differential refresh alive off the controller's RED RAM (seeded by the
+        // popup's displayBuffer just above); no-op on X3.
+        renderer.setSingleBufferFastDiff(true);
+        LOG_INF("READER", "Released secondary framebuffer for first-open indexing (free=%lu)",
+                static_cast<unsigned long>(esp_get_free_heap_size()));
+      }
+    }
     auto epub = loadEpub(initialBookPath);
+    if (releasedForIndexing) {
+      RenderLock lock;
+      if (renderer.reallocSecondaryBuffer()) {
+        renderer.setSingleBufferFastDiff(false);
+        LOG_INF("READER", "Restored secondary framebuffer after first-open indexing");
+      } else {
+        LOG_ERR("READER", "Secondary framebuffer realloc failed after indexing (free=%lu); reader will recover",
+                static_cast<unsigned long>(esp_get_free_heap_size()));
+      }
+    }
     if (!epub) {
       onGoBack();
       return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ include(GoogleTest)
 
 add_subdirectory(${REPO_ROOT}/lib/SaxParser ${CMAKE_CURRENT_BINARY_DIR}/SaxParser)
 
+add_subdirectory(buffered_io)
 add_subdirectory(natural_sort)
 add_subdirectory(differential_rounding)
 add_subdirectory(hyphenation_eval)

--- a/test/buffered_io/BufferedFileIOTest.cpp
+++ b/test/buffered_io/BufferedFileIOTest.cpp
@@ -1,0 +1,176 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "BufferedFileIO.h"
+#include "Serialization.h"
+
+// The wrappers batch tiny field reads/writes; every test uses a deliberately small buffer so
+// records straddle buffer boundaries and the refill/flush paths are exercised. Wire-format
+// compatibility with the plain serialization:: functions is the core contract: streams written
+// by either side must read back identically through the other.
+
+namespace {
+
+constexpr size_t kTinyBuffer = 16;  // smaller than most records -> constant refills/flushes
+
+std::string makeString(const size_t len, const char seed) {
+  std::string s(len, ' ');
+  for (size_t i = 0; i < len; ++i) {
+    s[i] = static_cast<char>('a' + ((seed + static_cast<char>(i)) % 26));
+  }
+  return s;
+}
+
+}  // namespace
+
+TEST(BufferedFileIO, WriterProducesSerializationCompatibleStream) {
+  FsFile file = HalFile::forReadWrite();
+
+  {
+    serialization::BufferedFileWriter writer(file, kTinyBuffer);
+    writer.writePod(static_cast<uint32_t>(0xDEADBEEF));
+    writer.writeString("short");
+    writer.writeString(makeString(100, 3));  // > buffer: exercises the large-write bypass
+    writer.writePod(static_cast<int16_t>(-7));
+    writer.writeString("");  // zero-length string
+    ASSERT_TRUE(writer.flush());
+  }
+
+  file.seek(0);
+  uint32_t pod32 = 0;
+  serialization::readPod(file, pod32);
+  EXPECT_EQ(pod32, 0xDEADBEEFu);
+  std::string s;
+  ASSERT_TRUE(serialization::readString(file, s));
+  EXPECT_EQ(s, "short");
+  ASSERT_TRUE(serialization::readString(file, s));
+  EXPECT_EQ(s, makeString(100, 3));
+  int16_t pod16 = 0;
+  serialization::readPod(file, pod16);
+  EXPECT_EQ(pod16, -7);
+  ASSERT_TRUE(serialization::readString(file, s));
+  EXPECT_TRUE(s.empty());
+}
+
+TEST(BufferedFileIO, ReaderReadsSerializationWrittenStream) {
+  FsFile file = HalFile::forReadWrite();
+  serialization::writePod(file, static_cast<uint32_t>(42));
+  serialization::writeString(file, "hello world");
+  serialization::writeString(file, makeString(200, 5));  // > buffer: large-read bypass
+  serialization::writePod(file, static_cast<uint8_t>(9));
+  file.seek(0);
+
+  serialization::BufferedFileReader reader(file, kTinyBuffer);
+  uint32_t pod32 = 0;
+  ASSERT_TRUE(reader.readPod(pod32));
+  EXPECT_EQ(pod32, 42u);
+  std::string s;
+  ASSERT_TRUE(reader.readString(s));
+  EXPECT_EQ(s, "hello world");
+  ASSERT_TRUE(reader.readString(s));
+  EXPECT_EQ(s, makeString(200, 5));
+  uint8_t pod8 = 0;
+  ASSERT_TRUE(reader.readPod(pod8));
+  EXPECT_EQ(pod8, 9);
+  // Stream exhausted: the next read must fail, not fabricate data.
+  EXPECT_FALSE(reader.readPod(pod8));
+}
+
+TEST(BufferedFileIO, PositionsMatchUnbufferedFilePositions) {
+  FsFile file = HalFile::forReadWrite();
+
+  serialization::BufferedFileWriter writer(file, kTinyBuffer);
+  EXPECT_EQ(writer.position(), 0u);
+  writer.writePod(static_cast<uint32_t>(1));
+  EXPECT_EQ(writer.position(), 4u);
+  writer.writeString("abcdef");  // u32 len + 6 bytes
+  EXPECT_EQ(writer.position(), 4u + 4u + 6u);
+  ASSERT_TRUE(writer.flush());
+  EXPECT_EQ(file.position(), 14u);  // flush reconciles the raw file with the logical position
+
+  file.seek(0);
+  serialization::BufferedFileReader reader(file, kTinyBuffer);
+  EXPECT_EQ(reader.position(), 0u);
+  uint32_t pod32 = 0;
+  ASSERT_TRUE(reader.readPod(pod32));
+  EXPECT_EQ(reader.position(), 4u);
+  std::string s;
+  ASSERT_TRUE(reader.readString(s));
+  EXPECT_EQ(reader.position(), 14u);
+}
+
+TEST(BufferedFileIO, SeekServesWindowHitsAndMisses) {
+  FsFile file = HalFile::forReadWrite();
+  // Record i: u32 marker, at offset i*4.
+  for (uint32_t i = 0; i < 64; ++i) {
+    serialization::writePod(file, i * 3u);
+  }
+  file.seek(0);
+
+  serialization::BufferedFileReader reader(file, 32);  // 8 records per window
+  uint32_t v = 0;
+
+  // Sequential fill, then seek BACK inside the freshly filled window.
+  ASSERT_TRUE(reader.readPod(v));
+  ASSERT_TRUE(reader.readPod(v));
+  reader.seek(4);  // in-window
+  ASSERT_TRUE(reader.readPod(v));
+  EXPECT_EQ(v, 3u);
+
+  // Far seek: outside any window.
+  reader.seek(60 * 4);
+  ASSERT_TRUE(reader.readPod(v));
+  EXPECT_EQ(v, 60u * 3u);
+
+  // Back to the start after the far seek.
+  reader.seek(0);
+  ASSERT_TRUE(reader.readPod(v));
+  EXPECT_EQ(v, 0u);
+}
+
+TEST(BufferedFileIO, OversizedStringSkipsPayloadAndStaysAligned) {
+  FsFile file = HalFile::forReadWrite();
+  serialization::writeString(file, "first");
+  // Oversized record written by hand: length beyond MAX_STRING_LENGTH plus its payload.
+  const uint32_t oversized = serialization::MAX_STRING_LENGTH + 8;
+  serialization::writePod(file, oversized);
+  const std::string payload(oversized, 'x');
+  file.write(reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
+  serialization::writeString(file, "after");
+  file.seek(0);
+
+  serialization::BufferedFileReader reader(file, kTinyBuffer);
+  std::string s;
+  ASSERT_TRUE(reader.readString(s));
+  EXPECT_EQ(s, "first");
+  // Oversized: must return false but skip the payload so the stream stays aligned.
+  EXPECT_FALSE(reader.readString(s));
+  ASSERT_TRUE(reader.readString(s));
+  EXPECT_EQ(s, "after");
+}
+
+TEST(BufferedFileIO, RoundTripThroughBothWrappers) {
+  FsFile file = HalFile::forReadWrite();
+
+  {
+    serialization::BufferedFileWriter writer(file, kTinyBuffer);
+    for (int i = 0; i < 50; ++i) {
+      writer.writeString(makeString(static_cast<size_t>(1 + (i * 7) % 40), static_cast<char>(i)));
+      writer.writePod(static_cast<uint32_t>(i * 1000));
+    }
+    ASSERT_TRUE(writer.flush());
+  }
+
+  file.seek(0);
+  serialization::BufferedFileReader reader(file, kTinyBuffer);
+  for (int i = 0; i < 50; ++i) {
+    std::string s;
+    ASSERT_TRUE(reader.readString(s)) << "record " << i;
+    EXPECT_EQ(s, makeString(static_cast<size_t>(1 + (i * 7) % 40), static_cast<char>(i)));
+    uint32_t v = 0;
+    ASSERT_TRUE(reader.readPod(v));
+    EXPECT_EQ(v, static_cast<uint32_t>(i * 1000));
+  }
+}

--- a/test/buffered_io/CMakeLists.txt
+++ b/test/buffered_io/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(BufferedFileIOTest
+  BufferedFileIOTest.cpp
+)
+
+target_include_directories(BufferedFileIOTest PRIVATE
+  ${REPO_ROOT}/test/shims
+  ${REPO_ROOT}/lib/Serialization
+  ${REPO_ROOT}/lib/Memory
+)
+
+target_link_libraries(BufferedFileIOTest PRIVATE
+  crosspoint_test_common
+  GTest::gtest_main
+)
+
+gtest_discover_tests(BufferedFileIOTest)

--- a/test/epub_opf/ContentOpfParserTest.cpp
+++ b/test/epub_opf/ContentOpfParserTest.cpp
@@ -318,3 +318,41 @@ TEST(ContentOpfParser, ResolvesSpineIdrefsUsingIndexedLookupForLargeManifest) {
   EXPECT_EQ(capturedSpineHrefs[1], "book/OEBPS/text/ch10.xhtml");
   EXPECT_EQ(capturedSpineHrefs[2], "book/OEBPS/text/ch0.xhtml");
 }
+
+TEST(ContentOpfParser, DisablesHashTrustedIndexOnDuplicateIdsAndStillResolves) {
+  const std::string cacheDir = makeTempDir();
+  ASSERT_FALSE(cacheDir.empty());
+  TempDirGuard dirGuard(cacheDir);
+
+  std::vector<std::string> capturedSpineHrefs;
+  ScopedSpineHrefSink sinkGuard(&capturedSpineHrefs);
+
+  // The indexed lookup trusts (idHash, idLen) without reading the id back, so two manifest
+  // items sharing an id (equal hash AND length — the same key shape a genuine 32-bit collision
+  // would produce) must disable the index for the whole book. The exact linear scan then
+  // resolves the ambiguous idref to its FIRST manifest occurrence, and unrelated idrefs keep
+  // resolving normally.
+  constexpr int kItemCount = 420;  // > LARGE_SPINE_THRESHOLD so the index path would engage
+  const std::string base = "/book/OEBPS/";
+  const std::string xml =
+      "<?xml version='1.0' encoding='utf-8'?>"
+      "<package xmlns:opf='http://www.idpf.org/2007/opf' xmlns:dc='http://purl.org/dc/elements/1.1/'>"
+      "<metadata><dc:title>T</dc:title></metadata>"
+      "<manifest>" +
+      buildManifestItems(kItemCount) +
+      "<item id='ch5' href='text/duplicate.xhtml' media-type='application/xhtml+xml'/>"
+      "</manifest>"
+      "<spine>"
+      "<itemref idref='ch5'/>"
+      "<itemref idref='ch419'/>"
+      "</spine>"
+      "</package>";
+
+  BookMetadataCache cache(cacheDir);
+  ContentOpfParser parser(cacheDir, base, xml.size(), &cache);
+  ASSERT_TRUE(parseOpfXml(parser, xml));
+
+  ASSERT_EQ(capturedSpineHrefs.size(), 2u);
+  EXPECT_EQ(capturedSpineHrefs[0], "book/OEBPS/text/ch5.xhtml");  // first occurrence wins
+  EXPECT_EQ(capturedSpineHrefs[1], "book/OEBPS/text/ch419.xhtml");
+}


### PR DESCRIPTION
Add BufferedFileReader / BufferedFileWriter wrappers and use them
throughout the book-cache build path.  This batches the thousands of
tiny spine/TOC/itemref record reads/writes into 4 KB transfers instead
of one FsFile call per field.

Key changes:

- lib/Serialization/BufferedFileIO.h: new buffered reader/writer that
  degrades to pass-through on OOM, with std::string and POD helpers
  matching the existing serialization helpers.

- BookMetadataCache: wraps temp spine/toc files and book.bin output in
  buffers during buildBookBin().  Measured ~22.6 s of pure FsFile call
  overhead for a 1732-spine book is eliminated.

- ContentOpfParser: wraps the manifest item temp file in a writer
  during the manifest pass and a reader during the spine pass.
  Replaces the indexed idref lookup with a hash+length-trusted lookup
  that seeks straight to the href.  A duplicate-key scan after sorting
  disables the index when a real collision or spec-invalid duplicate id
  occurs, falling back to the exact linear scan. Hash-trusted matching adapted 
  from the FreeInk SDK's BookCatalog (github.com/Free-Ink/freeink-sdk,
 "Add SD-backed catalog for large EPUB containers" by Justin Mitchell), 
  whose rationale applies verbatim: the strings a verify would need are exactly 
  the RAM/IO this index exists to avoid.

- Tests: add duplicate-id test for ContentOpfParser and a dedicated
  buffered_io test suite.

No on-disk format changes; the buffered helpers preserve the existing
wire layout so old caches remain readable.