### PR TITLE
fix: Redefine left/right buttons in ccw orientation

### DIFF
--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -2,8 +2,33 @@
 
 #include "CrossPointSettings.h"
 
-bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint8_t) const) const {
+bool (*MappedInputManager::stripReversedPredicate)() = nullptr;
+
+void MappedInputManager::setStripReversedPredicate(bool (*predicate)()) { stripReversedPredicate = predicate; }
+
+bool MappedInputManager::isVerticalStripReversed() {
+  return stripReversedPredicate != nullptr && stripReversedPredicate();
+}
+
+MappedInputManager::Button MappedInputManager::applyStripOrder(const Button button) {
+  if (!isVerticalStripReversed()) {
+    return button;
+  }
+  // Only the four front buttons sit on the reversed strip. Up/Down (and their
+  // PageBack/PageForward aliases) are the side buttons on a different edge — their
+  // physical order is unchanged by rotation, so they must not swap.
   switch (button) {
+    case Button::Left:
+      return Button::Right;
+    case Button::Right:
+      return Button::Left;
+    default:
+      return button;
+  }
+}
+
+bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint8_t) const) const {
+  switch (applyStripOrder(button)) {
     case Button::Back:
       return (gpio.*fn)(SETTINGS.frontButtonBack);
     case Button::Confirm:
@@ -27,7 +52,7 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
 }
 
 uint8_t MappedInputManager::rawIndex(const Button button) const {
-  switch (button) {
+  switch (applyStripOrder(button)) {
     case Button::Back:
       return SETTINGS.frontButtonBack;
     case Button::Confirm:
@@ -64,6 +89,12 @@ unsigned long MappedInputManager::getHeldTime() const { return gpio.getHeldTime(
 
 MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const char* confirm, const char* previous,
                                                          const char* next) const {
+  // On a reversed strip the Left/Right roles are swapped (see applyStripOrder), so the
+  // hint text has to follow — otherwise the label would contradict what the button does.
+  const bool reversed = isVerticalStripReversed();
+  const char* previousLabel = reversed ? next : previous;
+  const char* nextLabel = reversed ? previous : next;
+
   // Build the label order based on the configured hardware mapping.
   auto labelForHardware = [&](uint8_t hw) -> const char* {
     // Compare against configured logical roles and return the matching label.
@@ -74,10 +105,10 @@ MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const
       return confirm;
     }
     if (hw == SETTINGS.frontButtonLeft) {
-      return previous;
+      return previousLabel;
     }
     if (hw == SETTINGS.frontButtonRight) {
-      return next;
+      return nextLabel;
     }
     return "";
   };

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -15,6 +15,19 @@ class MappedInputManager {
 
   explicit MappedInputManager(HalGPIO& gpio) : gpio(gpio) {}
 
+  // Landscape CCW renders the front-button strip bottom-to-top, so the button that is
+  // physically *above* the other is the one portrait treats as "next/down". Without a
+  // swap the on-screen hints read "Down" above "Up" and pressing the upper button moves
+  // the selection down (issue #87). Both the logical Left/Right roles and their hint text
+  // follow the strip order — logical buttons survive orientation, raw indices do not.
+  //
+  // The predicate is installed once at startup (main.cpp) and queried live, so the flag
+  // can never go stale against a renderer whose orientation changed. It must answer for
+  // the orientation the *user* is holding, which is why the themes' transient flip to
+  // Portrait while drawing the hint strip is not allowed to feed it.
+  static void setStripReversedPredicate(bool (*predicate)());
+  static bool isVerticalStripReversed();
+
   void update() const { gpio.update(); }
   bool wasPressed(Button button) const;
   bool wasReleased(Button button) const;
@@ -41,6 +54,11 @@ class MappedInputManager {
 
  private:
   HalGPIO& gpio;
+  static bool (*stripReversedPredicate)();
+
+  // Left/Right (and their PageBack/PageForward aliases) swap when the front-button strip
+  // runs bottom-to-top on screen, so "previous" always sits above "next".
+  static Button applyStripOrder(Button button);
 
   bool mapButton(Button button, bool (HalGPIO::*fn)(uint8_t) const) const;
 };

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -56,8 +56,9 @@ class MappedInputManager {
   HalGPIO& gpio;
   static bool (*stripReversedPredicate)();
 
-  // Left/Right (and their PageBack/PageForward aliases) swap when the front-button strip
-  // runs bottom-to-top on screen, so "previous" always sits above "next".
+  // Left/Right swap when the front-button strip runs bottom-to-top on screen, so
+  // "previous" always sits above "next". The side buttons (Up/Down and their
+  // PageBack/PageForward aliases) are on a different edge and never swap.
   static Button applyStripOrder(Button button);
 
   bool mapButton(Button button, bool (HalGPIO::*fn)(uint8_t) const) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -702,6 +702,11 @@ void setup() {
   WEATHER_SETTINGS.loadFromFile();
   UITheme::getInstance().reload();
   ButtonNavigator::setMappedInputManager(mappedInputManager);
+  // In LandscapeCounterClockwise the front-button strip runs bottom-to-top on screen, so the
+  // logical Left/Right roles (and their hints) swap to keep "previous/Up" above "next/Down".
+  // See MappedInputManager::setStripReversedPredicate and issue #87.
+  MappedInputManager::setStripReversedPredicate(
+      [] { return renderer.getOrientation() == GfxRenderer::Orientation::LandscapeCounterClockwise; });
 
   // First serial output only here to avoid timing inconsistencies for power button press duration verification
   LOG_DBG("MAIN", "Starting CrossPoint version " CROSSPOINT_VERSION);


### PR DESCRIPTION
Fix issue #87 