### PR TITLE
fix: (x3) power down the SD rail for sleep instead of latching GPIO13

### DIFF
--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -1,6 +1,7 @@
 #include "HalPowerManager.h"
 
 #include <Logging.h>
+#include <PowerManager.h>
 #include <WiFi.h>
 #include <esp_sleep.h>
 
@@ -112,23 +113,38 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio, bool keepClockAlive) const {
   // Perform all hardware preparation immediately (while the button may still be held)
   // so the user gets instant visual feedback (display already off). Only block for
   // button release at the very end, right before entering sleep.
-  // GPIO13 is connected to the battery latch MOSFET.
+  // GPIO13 on X4 is the battery latch MOSFET.
   // When keepClockAlive is false (default): GPIO13 goes LOW, the MCU is
   // completely powered off during sleep (including the LP timer / RTC memory).
   // When keepClockAlive is true: GPIO13 stays HIGH, the MCU remains powered
   // at ~3-4 mA so the LP timer keeps running and RTC memory is preserved.
   // This allows HalClock to accurately compute elapsed sleep time on wake.
-  constexpr gpio_num_t GPIO_SPIWP = GPIO_NUM_13;
-  // Release any GPIO hold from a previous sleep cycle (keepClockAlive=true leaves GPIO13 held after wake).
-  // Without this, gpio_set_level() below silently fails and GPIO13 is stuck in its prior state,
-  // causing the device to enter a sleep/wake loop that requires a hardware reset to escape.
-  gpio_hold_dis(GPIO_SPIWP);
-  gpio_deep_sleep_hold_dis();
-  gpio_set_direction(GPIO_SPIWP, GPIO_MODE_OUTPUT);
-  gpio_set_level(GPIO_SPIWP, keepClockAlive ? 1 : 0);
-  esp_sleep_config_gpio_isolate();
-  gpio_deep_sleep_hold_en();
-  gpio_hold_en(GPIO_SPIWP);
+  //
+  // X3 does NOT share this meaning: there GPIO13 is the SD rail's power enable
+  // (active-high), declared as sd.powerEnable in the XTEINK_X3 board profiles.
+  // X3 keeps time on a battery-backed DS3231 (I2C 0x68), so it never needs the
+  // LP timer held alive across sleep — main.cpp forces keepLpAlive=false on X3
+  // for exactly that reason. So on X3 we hand the pin to the SDK's rail teardown
+  // (which cuts the card's power and latches it off) instead of treating it as a
+  // latch; SDCardManager::begin() releases that hold and re-powers on the next
+  // boot. Doing both would make us a second, independent writer of the pin.
+  if (gpio.deviceIsX3()) {
+    freeink::PowerManager::powerDownRailsForSleep();
+    esp_sleep_config_gpio_isolate();
+    gpio_deep_sleep_hold_en();
+  } else {
+    constexpr gpio_num_t GPIO_SPIWP = GPIO_NUM_13;
+    // Release any GPIO hold from a previous sleep cycle (keepClockAlive=true leaves GPIO13 held after wake).
+    // Without this, gpio_set_level() below silently fails and GPIO13 is stuck in its prior state,
+    // causing the device to enter a sleep/wake loop that requires a hardware reset to escape.
+    gpio_hold_dis(GPIO_SPIWP);
+    gpio_deep_sleep_hold_dis();
+    gpio_set_direction(GPIO_SPIWP, GPIO_MODE_OUTPUT);
+    gpio_set_level(GPIO_SPIWP, keepClockAlive ? 1 : 0);
+    esp_sleep_config_gpio_isolate();
+    gpio_deep_sleep_hold_en();
+    gpio_hold_en(GPIO_SPIWP);
+  }
   pinMode(InputManager::POWER_BUTTON_PIN, INPUT_PULLUP);
 
   // Now wait for the power button to be fully released before arming the wakeup

--- a/platformio.ini
+++ b/platformio.ini
@@ -87,6 +87,7 @@ lib_deps =
   InputManager=symlink://freeink-sdk/libs/hardware/InputManager
   EInkDisplay=symlink://freeink-sdk/libs/display/FreeInkDisplay
   SDCardManager=symlink://freeink-sdk/libs/hardware/SDCardManager
+  PowerManager=symlink://freeink-sdk/libs/hardware/PowerManager
   bblanchon/ArduinoJson @ 7.4.2
   QRCode=symlink://lib/QRCode
   links2004/WebSockets @ 2.7.3


### PR DESCRIPTION
## Summary

GPIO13 means different things on the two C3 boards, and we were applying the X4 meaning to both:

- **X4** — battery latch MOSFET. Held HIGH across sleep when `keepClockAlive` is set so the LP timer and RTC memory survive. **Unchanged by this PR.**
- **X3** — the SD rail's power enable (active-high). X3 keeps time on a battery-backed **DS3231** (I2C 0x68), so [main.cpp:345-347](../blob/master/src/main.cpp#L345-L347) already forces `keepLpAlive=false` there and the latch behaviour was dead code.

Because we treated it as a latch on X3, **the SD rail was never actually cut for sleep** — the card stayed powered and drained the battery.

## Changes

```
bddeac7a  chore(sdk): sync freeink-sdk to upstream main (e6a8048)
f6be6ea4  fix(x3): power down the SD rail for sleep instead of latching GPIO13
```

Kept as two commits so the SDK bump can be reverted independently of our code.

**SDK sync** — fast-forwards the submodule 23 commits (`fe5ad8d1` → `e6a8048`). Our checkout had drifted ahead of the recorded pointer *and had lost its `origin` remote entirely*, so it could not be fetched or compared against upstream. Remote restored; pointer now matches `Free-Ink/freeink-sdk` main exactly.

**The fix** — X3 now routes through the SDK's `PowerManager::powerDownRailsForSleep()`, which drives the enable to its inactive level and latches it off. `SDCardManager::begin()` already releases that hold and re-powers the card on the next boot, so the wake path needed no changes.

**Build plumbing** — `PowerManager` added to `lib_deps` in `platformio.ini`. SDK libs are opted into individually here and we had never used that one; it only depends on `BoardConfig`, which we already had.

## Attribution

The pin definition and the drain diagnosis are upstream's work, adopted via freeink-sdk `2da0700` (crosspoint-reader#2808). This PR is the consumer side, since we do not otherwise call the SDK rail teardown. Credited via `Co-authored-by` on the fix commit.
