### PR TITLE
fix: correct false charging indicator on X3

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -445,19 +445,27 @@ bool HalGPIO::isUsbConnected() const {
   if (deviceIsX3()) {
     // X3: GPIO20 is repurposed as I2C SDA, so the X4 pin-level USB detect is
     // unusable here — the I2C pull-ups would always report HIGH. Probe the
-    // BQ27220 fuel gauge instead. Using just Current() mis-reports "not
-    // connected" when the battery is full (current ~= 0 mA); combine it with
-    // the Flags() DSG bit so we report true whenever the charger is present
-    // (DSG=0 means charging or fully charged, not discharging).
+    // BQ27220 fuel gauge instead.
+    //
+    // Current() is the primary signal: it is signed, and current flowing INTO
+    // the battery (positive, above a noise floor) only happens on a charger.
+    // DSG alone must NOT be trusted as "charger present": the gauge clears DSG
+    // whenever the pack isn't actively discharging above its detection
+    // threshold, which includes plain idle/relaxation on battery. Treating
+    // DSG=0 as connected made the UI latch to the charging bolt shortly after
+    // unplugging and never recover (issue #86). FC (fully charged) is the one
+    // resting state that does imply a charger, since it only latches while
+    // topped off on the charger, so it stays as a secondary signal.
     for (uint8_t attempt = 0; attempt < 2; ++attempt) {
       uint16_t flags = 0;
       if (X3GPIO::readI2CReg16LE(I2C_ADDR_BQ27220, BQ27220_FLAGS_REG, &flags)) {
-        if ((flags & BQ27220_FLAG_DSG) == 0) {
-          return true;
+        const bool discharging = (flags & BQ27220_FLAG_DSG) != 0;
+        if (!discharging && (flags & BQ27220_FLAG_FC) != 0) {
+          return true;  // topped off on the charger
         }
         int16_t currentMa = 0;
-        if (X3GPIO::readBQ27220CurrentMA(&currentMa) && currentMa > 0) {
-          return true;
+        if (X3GPIO::readBQ27220CurrentMA(&currentMa) && currentMa > USB_CHARGE_CURRENT_MIN_MA) {
+          return true;  // measurable current into the battery
         }
         return false;
       }

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -29,8 +29,13 @@
 #define BQ27220_SOC_REG 0x2C     // StateOfCharge() command code (%)
 #define BQ27220_CUR_REG 0x0C     // Current() command code (signed mA)
 #define BQ27220_VOLT_REG 0x08    // Voltage() command code (mV)
-#define BQ27220_FLAGS_REG 0x0A   // BatteryStatus() / Flags() command code (bit0=DSG)
-#define BQ27220_FLAG_DSG 0x0001  // DSG bit: 1 = discharging, 0 = charging or at rest
+#define BQ27220_FLAGS_REG 0x0A   // BatteryStatus() / Flags() command code (bit0=DSG, bit9=FC)
+#define BQ27220_FLAG_DSG 0x0001  // DSG bit: 1 = discharging, 0 = charging OR merely at rest
+#define BQ27220_FLAG_FC 0x0200   // FC bit: 1 = fully charged (only latches while on the charger)
+// Minimum Current() reading (mA, positive = into the battery) that counts as
+// "on the charger". A small guard band above 0 keeps gauge noise around rest
+// from being read as charging.
+#define USB_CHARGE_CURRENT_MIN_MA 5
 
 // Analog DS3231 RTC I2C
 #define I2C_ADDR_DS3231 0x68  // RTC I2C address

--- a/src/SystemStatus.h
+++ b/src/SystemStatus.h
@@ -74,7 +74,10 @@ struct SystemStatus {
     const esp_partition_t* running = esp_ota_get_running_partition();
     s.flashAppPartitionSize = running ? static_cast<uint64_t>(running->size) : 0;
     s.batteryPercent = powerManager.getBatteryPercentage();
-    s.charging = digitalRead(UART0_RXD) == HIGH;
+    // Route through the HAL rather than reading UART0_RXD directly: that pin is
+    // the X4-only USB detect, and on X3 it is repurposed as I2C SDA, where the
+    // bus pull-ups made this read HIGH (= "charging") permanently.
+    s.charging = gpio.isUsbConnected();
     s.uptimeSeconds = millis() / 1000;
     s.macAddress = WiFi.macAddress().c_str();
     s.sdTotalBytes = 0;


### PR DESCRIPTION
Fixes #86 — on X3 the battery icon falsely shows the charging bolt after unplugging.

## Root cause

X3 can't use the X4's pin-level USB detect (GPIO20 is repurposed as I2C SDA, where the bus pull-ups always read HIGH), so `isUsbConnected()` infers charger presence from the BQ27220 fuel gauge. It treated `DSG == 0` as "charger present":

```cpp
if ((flags & BQ27220_FLAG_DSG) == 0) {
  return true;   // "not discharging" != "plugged in"
}
```

The gauge clears DSG whenever the pack isn't actively discharging *above its detection threshold* — which includes plain idle rest on battery. The old header comment said as much ("0 = charging **or at rest**"), but the code treated that as charger-present anyway.

That matches every detail of the report: correct while charging; briefly correct right after unplugging (battery still under load); then as the reader settles into low idle draw the gauge relaxes, DSG clears, and the bolt latches on and holds. Battery percentage was unaffected because it reads a different register (SoC `0x2C`).

## The fix

`Current()` becomes the primary signal — current flowing *into* the battery only happens on a charger — with a 5 mA guard band so gauge noise around rest doesn't read as charging. The full-battery case the DSG check was reaching for is now covered by **FC** (bit 9), which unlike DSG only latches while topped off on the charger.

## Also fixed

Two other consumers of the same detection, both checked:

- **`getWakeupReason()`** ([HalGPIO.cpp](../blob/fix/x3-charging-icon/lib/hal/HalGPIO.cpp)) — a battery POWERON at rest could be misclassified as `AfterUSBPower` and sent straight back to sleep. Same false-positive family, now gated on real charge current.
- **`SystemStatus`** ([SystemStatus.h](../blob/fix/x3-charging-icon/src/SystemStatus.h)) — read `digitalRead(UART0_RXD) == HIGH` directly and unconditionally, i.e. the X4-only method, so the web UI reported "charging" permanently on X3. Now routed through the HAL. `UART0_RXD` is no longer referenced outside the HAL.

`main.cpp`'s serial-log gate also calls this; it stays true whenever genuinely charging or FC-latched.
