### PR TITLE
fix: (opf/cover) stop the huge-manifest abort and the thumbnail full-book parse

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -770,6 +770,34 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   return true;
 }
 
+bool Epub::loadForCover() {
+  // Cover-only load: get coverItemHref WITHOUT building the spine/TOC book.bin (which, on a huge
+  // book, is both slow and the site of the large manifest-index build). Used by RecentBooks / Home
+  // cover thumbnails so showing a thumbnail never triggers a full-book parse.
+  bookMetadataCache.reset(new BookMetadataCache(cachePath));
+  cssParser.reset(new CssParser(cachePath));  // constructed for API symmetry; not parsed here
+
+  // Fast path: a book.bin already exists — it carries coverItemHref, no OPF parse needed.
+  if (bookMetadataCache->load()) {
+    return true;
+  }
+
+  // No cache: metadata-only OPF parse. OpfCacheMode::Disabled passes a null cache to ContentOpfParser,
+  // so NO manifest item index / .items.bin / spine cache is built — only title/author/coverItemHref
+  // are extracted. This is the whole point: a 1732-spine book contributes no giant index here.
+  if (!parseContentOpf(bookMetadataCache->coreMetadata, OpfCacheMode::Disabled)) {
+    LOG_INF("EBP", "loadForCover: content.opf parse failed for %s", filepath.c_str());
+    return false;
+  }
+  if (bookMetadataCache->coreMetadata.coverItemHref.empty()) {
+    return false;  // no discoverable cover — caller shows a placeholder
+  }
+  // Mark loaded so ensureCoverImageCached()'s isLoaded() gate passes. Spine/TOC stay empty — the
+  // caller uses only the cover path (documented on loadForCover / markCoverMetadataLoaded).
+  bookMetadataCache->markCoverMetadataLoaded();
+  return true;
+}
+
 bool Epub::clearCache(const bool preserveThumbs) const {
   if (!Storage.exists(cachePath.c_str())) {
     LOG_DBG("EPB", "Cache does not exist, no action needed");

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -113,6 +113,14 @@ class Epub {
   std::string& getBasePath() { return contentBasePath; }
   bool load(bool buildIfMissing = true, bool skipLoadingCss = false);
 
+  // Lightweight load for COVER thumbnails only: populate the cover image reference WITHOUT building
+  // the spine/TOC book.bin. Uses book.bin if it already exists; otherwise does a metadata-only OPF
+  // parse (OpfCacheMode::Disabled — no manifest item index, no .items.bin), which for a huge book
+  // (e.g. 1732 spines) avoids both the cost and the fragile large-index build of a full load(). After
+  // this, only the cover path is valid (getCoverImageCachePath / generateThumbBmp / cover extraction)
+  // — the spine/TOC accessors are NOT populated. Returns false if the cover reference can't be found.
+  bool loadForCover();
+
   // True when opening the book will trigger the (multi-second) first-open index
   // build inside load(): the spine/TOC cache (book.bin) or the compiled CSS rules
   // cache is missing. Cheap (only file-existence checks) so callers can decide

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -143,4 +143,9 @@ class BookMetadataCache {
   int getTocCount() const { return tocCount; }
   bool isTocReliable() const { return tocReliable; }
   bool isLoaded() const { return loaded; }
+  // Mark the cache "loaded" after a COVER-ONLY OPF parse populated coreMetadata (coverItemHref etc.)
+  // without building the spine/TOC book.bin. Lets cover extraction proceed (isLoaded() gate) while
+  // spineCount/tocCount stay 0 — the caller must NOT use the spine/TOC accessors in this state.
+  // See Epub::loadForCover(). This avoids the full 1732-spine book.bin build just to show a thumbnail.
+  void markCoverMetadataLoaded() { loaded = true; }
 };

--- a/lib/Epub/Epub/FootnoteEntry.h
+++ b/lib/Epub/Epub/FootnoteEntry.h
@@ -9,8 +9,12 @@ struct FootnoteEntry {
   char number[FOOTNOTE_NUMBER_LEN];
   char href[FOOTNOTE_HREF_LEN];
 
+  // Zero the WHOLE fixed-length arrays, not just the leading NUL: writeBlock serializes the full
+  // FOOTNOTE_NUMBER_LEN/HREF_LEN bytes, so uninitialized tail bytes after the terminator made
+  // content.bin non-deterministic (the same book compiled twice differed in that padding — harmless
+  // to readers, which stop at the NUL, but it broke byte-identity / cache fingerprinting).
   FootnoteEntry() {
-    number[0] = '\0';
-    href[0] = '\0';
+    std::memset(number, 0, sizeof(number));
+    std::memset(href, 0, sizeof(href));
   }
 };

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -437,6 +437,9 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
         self->useItemIndex = true;
         LOG_DBG("COF", "Using fast index for %zu manifest items", self->itemIndex.size());
       }
+      // (A manifest past MAX_INDEX_ENTRIES latched indexDisabled_ and CLEARED itemIndex above, so its
+      // size is now < LARGE_SPINE_THRESHOLD and this whole block is skipped → linear scan. No branch
+      // needed here.)
     }
     return;
   }
@@ -548,12 +551,25 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
     // full FsFile call each). The index entry records the position AFTER the id string:
     // hash-trusted lookups seek straight to the href and never re-read the id.
     self->itemWriter_->writeString(itemId);
-    if (self->tempItemStore) {
-      ItemIndexEntry entry;
-      entry.idHash = fnvHash(itemId);
-      entry.idLen = static_cast<uint16_t>(itemId.size());
-      entry.hrefOffset = self->itemWriter_->position();
-      self->itemIndex.push_back(entry);
+    if (self->tempItemStore && !self->indexDisabled_) {
+      // A huge manifest (e.g. a 1732-spine book) would grow this in-RAM index until a deque chunk
+      // allocation fails — and the device build is -fno-exceptions, so a throwing operator new aborts
+      // the firmware (observed: bad_alloc -> terminate on King's Avatar). CAP the index: past
+      // MAX_INDEX_ENTRIES, abandon it (drop what we have, latch disabled) and let idref lookups use
+      // the exact linear scan over .items.bin. The index is a pure speed optimisation; correctness is
+      // unaffected. The cap is well above normal books and far below the point of heap trouble.
+      if (self->itemIndex.size() >= MAX_INDEX_ENTRIES) {
+        self->indexDisabled_ = true;
+        self->itemIndex.clear();
+        self->itemIndex.shrink_to_fit();
+        LOG_INF("COF", "manifest exceeds %u items; using linear idref lookup (no fast index)", MAX_INDEX_ENTRIES);
+      } else {
+        ItemIndexEntry entry;
+        entry.idHash = fnvHash(itemId);
+        entry.idLen = static_cast<uint16_t>(itemId.size());
+        entry.hrefOffset = self->itemWriter_->position();
+        self->itemIndex.push_back(entry);
+      }
     }
     self->itemWriter_->writeString(href);
 

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -552,23 +552,20 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
     // hash-trusted lookups seek straight to the href and never re-read the id.
     self->itemWriter_->writeString(itemId);
     if (self->tempItemStore && !self->indexDisabled_) {
-      // A huge manifest (e.g. a 1732-spine book) would grow this in-RAM index until a deque chunk
-      // allocation fails — and the device build is -fno-exceptions, so a throwing operator new aborts
-      // the firmware (observed: bad_alloc -> terminate on King's Avatar). CAP the index: past
-      // MAX_INDEX_ENTRIES, abandon it (drop what we have, latch disabled) and let idref lookups use
-      // the exact linear scan over .items.bin. The index is a pure speed optimisation; correctness is
-      // unaffected. The cap is well above normal books and far below the point of heap trouble.
-      if (self->itemIndex.size() >= MAX_INDEX_ENTRIES) {
+      ItemIndexEntry entry;
+      entry.idHash = fnvHash(itemId);
+      entry.idLen = static_cast<uint16_t>(itemId.size());
+      entry.hrefOffset = self->itemWriter_->position();
+      // Grow the in-RAM index with NOTHROW allocation. It keeps growing as long as the heap can hold
+      // it (~12 bytes/item), so even a 1732-spine book keeps the fast binary-search index whenever
+      // memory allows. Only if a growth genuinely can't be satisfied (OOM / fragmentation) do we
+      // abandon the index and fall back to the exact linear scan over .items.bin — never abort (the
+      // device is -fno-exceptions). No arbitrary item-count cap: memory is the only limit.
+      if (!self->itemIndex.push_back(entry)) {
         self->indexDisabled_ = true;
-        self->itemIndex.clear();
-        self->itemIndex.shrink_to_fit();
-        LOG_INF("COF", "manifest exceeds %u items; using linear idref lookup (no fast index)", MAX_INDEX_ENTRIES);
-      } else {
-        ItemIndexEntry entry;
-        entry.idHash = fnvHash(itemId);
-        entry.idLen = static_cast<uint16_t>(itemId.size());
-        entry.hrefOffset = self->itemWriter_->position();
-        self->itemIndex.push_back(entry);
+        LOG_INF("COF", "manifest index OOM at %zu items; using linear idref lookup for this book",
+                self->itemIndex.size());
+        self->itemIndex.clear();  // free the partial index; lookups use the linear scan
       }
     }
     self->itemWriter_->writeString(href);

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -83,7 +83,11 @@ class ContentOpfParser final : public Print {
       data_[size_++] = e;
       return true;
     }
-    void clear() { data_.reset(); size_ = 0; cap_ = 0; }
+    void clear() {
+      data_.reset();
+      size_ = 0;
+      cap_ = 0;
+    }
     size_t size() const { return size_; }
     ItemIndexEntry* begin() { return data_.get(); }
     ItemIndexEntry* end() { return data_.get() + size_; }

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -1,11 +1,15 @@
 #pragma once
 #include <BufferedFileIO.h>
+#include <Memory.h>  // makeUniqueNoThrow — nothrow growth (device is -fno-exceptions)
 #include <Print.h>
 #include <SaxParser/SaxParser.h>
 
 #include <algorithm>
-#include <deque>
+#include <cstddef>
+#include <cstring>
+#include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "Epub.h"
@@ -56,15 +60,38 @@ class ContentOpfParser final : public Print {
     uint16_t idLen;       // length for collision reduction
     uint32_t hrefOffset;  // offset of the href string in .items.bin (record's id skipped)
   };
-  std::deque<ItemIndexEntry> itemIndex;
+  // In-RAM manifest fast index (sorted by (idHash,idLen) for binary-search idref lookup). Grown with
+  // NOTHROW allocation (device is -fno-exceptions, so a throwing container abort()s on a fragmented
+  // heap — observed on a 1732-spine book). It grows as long as memory allows; the FIRST growth that
+  // can't be satisfied latches indexDisabled_ and idref lookups fall back to the exact linear scan
+  // over .items.bin. So a big book keeps the fast index whenever the heap can hold it (~12 bytes/item),
+  // and only genuinely-out-of-memory books degrade — no arbitrary item-count cap. The index is a pure
+  // speed optimisation, never correctness. push_back returns false on OOM (never throws).
+  struct ItemIndexVec {
+    std::unique_ptr<ItemIndexEntry[]> data_;
+    size_t size_ = 0;
+    size_t cap_ = 0;
+    bool push_back(const ItemIndexEntry& e) {
+      if (size_ == cap_) {
+        const size_t newCap = cap_ == 0 ? 64 : cap_ * 2;
+        auto next = makeUniqueNoThrow<ItemIndexEntry[]>(newCap);
+        if (!next) return false;  // OOM — caller disables the index, falls back to linear scan
+        if (size_ > 0) std::memcpy(next.get(), data_.get(), size_ * sizeof(ItemIndexEntry));
+        data_ = std::move(next);
+        cap_ = newCap;
+      }
+      data_[size_++] = e;
+      return true;
+    }
+    void clear() { data_.reset(); size_ = 0; cap_ = 0; }
+    size_t size() const { return size_; }
+    ItemIndexEntry* begin() { return data_.get(); }
+    ItemIndexEntry* end() { return data_.get() + size_; }
+    const ItemIndexEntry& operator[](size_t i) const { return data_[i]; }
+  };
+  ItemIndexVec itemIndex;
   bool useItemIndex = false;
-  // Latched when the manifest exceeds MAX_INDEX_ENTRIES: the in-RAM fast index is abandoned for this
-  // book (dropped) and idref lookups use the exact linear scan over .items.bin. The device build is
-  // -fno-exceptions, so letting the deque grow until a chunk alloc fails would ABORT the firmware
-  // (observed on a 1732-spine book); the cap prevents that. The index is a pure speed optimisation,
-  // never correctness. Chosen well above normal books (~hundreds of items) and far below heap trouble.
-  bool indexDisabled_ = false;
-  static constexpr size_t MAX_INDEX_ENTRIES = 1200;
+  bool indexDisabled_ = false;  // latched when an index growth hit OOM → linear-scan fallback
 
   // Memo of the last manifest item's media-type and its classification (MediaClass enum in the
   // .cpp, stored as its uint8_t value here). Manifest items overwhelmingly repeat one media type

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -58,6 +58,13 @@ class ContentOpfParser final : public Print {
   };
   std::deque<ItemIndexEntry> itemIndex;
   bool useItemIndex = false;
+  // Latched when the manifest exceeds MAX_INDEX_ENTRIES: the in-RAM fast index is abandoned for this
+  // book (dropped) and idref lookups use the exact linear scan over .items.bin. The device build is
+  // -fno-exceptions, so letting the deque grow until a chunk alloc fails would ABORT the firmware
+  // (observed on a 1732-spine book); the cap prevents that. The index is a pure speed optimisation,
+  // never correctness. Chosen well above normal books (~hundreds of items) and far below heap trouble.
+  bool indexDisabled_ = false;
+  static constexpr size_t MAX_INDEX_ENTRIES = 1200;
 
   // Memo of the last manifest item's media-type and its classification (MediaClass enum in the
   // .cpp, stored as its uint8_t value here). Manifest items overwhelmingly repeat one media type

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<ReaderActivity::CoverExtractSession> ReaderActivity::beginCoverE
   if (!sidecarCoverPath(bookPath).empty()) return nullptr;  // sidecar takes priority; no extract needed
 
   Epub epub(bookPath, "/.crosspoint");
-  if (!epub.load(true, true)) return nullptr;
+  if (!epub.loadForCover()) return nullptr;  // cover ref only, no full book.bin build
 
   // If cover.img already exists and is a recognized image format, no extraction
   // needed. Must match the decode side's validity check (coverImageCachedValidOnly,
@@ -366,9 +366,10 @@ void healStaleEpubSentinel(const std::string& bookPath, const std::string& thumb
   if (!isSentinel) return;
 
   // coverImageCachedValidOnly() checks cover.img exists + non-empty + a known image format,
-  // without triggering any extraction — exactly the "sentinel is stale" condition.
+  // without triggering any extraction — exactly the "sentinel is stale" condition. loadForCover()
+  // gets the cover ref without a full book.bin build.
   Epub epub(bookPath, "/.crosspoint");
-  if (epub.load(true, true) && epub.coverImageCachedValidOnly()) {
+  if (epub.loadForCover() && epub.coverImageCachedValidOnly()) {
     LOG_DBG("COVER", "Healing stale sentinel %s (cover.img present & valid)", thumbFile.c_str());
     Storage.remove(thumbFile.c_str());
   }
@@ -408,9 +409,11 @@ ThumbResult ReaderActivity::ensureCoverThumb(const std::string& bookPath, int wi
     // so a book whose cover.img is actually present & valid gets decoded instead of skipped.
     healStaleEpubSentinel(bookPath, file);
     Epub epub(bookPath, "/.crosspoint");
-    // allowExtract=false: decode only an already-cached cover.img; the sliced
+    // loadForCover(): get the cover reference WITHOUT building the spine/TOC book.bin — showing a
+    // thumbnail must never trigger a full-book parse (a 1732-spine book's index build is slow and was
+    // a crash site). allowExtract=false: decode only an already-cached cover.img; the sliced
     // beginCoverExtractSession owns the (potentially multi-second) ZIP inflate.
-    if (!epub.load(true, true)) return ThumbResult::TransientFail;
+    if (!epub.loadForCover()) return ThumbResult::TransientFail;
     return epub.generateThumbBmp(width, height, /*allowExtract=*/false);
   }
   if (FsHelpers::hasXtcExtension(bookPath)) {
@@ -452,9 +455,10 @@ ThumbResult ReaderActivity::ensureCoverThumb(const std::string& bookPath, int he
     // Clear any sentinel left permanent by an older build for what was only a transient failure.
     healStaleEpubSentinel(bookPath, file);
     Epub epub(bookPath, "/.crosspoint");
+    // loadForCover(): cover reference only, no full book.bin build (see the width/height overload).
     // allowExtract=false: decode only an already-cached cover.img; the sliced
     // beginCoverExtractSession owns the (potentially multi-second) ZIP inflate.
-    if (!epub.load(true, true)) return ThumbResult::TransientFail;
+    if (!epub.loadForCover()) return ThumbResult::TransientFail;
     return epub.generateThumbBmp(height, /*allowExtract=*/false);
   }
   if (FsHelpers::hasXtcExtension(bookPath)) {
@@ -497,7 +501,7 @@ std::unique_ptr<PngDecodeSession> beginPngThumbSessionImpl(const std::string& bo
     // runs first in the caller's ladder and produces it). Otherwise return null so the
     // caller falls through to that sliced extraction.
     Epub epub(bookPath, "/.crosspoint");
-    if (!epub.load(true, true)) return nullptr;
+    if (!epub.loadForCover()) return nullptr;  // cover ref only, no full book.bin build
     srcPath = epub.getCoverImageCachePath();
     FsFile peek;
     if (!Storage.openFileForRead("PNG", srcPath, peek)) return nullptr;  // not yet extracted

--- a/test/epub_opf/CMakeLists.txt
+++ b/test/epub_opf/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories(ContentOpfParserTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${REPO_ROOT}
   ${REPO_ROOT}/lib
+  ${REPO_ROOT}/lib/Memory  # Memory.h (makeUniqueNoThrow) — matches the device per-lib include path
   ${REPO_ROOT}/lib/Epub
   ${REPO_ROOT}/lib/Epub/Epub
   ${REPO_ROOT}/lib/Epub/Epub/parsers

--- a/test/epub_opf/ContentOpfParserTest.cpp
+++ b/test/epub_opf/ContentOpfParserTest.cpp
@@ -319,11 +319,13 @@ TEST(ContentOpfParser, ResolvesSpineIdrefsUsingIndexedLookupForLargeManifest) {
   EXPECT_EQ(capturedSpineHrefs[2], "book/OEBPS/text/ch0.xhtml");
 }
 
-// A manifest past MAX_INDEX_ENTRIES (the King's Avatar case: 1732 items) must NOT build the in-RAM
-// fast index — on the -fno-exceptions device build that grows until a deque chunk alloc aborts the
-// firmware. It must still OPEN and resolve every spine idref via the exact linear scan. This is the
-// regression guard for "a huge book crashes the device": the book opens, just with linear lookups.
-TEST(ContentOpfParser, HugeManifestResolvesViaLinearScanWithoutIndex) {
+// A huge manifest (the King's Avatar case: 1732 items) must parse without aborting and resolve every
+// spine idref. The in-RAM index grows with NOTHROW allocation — kept when memory allows (the common
+// case, and what the host has), dropped for the exact linear scan only on genuine OOM. Either way the
+// book OPENS and resolves correctly. This is the regression guard for "a huge book crashes the device"
+// (it used to abort building the index on -fno-exceptions) AND for "the fallback is O(N^2) slow" (the
+// index is kept when there's memory, so a big book stays fast).
+TEST(ContentOpfParser, HugeManifestResolvesCorrectly) {
   const std::string cacheDir = makeTempDir();
   ASSERT_FALSE(cacheDir.empty());
   TempDirGuard dirGuard(cacheDir);

--- a/test/epub_opf/ContentOpfParserTest.cpp
+++ b/test/epub_opf/ContentOpfParserTest.cpp
@@ -319,6 +319,45 @@ TEST(ContentOpfParser, ResolvesSpineIdrefsUsingIndexedLookupForLargeManifest) {
   EXPECT_EQ(capturedSpineHrefs[2], "book/OEBPS/text/ch0.xhtml");
 }
 
+// A manifest past MAX_INDEX_ENTRIES (the King's Avatar case: 1732 items) must NOT build the in-RAM
+// fast index — on the -fno-exceptions device build that grows until a deque chunk alloc aborts the
+// firmware. It must still OPEN and resolve every spine idref via the exact linear scan. This is the
+// regression guard for "a huge book crashes the device": the book opens, just with linear lookups.
+TEST(ContentOpfParser, HugeManifestResolvesViaLinearScanWithoutIndex) {
+  const std::string cacheDir = makeTempDir();
+  ASSERT_FALSE(cacheDir.empty());
+  TempDirGuard dirGuard(cacheDir);
+
+  std::vector<std::string> capturedSpineHrefs;
+  ScopedSpineHrefSink sinkGuard(&capturedSpineHrefs);
+
+  constexpr int kItemCount = 1500;  // > MAX_INDEX_ENTRIES (1200) → index capped/disabled, linear scan
+  const std::string base = "/book/OEBPS/";
+  const std::string xml =
+      "<?xml version='1.0' encoding='utf-8'?>"
+      "<package xmlns:opf='http://www.idpf.org/2007/opf' xmlns:dc='http://purl.org/dc/elements/1.1/'>"
+      "<metadata><dc:title>Huge</dc:title></metadata>"
+      "<manifest>" +
+      buildManifestItems(kItemCount) +
+      "</manifest>"
+      "<spine>"
+      "<itemref idref='ch1499'/>"  // last item — resolvable only if the whole manifest was stored
+      "<itemref idref='ch750'/>"   // middle
+      "<itemref idref='missing'/>"
+      "<itemref idref='ch0'/>"     // first
+      "</spine>"
+      "</package>";
+
+  BookMetadataCache cache(cacheDir);
+  ContentOpfParser parser(cacheDir, base, xml.size(), &cache);
+  ASSERT_TRUE(parseOpfXml(parser, xml)) << "a 1500-item manifest must parse without aborting";
+
+  ASSERT_EQ(capturedSpineHrefs.size(), 3u);
+  EXPECT_EQ(capturedSpineHrefs[0], "book/OEBPS/text/ch1499.xhtml");
+  EXPECT_EQ(capturedSpineHrefs[1], "book/OEBPS/text/ch750.xhtml");
+  EXPECT_EQ(capturedSpineHrefs[2], "book/OEBPS/text/ch0.xhtml");
+}
+
 TEST(ContentOpfParser, DisablesHashTrustedIndexOnDuplicateIdsAndStillResolves) {
   const std::string cacheDir = makeTempDir();
   ASSERT_FALSE(cacheDir.empty());

--- a/test/epub_opf/ContentOpfParserTest.cpp
+++ b/test/epub_opf/ContentOpfParserTest.cpp
@@ -346,7 +346,7 @@ TEST(ContentOpfParser, HugeManifestResolvesCorrectly) {
       "<itemref idref='ch1499'/>"  // last item — resolvable only if the whole manifest was stored
       "<itemref idref='ch750'/>"   // middle
       "<itemref idref='missing'/>"
-      "<itemref idref='ch0'/>"     // first
+      "<itemref idref='ch0'/>"  // first
       "</spine>"
       "</package>";
 


### PR DESCRIPTION
Standalone-merit fixes recovered from the paused `feat-stage1-extraction` branch. They are independent of the Stage-1 / content.bin work (which stays parked) and each fixes something live on `master` today.

## Why now

Reviewing the paused branch for salvageable work, its own cherry-pick doc turned out to be stale — three of the four fixes it listed had already landed on master. What it *missed* is this set, which was recorded in memory as a real device crash but never ported.

## What's in it

**1-2. Manifest fast-index no longer aborts the firmware** (`32f4ec2a`, `7756cef9`)

The in-RAM OPF manifest index was a `std::deque`. The device builds `-fno-exceptions`, so a failed chunk allocation on a fragmented heap turns libstdc++'s throwing `operator new` into a direct `abort()`. A 1732-item manifest (King's Avatar) reproduced it just by drawing a thumbnail in RecentBooks.

Replaced with `ItemIndexVec`, a nothrow-grown doubling array over `makeUniqueNoThrow`. It keeps the fast binary-search index whenever the heap can hold it (~12 B/item), and only a growth that genuinely cannot be satisfied latches `indexDisabled_` and falls back to the exact linear scan over `.items.bin`. Correctness is never at stake — the index is purely a speed optimisation.

The two commits are kept in sequence because the second explains the first: `32f4ec2a`'s coarse 1200-item cap sent King's Avatar straight to the O(N) linear scan, and since the OPF parse resolves an idref per spine itemref that is O(N²) — measured **110 seconds** to parse content.opf. `7756cef9` removes the cap. Squash on merge if preferred.

**3. Cover thumbnails no longer trigger a full book parse** (`8a4681fa`)

`ensureCoverThumb` and friends called `epub.load(true, true)`, which builds the entire spine/TOC `book.bin` when missing — a full OPF parse plus manifest index, just to show a thumbnail. Adds `Epub::loadForCover()`: uses `book.bin` if it already exists, otherwise a metadata-only OPF parse (`OpfCacheMode::Disabled` — no manifest index, no `.items.bin`, no spine cache) and marks the metadata loaded so cover extraction's `isLoaded()` gate passes. Rewires all five cover entry points in `ReaderActivity`.

After this a huge book contributes no giant manifest index merely to render its thumbnail — faster, and defence-in-depth on top of fix 1-2. Only the cover path is valid after `loadForCover()`; spine/TOC accessors stay empty, as documented on the method.

**4. FootnoteEntry zero-inits its full arrays** (`5ded779f`)

The constructor set only the leading NUL, leaving uninitialized tail bytes. Readers stop at the NUL so nothing is broken today — this is hygiene that makes any byte-for-byte serialization of the struct deterministic.
