### PR TITLE
perf: standalone picks from the paused compilation effort (tjpgd host build, ZIP spine-stat cache, img/SVG dims)

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -10,12 +10,16 @@
 #include <PngToBmpConverter.h>
 #include <Serialization.h>
 #include <ZipFile.h>
+#include <esp_system.h>
 
+#include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <deque>
 #include <limits>
 #include <optional>
 
+#include "Epub/HashUtils.h"
 #include "Epub/ImageFormatDetector.h"
 #include "Epub/parsers/ContainerParser.h"
 #include "Epub/parsers/ContentOpfParser.h"
@@ -1291,6 +1295,85 @@ bool Epub::getItemSize(const std::string& itemHref, size_t* size) const {
   ZipFile zip(filepath);
   primeZip(zip);
   const bool ok = zip.getInflatedFileSize(path.c_str(), size);
+  adoptZipDetails(zip);
+  return ok;
+}
+
+void Epub::ensureSpineStats() const {
+  if (spineStatsResolved_) return;
+  spineStatsResolved_ = true;  // one attempt per book instance; on failure fall back to scans
+
+  const int spineCount = getSpineItemsCount();
+  if (spineCount <= 0) return;
+
+  // Heap gate: the deque needs ~sizeof(FileStatSlim) per spine plus a transient targets deque
+  // of the same order during the walk. Require comfortable headroom so a genuinely low heap
+  // falls back to per-spine scans (correct, slower) instead of aborting under -fno-exceptions.
+  const size_t perSpine = sizeof(ZipFile::FileStatSlim) + sizeof(ZipFile::SizeTarget);
+  const size_t needed = static_cast<size_t>(spineCount) * perSpine + 32u * 1024u;
+  if (esp_get_free_heap_size() < needed) {
+    LOG_INF("EBP", "spine-stat cache skipped (need %lu, free %lu) — falling back to per-spine scans",
+            static_cast<unsigned long>(needed), static_cast<unsigned long>(esp_get_free_heap_size()));
+    return;
+  }
+
+  ZipFile zip(filepath);
+  primeZip(zip);
+
+  // Build sorted (hash,len)->spineIndex targets, one central-directory walk resolves all stats.
+  std::deque<ZipFile::SizeTarget> targets;
+  targets.resize(spineCount);
+  std::string pathScratch;
+  for (int i = 0; i < spineCount; i++) {
+    // Hrefs are already URI-decoded in the metadata cache; normalise to match the raw
+    // central-directory names fillFileStats hashes (same keying fillUncompressedSizes uses).
+    FsHelpers::normalisePath(getSpineItem(i).href, pathScratch);
+    ZipFile::SizeTarget t;
+    t.hash = HashUtils::fnvHash64(pathScratch.c_str(), pathScratch.size());
+    t.len = static_cast<uint16_t>(pathScratch.size());
+    t.index = static_cast<uint16_t>(i);
+    targets[i] = t;
+  }
+  std::sort(targets.begin(), targets.end(), [](const ZipFile::SizeTarget& a, const ZipFile::SizeTarget& b) {
+    return a.hash < b.hash || (a.hash == b.hash && a.len < b.len);
+  });
+
+  spineStats_.assign(spineCount, ZipFile::FileStatSlim{});
+  const int matched = zip.fillFileStats(targets, spineStats_);
+  adoptZipDetails(zip);
+  targets.clear();
+  targets.shrink_to_fit();
+
+  if (matched != spineCount) {
+    // Some spines didn't match the batch walk (hash mismatch / odd names). Keep the cache — the
+    // matched entries still short-circuit; unmatched ones (localHeaderOffset==0) fall back per-call.
+    LOG_INF("EBP", "spine-stat cache matched %d/%d — unmatched spines fall back to per-spine scans", matched,
+            spineCount);
+  }
+  spineStatsUsable_ = matched > 0;
+}
+
+bool Epub::getSpineItemStat(const int spineIndex, ZipFile::FileStatSlim* out) const {
+  if (!out || spineIndex < 0) return false;
+  ensureSpineStats();
+
+  if (spineStatsUsable_ && spineIndex < static_cast<int>(spineStats_.size())) {
+    const ZipFile::FileStatSlim& s = spineStats_[spineIndex];
+    // A matched entry has a non-zero local-header offset. Offset 0 is the archive's FIRST local
+    // header — in an EPUB that is always the uncompressed `mimetype` entry (spec-mandated first,
+    // STORED), never a spine XHTML, so 0 unambiguously means "unmatched in the batch walk" here.
+    // A false 0 would only cost this one spine a fallback scan (still correct), not a wrong result.
+    if (s.localHeaderOffset != 0) {
+      *out = s;
+      return true;
+    }
+  }
+
+  // Fallback: single linear scan for this spine (cache disabled or this spine unmatched).
+  ZipFile zip(filepath);
+  primeZip(zip);
+  const std::string entryPath = FsHelpers::normalisePath(getSpineItem(spineIndex).href);
+  const bool ok = zip.loadFileStatSlim(entryPath.c_str(), out);
   adoptZipDetails(zip);
   return ok;
 }

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -2,6 +2,7 @@
 
 #include <Print.h>
 
+#include <deque>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -65,7 +66,28 @@ class Epub {
   mutable uint16_t zipTotalEntries_ = 0;
   mutable bool zipDetailsCached_ = false;
 
+  // Per-book cache of each spine entry's ZIP central-directory stat, resolved in ONE
+  // central-directory walk (fillFileStats) the first time any spine stat is requested.
+  // Without it, every spine open re-runs a linear central-directory scan — on a book that
+  // interleaves ~1600 image entries with the XHTML spines (e.g. King's Avatar) that scan
+  // walks hundreds-to-thousands of entries and dominated the compile (~215 ms/spine,
+  // measured). Deque (not vector): ~14 B/spine, ~24 KB at 1732 spines — a vector would demand
+  // that as one contiguous block and abort on a fragmented heap under -fno-exceptions.
+  // Best-effort: on OOM the deque stays empty and getSpineItemStat falls back to a per-call
+  // linear scan (correct, just slow). In-memory only — content.bin is the durable cache, so
+  // this is cheap to rebuild and never persisted.
+  mutable std::deque<ZipFile::FileStatSlim> spineStats_;
+  mutable bool spineStatsResolved_ = false;
+  mutable bool spineStatsUsable_ = false;
+  void ensureSpineStats() const;
+
  public:
+  // Resolve a spine entry's ZIP central-directory stat via the per-book cache (one
+  // central-directory walk for the whole book, then O(1) per spine). Falls back to a single
+  // linear loadFileStatSlim scan if the cache couldn't be built (OOM) or the spine wasn't
+  // matched in the batch walk. Returns false only if the entry can't be found at all.
+  bool getSpineItemStat(int spineIndex, ZipFile::FileStatSlim* out) const;
+
   // Seed a fresh ZipFile over this book with the cached EOCD details (no-op
   // until the first adopt). Public so Section's EntryReader benefits too.
   void primeZip(ZipFile& zip) const;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -9,6 +9,9 @@
 #include <esp_heap_caps.h>
 #include <esp_system.h>
 #include <esp_task_wdt.h>
+#ifdef BENCH_EXTRACT_PROFILE
+#include <esp_timer.h>
+#endif
 
 // The build's scratch buffers are carved from a preallocated BuildArena
 // (docs/compiled-book-pipeline-plan.md Phase 2), device-validated 2026-07-18
@@ -450,6 +453,11 @@ struct Section::BuildState {
   std::string contentBase;
   std::string imageBasePath;
   size_t inflatedSize = 0;
+  // The spine entry's ZIP central-directory stat, resolved once in setup via Epub's per-book
+  // cache (one central-dir walk for the whole book) so the parse's EntryReader::open skips the
+  // per-spine linear central-directory scan that dominated the compile. Valid when statValid.
+  ZipFile::FileStatSlim spineStat = {};
+  bool statValid = false;
   CssParser* cssParser = nullptr;
   std::vector<uint32_t> lut;
   std::unique_ptr<ChapterHtmlSlimParser> visitor;
@@ -607,10 +615,17 @@ Section::BuildPhaseResult Section::runBuildSetup(BuildState& st) {
     Storage.mkdir(sectionsDir.c_str());
   }
 
-  // Get inflated size up-front so the parser can choose progress granularity.
+  // Get inflated size up-front so the parser can choose progress granularity. Resolve the
+  // spine's ZIP stat once here (via Epub's per-book cache) and reuse it for the parse's
+  // EntryReader::open, so we scan the central directory once per book instead of once per
+  // spine open (the compile's dominant cost, measured). uncompressedSize doubles as the
+  // inflated size — no separate getSpineItemInflatedSize scan.
   const uint32_t phaseSetupStart = millis();
   st.inflatedSize = 0;
-  if (!epub->getSpineItemInflatedSize(spineIndex, &st.inflatedSize)) {
+  st.statValid = epub->getSpineItemStat(spineIndex, &st.spineStat);
+  if (st.statValid) {
+    st.inflatedSize = st.spineStat.uncompressedSize;
+  } else if (!epub->getSpineItemInflatedSize(spineIndex, &st.inflatedSize)) {
     LOG_ERR("SCT", "Failed to get inflated size for %s", st.localPath.c_str());
     return BuildPhaseResult::Failed;
   }
@@ -810,8 +825,11 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
                 static_cast<uint32_t>(PARSE_CHUNK_BYTES), esp_get_free_heap_size());
         streamFailed = true;
       } else {
-        const std::string entryPath = FsHelpers::normalisePath(st.localPath);
-        if (!st.reader->open(entryPath.c_str())) {
+        // Prefer the stat resolved in setup (skips the per-spine central-directory scan);
+        // fall back to the by-name open when the cache was unavailable for this spine.
+        const bool opened = st.statValid ? st.reader->open(st.spineStat)
+                                         : st.reader->open(FsHelpers::normalisePath(st.localPath).c_str());
+        if (!opened) {
           streamFailed = true;  // EntryReader::open already logged the cause
         } else {
           // The inflate ring is now allocated (open() took its ~32 KB contiguous block first). Only
@@ -835,21 +853,40 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
   // ZIP state. Keeps the ring and the parser's layout working set temporally disjoint.
   if (!streamFailed && st.useTempExtract && !st.extractDone) {
     bool done = false;
+#ifdef BENCH_EXTRACT_PROFILE
+    LOG_INF("SCT", "spine=%d EXTRACTPROF prelude=%ums (zip open + entry seek + file open)", spineIndex,
+            static_cast<uint32_t>(millis() - sliceStart));
+    uint32_t inflateUs = 0, writeUs = 0;
+#endif
     while (!done) {
       size_t produced = 0;
+#ifdef BENCH_EXTRACT_PROFILE
+      const int64_t ti = esp_timer_get_time();
+#endif
       if (!st.reader->step(st.chunkBuf, st.extractCap, &produced, &done)) {
         streamFailed = true;
         break;
       }
+#ifdef BENCH_EXTRACT_PROFILE
+      inflateUs += static_cast<uint32_t>(esp_timer_get_time() - ti);
+      const int64_t tw = esp_timer_get_time();
+#endif
       if (produced > 0 && st.tempFile.write(st.chunkBuf, produced) != produced) {
         LOG_ERR("SCT", "Failed to write extracted XHTML to %s", st.tempPath.c_str());
         streamFailed = true;
         break;
       }
+#ifdef BENCH_EXTRACT_PROFILE
+      writeUs += static_cast<uint32_t>(esp_timer_get_time() - tw);
+#endif
       if (!done && overBudget()) {
         return yieldSlice();
       }
     }
+#ifdef BENCH_EXTRACT_PROFILE
+    LOG_INF("SCT", "spine=%d EXTRACTPROF inflate=%ums sd_write=%ums", spineIndex, inflateUs / 1000, writeUs / 1000);
+    const int64_t tClose = esp_timer_get_time();
+#endif
     if (!streamFailed && st.reader->bytesProduced() != st.inflatedSize) {
       LOG_ERR("SCT", "Decompressed size mismatch (expected %u, got %u)", static_cast<uint32_t>(st.inflatedSize),
               static_cast<uint32_t>(st.reader->bytesProduced()));
@@ -871,6 +908,10 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
       if (!Storage.openFileForRead("SCT", st.tempPath, st.tempFile)) {
         streamFailed = true;
       } else {
+#ifdef BENCH_EXTRACT_PROFILE
+        LOG_INF("SCT", "spine=%d EXTRACTPROF fileops=%ums (flush/close/reopen)", spineIndex,
+                static_cast<uint32_t>((esp_timer_get_time() - tClose) / 1000));
+#endif
         LOG_INF("SCT", "createSectionFile spine=%d extracted %u bytes to temp (free=%lu)", spineIndex,
                 static_cast<uint32_t>(st.inflatedSize), esp_get_free_heap_size());
         if (overBudget()) {
@@ -886,8 +927,17 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
   // lookup opened in runBuildSetup.
   if (!streamFailed) {
     if (st.useTempExtract) {
+#ifdef BENCH_EXTRACT_PROFILE
+      uint32_t sdReadUs = 0, visitorUs = 0;
+#endif
       while (true) {
+#ifdef BENCH_EXTRACT_PROFILE
+        const int64_t tr = esp_timer_get_time();
+#endif
         const int n = st.tempFile.read(st.chunkBuf, PARSE_CHUNK_BYTES);
+#ifdef BENCH_EXTRACT_PROFILE
+        sdReadUs += static_cast<uint32_t>(esp_timer_get_time() - tr);
+#endif
         if (n < 0) {
           LOG_ERR("SCT", "Failed to read extracted XHTML from %s", st.tempPath.c_str());
           streamFailed = true;
@@ -899,7 +949,14 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
         st.tempBytesFed += static_cast<size_t>(n);
         // A short write means the parser failed mid-stream (it returns 0 after an
         // internal error) — same abort the one-shot readFileToStream path performed.
-        if (st.visitor->write(st.chunkBuf, static_cast<size_t>(n)) != static_cast<size_t>(n)) {
+#ifdef BENCH_EXTRACT_PROFILE
+        const int64_t tv = esp_timer_get_time();
+#endif
+        const size_t wrote = st.visitor->write(st.chunkBuf, static_cast<size_t>(n));
+#ifdef BENCH_EXTRACT_PROFILE
+        visitorUs += static_cast<uint32_t>(esp_timer_get_time() - tv);
+#endif
+        if (wrote != static_cast<size_t>(n)) {
           streamFailed = true;
           break;
         }
@@ -907,6 +964,9 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
           return yieldSlice();
         }
       }
+#ifdef BENCH_EXTRACT_PROFILE
+      LOG_INF("SCT", "spine=%d PARSEPROF sd_read=%ums visitor=%ums", spineIndex, sdReadUs / 1000, visitorUs / 1000);
+#endif
       if (!streamFailed && st.tempBytesFed != st.inflatedSize) {
         LOG_ERR("SCT", "Extracted size mismatch (expected %u, fed %u)", static_cast<uint32_t>(st.inflatedSize),
                 static_cast<uint32_t>(st.tempBytesFed));
@@ -955,7 +1015,14 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
     st.tempPath.clear();
   }
   st.streamOk = !streamFailed;
+#ifdef BENCH_EXTRACT_PROFILE
+  const int64_t tFin = esp_timer_get_time();
+#endif
   st.finalizeOk = st.visitor->finalize();
+#ifdef BENCH_EXTRACT_PROFILE
+  LOG_INF("SCT", "spine=%d EXTRACTPROF finalize=%ums", spineIndex,
+          static_cast<uint32_t>((esp_timer_get_time() - tFin) / 1000));
+#endif
   st.parserStreamOk = st.visitor->streamSucceeded();
   if (st.cssParser) {
     st.cssParser->logResolveStats(st.localPath.c_str());

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -869,6 +869,12 @@ void ChapterHtmlSlimParser::startElement(void* userData, const char* name, const
   if (matches(name, IMAGE_TAGS, NUM_IMAGE_TAGS)) {
     std::string src;
     std::string alt;
+    // Explicit width/height from the markup (e.g. an SVG cover: <image width="455" height="751" .../>,
+    // or <img width= height=>). When both are present and numeric they are the intrinsic dimensions the
+    // publisher declared, so we can size the image WITHOUT reading the JPEG/PNG header from the ZIP — a
+    // ring-hungry inflate that OOMs on the reader's tight heap (the "Failed to read image dimensions:
+    // cover.jpeg" that left the titlepage blank). 0 = attribute absent/non-numeric → fall back.
+    int attrWidth = 0, attrHeight = 0;
     if (atts != nullptr) {
       for (int i = 0; atts[i]; i += 2) {
         if (strcmp(atts[i], "src") == 0 || strcmp(atts[i], "href") == 0 || strcmp(atts[i], "xlink:href") == 0) {
@@ -880,6 +886,10 @@ void ChapterHtmlSlimParser::startElement(void* userData, const char* name, const
           }
         } else if (strcmp(atts[i], "alt") == 0) {
           alt = atts[i + 1];
+        } else if (strcmp(atts[i], "width") == 0) {
+          attrWidth = atoi(atts[i + 1]);  // ignores a trailing "%"/"px"; 0 for non-leading-digit values
+        } else if (strcmp(atts[i], "height") == 0) {
+          attrHeight = atoi(atts[i + 1]);
         }
       }
 
@@ -983,11 +993,19 @@ void ChapterHtmlSlimParser::startElement(void* userData, const char* name, const
             if (extPos != std::string::npos) ext = resolvedPath.substr(extPos);
             std::string cachedImagePath = self->imageBasePath + std::to_string(self->imageCounter++) + ext;
 
-            // Get dimensions from the pre-built manifest (fast, heap-safe) or fall back to
-            // reading the ZIP entry header directly (safe outside a streaming inflate context).
+            // Get dimensions, cheapest ring-free source first:
+            //  1. explicit width/height on the tag (an SVG cover / sized <img>) — no ZIP read at all;
+            //  2. the pre-built image manifest (each header read at most once ever);
+            //  3. fall back to reading the ZIP entry header directly — a ~32 KB inflate ring that can
+            //     OOM on the reader's tight heap (this is what left the cover.jpeg titlepage blank).
             ImageDimensions dims = {0, 0};
             bool dimsOk = false;
-            if (self->imageManifest) {
+            if (attrWidth > 0 && attrHeight > 0) {
+              dims.width = attrWidth;
+              dims.height = attrHeight;
+              dimsOk = true;
+            }
+            if (!dimsOk && self->imageManifest) {
               // Resolve + cache on a miss: each image's header is read at most once ever.
               const ImageManifestEntry* entry =
                   self->imageManifest->ensureResolved(self->epub->getPath(), resolvedPath);

--- a/lib/TJpgDec/src/tjpgd.h
+++ b/lib/TJpgDec/src/tjpgd.h
@@ -12,13 +12,13 @@ extern "C" {
 
 #include "tjpgdcnf.h"
 
-#if defined(_WIN32) /* VC++ or some compiler without stdint.h */
+#if defined(_MSC_VER) && (_MSC_VER < 1600) /* Old VC++ without <stdint.h> */
 typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef short int16_t;
 typedef unsigned long uint32_t;
 typedef long int32_t;
-#else /* Embedded platform */
+#else /* Embedded platform, MinGW, MSVC 2010+ — all provide <stdint.h> */
 #include <stdint.h>
 #endif
 

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -88,8 +88,14 @@ bool ZipFile::loadFileStatSlim(const char* filename, FileStatSlim* fileStat) {
 
   uint32_t sig;
   char itemName[256];
+#ifdef BENCH_EXTRACT_PROFILE
+  uint32_t scanned = 0;
+#endif
 
   while (true) {
+#ifdef BENCH_EXTRACT_PROFILE
+    ++scanned;
+#endif
     uint32_t entryStart = file.position();
 
     if (file.read(&sig, 4) != 4 || sig != 0x02014b50) {
@@ -157,6 +163,10 @@ bool ZipFile::loadFileStatSlim(const char* filename, FileStatSlim* fileStat) {
     LOG_DBG("ZIP", "loadFileStatSlim: entry not found after scan: %s (normalized=%s)", filename,
             normalizedFilename.c_str());
   }
+#ifdef BENCH_EXTRACT_PROFILE
+  LOG_INF("ZIP", "STATSCAN entries=%lu wrapped=%d found=%d", static_cast<unsigned long>(scanned), wrapped ? 1 : 0,
+          found ? 1 : 0);
+#endif
 
   return found;
 }
@@ -411,6 +421,74 @@ int ZipFile::fillUncompressedSizes(const std::deque<SizeTarget>& targets, std::d
       while (it != targets.end() && it->hash == hash && it->len == nameLen) {
         if (it->index < sizes.size()) {
           sizes[it->index] = uncompressedSize;
+          matched++;
+        }
+        ++it;
+      }
+
+      if (matched >= targetCount) {
+        break;
+      }
+    } else {
+      file.seekCur(nameLen);
+    }
+
+    file.seekCur(m + k);
+  }
+
+  return matched;
+}
+
+int ZipFile::fillFileStats(const std::deque<SizeTarget>& targets, std::deque<FileStatSlim>& stats) {
+  if (targets.empty()) {
+    return 0;
+  }
+
+  const ScopedOpenClose zip{*this};
+  if (!zip) return 0;
+
+  if (!loadZipDetails()) return 0;
+
+  file.seek(zipDetails.centralDirOffset);
+
+  int matched = 0;
+  const int targetCount = static_cast<int>(targets.size());
+  uint32_t sig;
+  char itemName[256];
+
+  while (file.available()) {
+    file.read(&sig, 4);
+    if (sig != 0x02014b50) break;
+
+    file.seekCur(6);
+    uint16_t method;
+    file.read(&method, 2);
+    file.seekCur(8);
+    uint32_t compressedSize, uncompressedSize;
+    file.read(&compressedSize, 4);
+    file.read(&uncompressedSize, 4);
+    uint16_t nameLen, m, k;
+    file.read(&nameLen, 2);
+    file.read(&m, 2);
+    file.read(&k, 2);
+    file.seekCur(8);
+    uint32_t localHeaderOffset;
+    file.read(&localHeaderOffset, 4);
+
+    if (nameLen < 256) {
+      file.read(itemName, nameLen);
+      itemName[nameLen] = '\0';
+
+      const uint64_t hash = HashUtils::fnvHash64(itemName, nameLen);
+      const SizeTarget key = {hash, nameLen, 0};
+
+      auto it = std::lower_bound(targets.begin(), targets.end(), key, [](const SizeTarget& a, const SizeTarget& b) {
+        return a.hash < b.hash || (a.hash == b.hash && a.len < b.len);
+      });
+
+      while (it != targets.end() && it->hash == hash && it->len == nameLen) {
+        if (it->index < stats.size()) {
+          stats[it->index] = {method, compressedSize, uncompressedSize, localHeaderOffset};
           matched++;
         }
         ++it;
@@ -779,16 +857,21 @@ ZipFile::EntryReader::EntryReader(EntryReader&&) noexcept = default;
 ZipFile::EntryReader& ZipFile::EntryReader::operator=(EntryReader&&) noexcept = default;
 
 bool ZipFile::EntryReader::open(const char* filename) {
-  impl_->reset();
-
   FileStatSlim fileStat = {};
   if (!impl_->zf.loadFileStatSlim(filename, &fileStat)) {
     LOG_ERR("ZIP", "EntryReader::open: entry not found: %s", filename);
     return false;
   }
+  return open(fileStat);
+}
+
+bool ZipFile::EntryReader::open(const FileStatSlim& fileStat) {
+  impl_->reset();
+
   const long dataOffset = impl_->zf.getDataOffset(fileStat);
   if (dataOffset < 0) {
-    LOG_ERR("ZIP", "EntryReader::open: bad data offset for %s", filename);
+    LOG_ERR("ZIP", "EntryReader::open: bad data offset (localHeaderOffset=%lu)",
+            static_cast<unsigned long>(fileStat.localHeaderOffset));
     return false;
   }
 

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -83,6 +83,11 @@ class ZipFile {
   // operator new under -fno-exceptions) — deque's ~512-byte chunks drop the contiguity
   // requirement while keeping the random-access iterators lower_bound needs.
   int fillUncompressedSizes(const std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes);
+  // Batch lookup of FULL entry stats in ONE central-directory walk (vs one linear scan per
+  // loadFileStatSlim call). targets must be sorted by (hash, len) like fillUncompressedSizes;
+  // stats[target.index] receives the entry's FileStatSlim. Returns number matched. Same deque
+  // rationale as fillUncompressedSizes (avoid a big contiguous block on a fragmented heap).
+  int fillFileStats(const std::deque<SizeTarget>& targets, std::deque<FileStatSlim>& stats);
   // Due to the memory required to run each of these, it is recommended to not preopen the zip file for multiple
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);
@@ -131,6 +136,12 @@ class ZipFile {
     // to the data start. Returns false if the entry is not found or on I/O error.
     // Closes any previously open entry first.
     bool open(const char* filename);
+
+    // Same, but for a caller that already holds the entry's central-dir stat
+    // (e.g. from Epub's cached per-spine stat table) — skips the linear
+    // central-directory scan loadFileStatSlim performs. Closes any previously
+    // open entry first.
+    bool open(const FileStatSlim& fileStat);
 
     // Decompress up to `cap` bytes into `out`. Sets `*produced` to the number
     // of bytes written and `*done` to true when the entry is exhausted.


### PR DESCRIPTION
Three fixes made during the (now paused) Stage-1 / fresh-reader effort that have **standalone value on `master`**, independent of whether the fresh reader ever ships. Cherry-picked from `feat-stage1-extraction`, with all Stage-1-coupled parts stripped.

## Commits

### 1. `fix(tjpgd)`: gate manual stdint typedefs on old MSVC, not `_WIN32`
`tjpgd.h` gated its manual `uint8_t`/`uint32_t`/... typedefs on `#if defined(_WIN32)`, but MinGW/MSYS2 defines `_WIN32` **and** ships a real `<stdint.h>` — so `typedef unsigned long uint32_t` collided with the standard `unsigned int`. A hard compile error in every host target that pulls in a JPEG converter, i.e. **all Windows host builds were broken**.

Upstream's own comment says the branch is for a compiler "without stdint.h", so `_WIN32` was simply the wrong guard. Narrowed to `_MSC_VER < 1600`. CI (Linux) was already on the `<stdint.h>` branch and is unaffected.

### 2. `perf(zip)`: per-book spine-stat cache — kill the per-spine ZIP central-dir scan
Every spine open ran a linear ZIP central-directory scan (`loadFileStatSlim`), **twice** — once in setup (`getSpineItemInflatedSize`) and once in the parse prelude (`EntryReader::open`). On a book interleaving ~1600 image entries with the XHTML spines (King's Avatar, 1732 spines) the scan cursor never helps, so each open walked 200–1733 entries.

Fix: resolve every spine's stat once per book in a single central-directory walk, then O(1) per spine.
- `ZipFile::fillFileStats()` — generalizes `fillUncompressedSizes` to fill a full `FileStatSlim` per target in one walk.
- `ZipFile::EntryReader::open(const FileStatSlim&)` — open by pre-resolved stat; the by-name `open()` delegates through it.
- `Epub::getSpineItemStat()`/`ensureSpineStats()` — lazily built per-book `deque<FileStatSlim>` (deque not vector: ~14 B/spine, ~24 KB at 1732 spines with no contiguous-block demand). **Memory-gated**: on low heap or an unmatched spine it falls back to a per-call scan — correct, just slow. In-memory only, never persisted.
- `Section.cpp` — one book-level walk replaces the two per-spine scans.

Device-measured (King's Avatar cold, 90 spines): prelude ~260 ms → ~61 ms, setup ~53 ms → ~35 ms, parse-done ~600 ms → ~418 ms; the 900–1778 ms outliers are gone.

Also carries flag-gated (`BENCH_EXTRACT_PROFILE`) instrumentation used to find this. **That flag is defined in no env here, so it is fully inert.**

### 3. `fix(epub)`: use explicit img/SVG width+height for image dims (ring-free)
When an `<img>`/`<svg><image>` carries explicit numeric `width`+`height`, use those as the intrinsic dimensions instead of reading the JPEG/PNG header from the ZIP — a ~32 KB inflate ring that can OOM on the reader's tight heap. That failure (`Failed to read image dimensions: cover.jpeg`) left the **titlepage blank** on books whose cover is a Calibre-style `<svg viewBox>` wrapper declaring its size (e.g. Small Gods, 455×751).

Order is now: explicit attrs → image manifest → ZIP header read. Existing sources remain as fallback, so this only *adds* a cheaper source that takes precedence when present.

## What was deliberately left out
- The Stage-1-only `bench_pagelayout` env and its `platformio.ini` block (commit 2) — `platformio.ini` is **untouched** by this PR.
- The fresh-reader producer-borrow changes to `EpubReaderActivity.cpp` (commit 3) — that file is **untouched**.
- Group B of the plan (Stage-1 pipeline fixes) stays on `feat-stage1-extraction`; it is latent until that work resumes.

## Testing
- **Host suite**: `EpubPipelineTest` **40/40 pass**, `ZipEntryReaderTest` **7/7 pass**. Both build on MinGW — which is itself the validation for commit 1 (`tjpgd.c` compiles again).
- **Device**: `pio run -e default` **SUCCESS** (RAM 16.6%, Flash 95.9%).
- Pre-existing, unrelated: `EpubCssPerformanceTest` fails to build on MinGW (`dlfcn.h` missing). Verified identical on clean `master`.
- Not done: no on-device runtime smoke test of the perf win or the cover render — the numbers quoted above are from the original measurements on `feat-stage1-extraction`, not re-measured here.