### PR TITLE
perf: batch streamed web responses and harden allocation

### DIFF
--- a/src/network/ChunkedResponse.h
+++ b/src/network/ChunkedResponse.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <Logging.h>
+#include <Memory.h>
+#include <WebServer.h>
+#include <esp_task_wdt.h>
+
+#include <cstring>
+#include <memory>
+
+// Coalesces a chunked (CONTENT_LENGTH_UNKNOWN) response body into TCP-sized
+// writes. Written naively, a streamed listing calls sendContent() once per
+// entry, and every call is its own HTTP chunk — chunk header, TCP write, and
+// the WebServer library's internal malloc for the chunk-size line. On a folder
+// with a few hundred files that dominates the response time.
+//
+// Ported from CrossInk commit 1d6b82f ("perf: batch web file list responses",
+// Julia Nguyen and Justin Mitchell), which back-ported crosspoint-reader
+// 302c0771. Generalised here from the JSON file listing to every streamed list
+// response, including WebDAV PROPFIND.
+class ChunkedResponse {
+ public:
+  explicit ChunkedResponse(WebServer* server) : server(server) {
+    // ~1 TCP segment. Heap rather than stack: handleClient() runs on the shared
+    // Arduino loop task, below the whole activity call chain and alongside a 1KB
+    // serialization buffer in the settings handler, so 1.4KB is not free there.
+    // The allocation is fallible and a failure degrades to the old per-entry
+    // sends rather than failing the request.
+    buffer = makeUniqueNoThrow<char[]>(CAPACITY);
+    if (!buffer) {
+      LOG_ERR("WEB", "OOM: chunked response buffer; falling back to per-entry sends");
+    }
+  }
+
+  void append(const char* data, size_t len) {
+    if (!buffer) {
+      server->sendContent(data, len);
+      return;
+    }
+    if (used + len > CAPACITY) flush();
+    if (len > CAPACITY) {
+      // Longer than the whole buffer — send it on its own rather than truncating.
+      server->sendContent(data, len);
+      return;
+    }
+    memcpy(buffer.get() + used, data, len);
+    used += len;
+  }
+
+  void append(const char* str) { append(str, strlen(str)); }
+
+  // Flushes the tail and terminates the chunked response with the empty chunk.
+  void finish() {
+    flush();
+    server->sendContent("");
+  }
+
+ private:
+  static constexpr size_t CAPACITY = 1400;
+
+  void flush() {
+    if (used == 0) return;
+    esp_task_wdt_reset();
+    server->sendContent(buffer.get(), used);
+    used = 0;
+    esp_task_wdt_reset();
+  }
+
+  WebServer* server;
+  std::unique_ptr<char[]> buffer;
+  size_t used = 0;
+};
+
+// JSON-array framing on top of ChunkedResponse: owns the brackets and the
+// separating commas so callers cannot emit a leading or doubled comma when an
+// entry is skipped.
+class ChunkedJsonArray {
+ public:
+  explicit ChunkedJsonArray(WebServer* server) : out(server) { out.append("[", 1); }
+
+  void addEntry(const char* json, size_t len) {
+    if (seenFirst) out.append(",", 1);
+    seenFirst = true;
+    out.append(json, len);
+  }
+
+  void finish() {
+    out.append("]", 1);
+    out.finish();
+  }
+
+ private:
+  ChunkedResponse out;
+  bool seenFirst = false;
+};

--- a/src/network/ChunkedResponse.h
+++ b/src/network/ChunkedResponse.h
@@ -43,7 +43,10 @@ class ChunkedResponse {
       server->sendContent(data, len);
       return;
     }
-    memcpy(buffer.get() + used, data, len);
+    // Typed local rather than arithmetic directly on get(): cppcheck does not
+    // resolve the unique_ptr<char[]> specialisation and reads get() as void*.
+    char* const base = buffer.get();
+    memcpy(base + used, data, len);
     used += len;
   }
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -6,6 +6,7 @@
 #include <HalClock.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Txt.h>
 #include <WiFi.h>
 #include <Xtc.h>
@@ -16,6 +17,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "ChunkedResponse.h"
 #include "CrossPointSettings.h"
 #include "FontInstaller.h"
 #include "HttpFileStreamer.h"
@@ -209,7 +211,13 @@ void CrossPointWebServer::begin() {
   LOG_DBG("WEB", "Network mode: %s", apMode ? "AP" : "STA");
 
   LOG_DBG("WEB", "Creating web server on port %d...", port);
-  server.reset(new WebServer(port));
+  // Nothrow: the build is -fno-exceptions, so a bare `new` would abort() on a
+  // fragmented heap instead of letting the check below report the failure.
+  server = makeUniqueNoThrow<WebServer>(port);
+  if (!server) {
+    LOG_ERR("WEB", "Failed to create WebServer!");
+    return;
+  }
 
   // Disable WiFi sleep to improve responsiveness and prevent 'unreachable' errors.
   // This is critical for reliable web server operation on ESP32.
@@ -219,11 +227,6 @@ void CrossPointWebServer::begin() {
   // We rely on disabling WiFi sleep for responsiveness.
 
   LOG_DBG("WEB", "[MEM] Free heap after WebServer allocation: %d bytes", ESP.getFreeHeap());
-
-  if (!server) {
-    LOG_ERR("WEB", "Failed to create WebServer!");
-    return;
-  }
 
   // Setup routes
   LOG_DBG("WEB", "Setting up routes...");
@@ -285,18 +288,30 @@ void CrossPointWebServer::begin() {
   // Collect WebDAV headers and register handler
   const char* davHeaders[] = {"Depth", "Destination", "Overwrite", "If", "Lock-Token", "Timeout"};
   server->collectHeaders(davHeaders, 6);
-  server->addHandler(new WebDAVHandler());  // Note: WebDAVHandler will be deleted by WebServer when server is stopped
-  LOG_DBG("WEB", "WebDAV handler initialized");
+  // Ownership passes to the WebServer, which deletes the handler when stopped.
+  // On OOM the HTTP server still comes up; only WebDAV is unavailable.
+  if (auto davHandler = makeUniqueNoThrow<WebDAVHandler>()) {
+    server->addHandler(davHandler.release());
+    LOG_DBG("WEB", "WebDAV handler initialized");
+  } else {
+    LOG_ERR("WEB", "OOM: WebDAV handler — WebDAV disabled");
+  }
 
   server->begin();
 
-  // Start WebSocket server for fast binary uploads
+  // Start WebSocket server for fast binary uploads. On OOM the rest of the
+  // server stays up; uploads fall back to the plain HTTP path. Every other
+  // wsServer use is already null-guarded.
   LOG_DBG("WEB", "Starting WebSocket server on port %d...", wsPort);
-  wsServer.reset(new WebSocketsServer(wsPort));
-  wsInstance = const_cast<CrossPointWebServer*>(this);
-  wsServer->begin();
-  wsServer->onEvent(wsEventCallback);
-  LOG_DBG("WEB", "WebSocket server started");
+  wsServer = makeUniqueNoThrow<WebSocketsServer>(wsPort);
+  if (wsServer) {
+    wsInstance = const_cast<CrossPointWebServer*>(this);
+    wsServer->begin();
+    wsServer->onEvent(wsEventCallback);
+    LOG_DBG("WEB", "WebSocket server started");
+  } else {
+    LOG_ERR("WEB", "OOM: WebSocket server — binary uploads disabled");
+  }
 
   udpActive = udp.begin(LOCAL_UDP_PORT);
   LOG_DBG("WEB", "Discovery UDP %s on port %d", udpActive ? "enabled" : "failed", LOCAL_UDP_PORT);
@@ -694,7 +709,7 @@ void CrossPointWebServer::handleStatusFast() const {
   sendJson(server.get(), 200, doc);
 }
 
-void CrossPointWebServer::scanFiles(const char* path, const std::function<void(FileInfo)>& callback) const {
+void CrossPointWebServer::scanFiles(const char* path, const FileVisitor visitor, void* context) const {
   FsFile root = Storage.open(path);
   if (!root) {
     LOG_DBG("WEB", "Failed to open directory: %s", path);
@@ -741,7 +756,7 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
         info.isEpub = isEpubFile(info.name);
       }
 
-      callback(info);
+      visitor(info, context);
     }
 
     file.close();
@@ -780,40 +795,39 @@ void CrossPointWebServer::handleFileListData() const {
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
   esp_task_wdt_reset();
-  server->sendContent("[");
-  char output[513];
-  constexpr size_t jsonOffset = 1;
-  constexpr size_t jsonSize = sizeof(output) - jsonOffset;
-  bool seenFirst = false;
+  ChunkedJsonArray out(server.get());
+  char output[512];
+  constexpr size_t outputSize = sizeof(output);
   JsonDocument doc;
 
-  scanFiles(currentPath.c_str(), [this, &output, &doc, seenFirst](const FileInfo& info) mutable {
-    esp_task_wdt_reset();
-    doc.clear();
-    doc["name"] = info.name;
-    doc["size"] = info.size;
-    doc["isDirectory"] = info.isDirectory;
-    doc["isEpub"] = info.isEpub;
+  struct FileListContext {
+    ChunkedJsonArray* out;
+    char* output;
+    JsonDocument* doc;
+  } context{&out, output, &doc};
 
-    const size_t written = serializeJson(doc, output + jsonOffset, jsonSize);
-    if (written >= jsonSize) {
-      LOG_DBG("WEB", "Skipping file entry with oversized JSON for name: %s", info.name.c_str());
-      return;
-    }
+  scanFiles(
+      currentPath.c_str(),
+      [](const FileInfo& info, void* rawContext) {
+        auto& ctx = *static_cast<FileListContext*>(rawContext);
+        esp_task_wdt_reset();
+        ctx.doc->clear();
+        (*ctx.doc)["name"] = info.name;
+        (*ctx.doc)["size"] = info.size;
+        (*ctx.doc)["isDirectory"] = info.isDirectory;
+        (*ctx.doc)["isEpub"] = info.isEpub;
 
-    if (seenFirst) {
-      output[0] = ',';
-      server->sendContent(output, jsonOffset + written);
-    } else {
-      seenFirst = true;
-      server->sendContent(output + jsonOffset, written);
-    }
-    esp_task_wdt_reset();
-  });
+        const size_t written = serializeJson(*ctx.doc, ctx.output, outputSize);
+        if (written >= outputSize) {
+          LOG_DBG("WEB", "Skipping file entry with oversized JSON for name: %s", info.name.c_str());
+          return;
+        }
+        ctx.out->addEntry(ctx.output, written);
+      },
+      &context);
 
   esp_task_wdt_reset();
-  server->sendContent("]");
-  server->sendContent("");
+  out.finish();
   LOG_WEB_MEM("files_exit");
   LOG_DBG("WEB", "Served file listing page for path: %s", currentPath.c_str());
 }
@@ -1459,27 +1473,19 @@ void CrossPointWebServer::handleGetSettings() const {
 
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
-  server->sendContent("[");
+  ChunkedJsonArray out(server.get());
 
-  char output[1025];
-  constexpr size_t jsonOffset = 1;
-  constexpr size_t jsonSize = sizeof(output) - jsonOffset;
-  bool seenFirst = false;
+  char output[1024];
+  constexpr size_t outputSize = sizeof(output);
   JsonDocument doc;
 
   auto sendEntry = [&]() {
-    const size_t written = serializeJson(doc, output + jsonOffset, jsonSize);
-    if (written >= jsonSize) {
+    const size_t written = serializeJson(doc, output, outputSize);
+    if (written >= outputSize) {
       LOG_DBG("WEB", "Settings entry JSON truncated (key=%s)", doc["key"].as<const char*>());
       return;
     }
-    if (seenFirst) {
-      output[0] = ',';
-      server->sendContent(output, jsonOffset + written);
-    } else {
-      seenFirst = true;
-      server->sendContent(output + jsonOffset, written);
-    }
+    out.addEntry(output, written);
   };
 
   for (const auto& sBase : settings) {
@@ -1579,8 +1585,7 @@ void CrossPointWebServer::handleGetSettings() const {
   appendValueSetting("refreshFrequencyPages", I18N.get(StrId::STR_REFRESH_FREQ), I18N.get(StrId::STR_CAT_DISPLAY),
                      I18N.get(StrId::STR_MENU_DISP_REFRESH), SETTINGS.refreshFrequencyPages, 0, 60, 1);
 
-  server->sendContent("]");
-  server->sendContent("");
+  out.finish();
   LOG_WEB_MEM("settings_exit");
   LOG_DBG("WEB", "Served settings API");
 }
@@ -2326,7 +2331,7 @@ void CrossPointWebServer::handleGetWifiNetworks() const {
   // Stream JSON array incrementally to avoid allocating the full response in memory
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
-  server->sendContent("[");
+  ChunkedJsonArray out(server.get());
 
   char output[320];
   constexpr size_t outputSize = sizeof(output);
@@ -2343,12 +2348,10 @@ void CrossPointWebServer::handleGetWifiNetworks() const {
     const size_t written = serializeJson(doc, output, outputSize);
     if (written >= outputSize) continue;
 
-    if (i > 0) server->sendContent(",");
-    server->sendContent(output);
+    out.addEntry(output, written);
   }
 
-  server->sendContent("]");
-  server->sendContent("");
+  out.finish();
   LOG_DBG("WEB", "Served Wi-Fi credentials API (%zu network(s))", credentials.size());
 }
 
@@ -2459,12 +2462,11 @@ void CrossPointWebServer::handleGetOpdsServers() const {
   // Stream JSON array incrementally to avoid allocating the full response in memory
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
-  server->sendContent("[");
+  ChunkedJsonArray out(server.get());
 
   char output[512];
   constexpr size_t outputSize = sizeof(output);
   JsonDocument doc;
-  bool seenFirst = false;
 
   for (size_t i = 0; i < servers.size(); i++) {
     doc.clear();
@@ -2478,15 +2480,10 @@ void CrossPointWebServer::handleGetOpdsServers() const {
     const size_t written = serializeJson(doc, output, outputSize);
     if (written >= outputSize) continue;
 
-    if (seenFirst) {
-      server->sendContent(",");
-    }
-    seenFirst = true;
-    server->sendContent(output);
+    out.addEntry(output, written);
   }
 
-  server->sendContent("]");
-  server->sendContent("");
+  out.finish();
   LOG_DBG("WEB", "Served OPDS servers API (%zu servers)", servers.size());
 }
 

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -89,7 +89,10 @@ class CrossPointWebServer {
   void abortWsUpload(const char* tag);
 
   // File scanning
-  void scanFiles(const char* path, const std::function<void(FileInfo)>& callback) const;
+  // Plain function pointer + context rather than std::function: the callback runs once per
+  // directory entry, and a std::function taking FileInfo by value copies its String each time.
+  using FileVisitor = void (*)(const FileInfo& info, void* context);
+  void scanFiles(const char* path, FileVisitor visitor, void* context) const;
   bool isEpubFile(const String& filename) const;
 
   // Request handlers

--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -8,6 +8,7 @@
 #include <Xtc.h>
 #include <esp_task_wdt.h>
 
+#include "ChunkedResponse.h"
 #include "HttpFileStreamer.h"
 
 namespace {
@@ -192,12 +193,13 @@ void WebDAVHandler::handlePropfind(WebServer& s) {
       // Root should always work — send minimal response
       s.setContentLength(CONTENT_LENGTH_UNKNOWN);
       s.send(207, "application/xml; charset=\"utf-8\"", "");
-      s.sendContent(
+      ChunkedResponse out(&s);
+      out.append(
           "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
           "<D:multistatus xmlns:D=\"DAV:\">\n");
-      sendPropEntry(s, "/", true, 0, FIXED_DATE);
-      s.sendContent("</D:multistatus>\n");
-      s.sendContent("");
+      sendPropEntry(out, "/", true, 0, FIXED_DATE);
+      out.append("</D:multistatus>\n");
+      out.finish();
       return;
     }
     s.send(500, "text/plain", "Failed to open");
@@ -208,18 +210,19 @@ void WebDAVHandler::handlePropfind(WebServer& s) {
 
   s.setContentLength(CONTENT_LENGTH_UNKNOWN);
   s.send(207, "application/xml; charset=\"utf-8\"", "");
-  s.sendContent(
+  ChunkedResponse out(&s);
+  out.append(
       "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
       "<D:multistatus xmlns:D=\"DAV:\">\n");
 
   // Entry for the resource itself
   if (isDir) {
-    sendPropEntry(s, path, true, 0, FIXED_DATE);
+    sendPropEntry(out, path, true, 0, FIXED_DATE);
   } else {
-    sendPropEntry(s, path, false, root.size(), FIXED_DATE);
+    sendPropEntry(out, path, false, root.size(), FIXED_DATE);
     root.close();
-    s.sendContent("</D:multistatus>\n");
-    s.sendContent("");
+    out.append("</D:multistatus>\n");
+    out.finish();
     return;
   }
 
@@ -248,9 +251,9 @@ void WebDAVHandler::handlePropfind(WebServer& s) {
         childPath += fileName;
 
         if (file.isDirectory()) {
-          sendPropEntry(s, childPath, true, 0, FIXED_DATE);
+          sendPropEntry(out, childPath, true, 0, FIXED_DATE);
         } else {
-          sendPropEntry(s, childPath, false, file.size(), FIXED_DATE);
+          sendPropEntry(out, childPath, false, file.size(), FIXED_DATE);
         }
       }
 
@@ -262,41 +265,41 @@ void WebDAVHandler::handlePropfind(WebServer& s) {
   }
 
   root.close();
-  s.sendContent("</D:multistatus>\n");
-  s.sendContent("");
+  out.append("</D:multistatus>\n");
+  out.finish();
 }
 
-void WebDAVHandler::sendPropEntry(WebServer& s, const String& path, bool isDir, size_t size,
+void WebDAVHandler::sendPropEntry(ChunkedResponse& out, const String& path, bool isDir, size_t size,
                                   const String& lastModified) const {
   String href;
   urlEncodePath(path, href);
   // Ensure directory hrefs end with /
   if (isDir && !href.endsWith("/")) href += "/";
 
-  String xml = "<D:response><D:href>";
-  xml += href;
-  xml += "</D:href><D:propstat><D:prop>";
+  // Append the pieces straight into the batch buffer. Assembling an
+  // intermediate String here would add a realloc-and-copy chain plus a
+  // temporary for every directory entry, and the buffer already coalesces.
+  out.append("<D:response><D:href>");
+  out.append(href.c_str(), href.length());
+  out.append("</D:href><D:propstat><D:prop>");
 
   if (isDir) {
-    xml += "<D:resourcetype><D:collection/></D:resourcetype>";
+    out.append("<D:resourcetype><D:collection/></D:resourcetype>");
   } else {
-    xml += "<D:resourcetype/>";
-    xml += "<D:getcontentlength>";
-    xml += String(size);
-    xml += "</D:getcontentlength>";
-    String mime = getMimeType(path);
-    xml += "<D:getcontenttype>";
-    xml += mime;
-    xml += "</D:getcontenttype>";
+    char sizeBuf[24];
+    const int written = snprintf(sizeBuf, sizeof(sizeBuf), "%lu", (unsigned long)size);
+    const String mime = getMimeType(path);
+    out.append("<D:resourcetype/><D:getcontentlength>");
+    out.append(sizeBuf, written < 0 ? 0 : (size_t)written);
+    out.append("</D:getcontentlength><D:getcontenttype>");
+    out.append(mime.c_str(), mime.length());
+    out.append("</D:getcontenttype>");
   }
 
-  xml += "<D:getlastmodified>";
-  xml += lastModified;
-  xml += "</D:getlastmodified>";
-
-  xml += "</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>\n";
-
-  s.sendContent(xml);
+  out.append("<D:getlastmodified>");
+  out.append(lastModified.c_str(), lastModified.length());
+  out.append("</D:getlastmodified>");
+  out.append("</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>\n");
 }
 
 // ── GET ──────────────────────────────────────────────────────────────────────

--- a/src/network/WebDAVHandler.h
+++ b/src/network/WebDAVHandler.h
@@ -3,6 +3,8 @@
 #include <HalStorage.h>
 #include <WebServer.h>
 
+#include "ChunkedResponse.h"
+
 class WebDAVHandler : public RequestHandler {
  public:
   // RequestHandler interface
@@ -39,6 +41,7 @@ class WebDAVHandler : public RequestHandler {
   int getDepth(WebServer& s) const;
   bool getOverwrite(WebServer& s) const;
   void clearEpubCacheIfNeeded(const String& path) const;
-  void sendPropEntry(WebServer& s, const String& href, bool isDir, size_t size, const String& lastModified) const;
+  void sendPropEntry(ChunkedResponse& out, const String& href, bool isDir, size_t size,
+                     const String& lastModified) const;
   String getMimeType(const String& path) const;
 };


### PR DESCRIPTION
Streamed list responses sent one HTTP chunk per entry - chunk header, TCP write, and the WebServer library''s chunk-size malloc for every file. This coalesces them into ~1 TCP segment.

## Changes

**Batching** - new `ChunkedResponse` / `ChunkedJsonArray` in `src/network/ChunkedResponse.h`, holding a 1.4KB `makeUniqueNoThrow` buffer. Applied to five endpoints: file list, settings, Wi-Fi networks, OPDS servers, and WebDAV PROPFIND. On allocation failure it degrades to the previous per-entry sends rather than failing the request. Centralising the separator also fixed the Wi-Fi list keying its comma on the loop index instead of on entries actually emitted, which produced invalid JSON when an oversized entry was skipped.

**Per-entry heap churn** - `sendPropEntry()` now appends fragments straight into the batch buffer instead of building an Arduino `String` per PROPFIND row, and `scanFiles()` takes a function pointer plus context rather than a `std::function<void(FileInfo)>` that copied `FileInfo` (and its `String`) once per directory entry. The latter also removes a `std::function` from a callback path, per the guidance in `.skills/SKILL.md`.

**Allocation hardening** - `WebServer`, `WebDAVHandler` and `WebSocketsServer` now use `makeUniqueNoThrow`. With `-fno-exceptions` a bare `new` aborts on a fragmented heap, so the existing null check on `WebServer` could never fire. WebDAV and the WebSocket upload path now log and degrade instead of taking the device down.

## Attribution

Batching and the `scanFiles` visitor are ported from CrossInk commits `1d6b82f` and `a9d0b80` by Julia Nguyen and Justin Mitchell; the former back-ported crosspoint-reader `302c0771`. Credited in the `ChunkedResponse.h` header comment.

## Cost

+340 bytes flash, static RAM unchanged (54,428). At runtime, +1.4KB transient heap for the duration of one streamed response.
