### PR TITLE
fix(reader): stop freezing when finishing a book in a series (#104)

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -798,6 +798,29 @@ bool Epub::loadForCover() {
   return true;
 }
 
+bool Epub::loadForMetadata() {
+  // Metadata-only load: see the header for why this exists (issue #104 — the series-sequel scan used
+  // to full-load every EPUB in the folder). Structured exactly like loadForCover(); the only
+  // difference is which field the caller goes on to read, so neither marks the other's data valid.
+  bookMetadataCache.reset(new BookMetadataCache(cachePath));
+  cssParser.reset(new CssParser(cachePath));  // constructed for API symmetry; not parsed here
+
+  // Fast path: an existing book.bin already carries title/author/series, no OPF parse needed.
+  if (bookMetadataCache->load()) {
+    return true;
+  }
+
+  // No cache: metadata-only OPF parse. OpfCacheMode::Disabled passes a null cache to
+  // ContentOpfParser, so no manifest item index / .items.bin / spine cache is built.
+  if (!parseContentOpf(bookMetadataCache->coreMetadata, OpfCacheMode::Disabled)) {
+    LOG_INF("EBP", "loadForMetadata: content.opf parse failed for %s", filepath.c_str());
+    return false;
+  }
+  // Mark loaded for API symmetry with loadForCover(); spine/TOC stay empty and must not be used.
+  bookMetadataCache->markCoverMetadataLoaded();
+  return true;
+}
+
 bool Epub::clearCache(const bool preserveThumbs) const {
   if (!Storage.exists(cachePath.c_str())) {
     LOG_DBG("EPB", "Cache does not exist, no action needed");

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -121,6 +121,19 @@ class Epub {
   // — the spine/TOC accessors are NOT populated. Returns false if the cover reference can't be found.
   bool loadForCover();
 
+  // Lightweight load for CATALOGUE METADATA only (title/author/series/seriesIndex/language), WITHOUT
+  // building the spine/TOC book.bin. Same rationale and mechanism as loadForCover(): uses book.bin if
+  // it already exists, otherwise does a metadata-only OPF parse (OpfCacheMode::Disabled — no manifest
+  // item index, no .items.bin). After this, ONLY the metadata accessors above are valid; the spine/TOC
+  // accessors and the cover path are NOT populated.
+  //
+  // Exists because scanning a folder for a series sequel must read series metadata from every EPUB in
+  // it. Doing that with full load() calls meant one manifest/spine index build per candidate, run from
+  // inside the reader with its heap still committed — the finished-book reboot on a large series folder
+  // (issue #104). Cheap enough to call in a loop; still not free (one OPF parse per call), so callers
+  // scanning many books should bound the candidate set first.
+  bool loadForMetadata();
+
   // True when opening the book will trigger the (multi-second) first-open index
   // build inside load(): the spine/TOC cache (book.bin) or the compiled CSS rules
   // cache is missing. Cheap (only file-existence checks) so callers can decide

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -149,9 +149,10 @@ class BookMetadataCache {
   int getTocCount() const { return tocCount; }
   bool isTocReliable() const { return tocReliable; }
   bool isLoaded() const { return loaded; }
-  // Mark the cache "loaded" after a COVER-ONLY OPF parse populated coreMetadata (coverItemHref etc.)
-  // without building the spine/TOC book.bin. Lets cover extraction proceed (isLoaded() gate) while
-  // spineCount/tocCount stay 0 — the caller must NOT use the spine/TOC accessors in this state.
-  // See Epub::loadForCover(). This avoids the full 1732-spine book.bin build just to show a thumbnail.
+  // Mark the cache "loaded" after a METADATA-ONLY OPF parse populated coreMetadata (title, author,
+  // series, coverItemHref, ...) without building the spine/TOC book.bin. Lets the isLoaded() gates
+  // pass while spineCount/tocCount stay 0 — the caller must NOT use the spine/TOC accessors in this
+  // state. Used by Epub::loadForCover() (avoids a full 1732-spine book.bin build just to show a
+  // thumbnail) and Epub::loadForMetadata() (same, for a series-sequel folder scan).
   void markCoverMetadataLoaded() { loaded = true; }
 };

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -5,13 +5,13 @@
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
-#include <esp_task_wdt.h>
 #include <I18n.h>
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
 #include <PngToBmpConverter.h>
 #include <Txt.h>
 #include <Xtc.h>
+#include <esp_task_wdt.h>
 
 #include <algorithm>
 #include <cerrno>

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -610,18 +610,24 @@ void FinishedBookActivity::onEnter() {
 }
 
 void FinishedBookActivity::loop() {
+  // Built ONCE per loop() rather than per event: the model depends only on member state, and
+  // constructing it allocates five rows of translated strings. Rebuilding it inside the event loop
+  // put that cost in front of every button press. Any handler below that changes what the rows say
+  // (the two toggles) returns immediately, so a single build stays consistent with the events it
+  // dispatches.
+  const RowModel model = buildRowModel();
+  const int optionCount = model.count();
+  if (optionCount <= 0) {
+    return;
+  }
+
+  selectedIndex_ = std::clamp(selectedIndex_, 0, optionCount - 1);
+
   ButtonEventManager::ButtonEvent ev;
   while (buttonEvents.consumeEvent(ev)) {
     if (ev.type != ButtonEventManager::PressType::Short) {
       continue;
     }
-
-    const RowModel model = buildRowModel();
-    const int optionCount = model.count();
-    if (optionCount <= 0) {
-      return;
-    }
-    selectedIndex_ = std::clamp(selectedIndex_, 0, optionCount - 1);
 
     const auto finishWith = [this](const BookFinished::FinishedBookAction action) {
       MenuResult menuResult;
@@ -662,19 +668,12 @@ void FinishedBookActivity::loop() {
       }
       return;
     }
-
-    if (ev.button == MappedInputManager::Button::Down || ev.button == MappedInputManager::Button::Right) {
-      selectedIndex_ = (selectedIndex_ + 1) % optionCount;
-      requestUpdate();
-      return;
-    }
-
-    if (ev.button == MappedInputManager::Button::Up || ev.button == MappedInputManager::Button::Left) {
-      selectedIndex_ = (selectedIndex_ + optionCount - 1) % optionCount;
-      requestUpdate();
-      return;
-    }
   }
+
+  // Selection movement via the navigator, not consumed events — see the buttonNavigator comment in
+  // the header for why Up/Down/Left/Right never arrive as events on this screen.
+  buttonNavigator.onNextList(selectedIndex_, optionCount, [this] { requestUpdate(); });
+  buttonNavigator.onPreviousList(selectedIndex_, optionCount, [this] { requestUpdate(); });
 
   if (nextBookAvailable_ && !nextBookMetadataLoaded_) {
     const auto metadata = loadNextBookMetadata(nextBookPath_);

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -5,6 +5,7 @@
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
+#include <esp_task_wdt.h>
 #include <I18n.h>
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
@@ -177,7 +178,10 @@ NextBookMetadata loadNextBookMetadata(const std::string& nextBookPath) {
   if (FsHelpers::hasEpubExtension(nextBookPath)) {
     Epub epub(nextBookPath, "/.crosspoint");
     epub.setSyntheticTocFallbackEnabled(SETTINGS.syntheticTocFallback != 0);
-    if (epub.load(true, true)) {
+    // loadForCover(), not load(): this preview needs metadata + the cover thumb, never the spine/TOC.
+    // A full load() here rebuilt book.bin and reparsed the CSS for a book the user may not even open,
+    // costing ~2 s inside the reader — the same waste the sequel scan used to pay per candidate.
+    if (epub.loadForCover()) {
       metadata.title = epub.getTitle();
       metadata.author = epub.getAuthor();
       metadata.series = epub.getSeries();
@@ -284,63 +288,83 @@ std::string pathWithFilename(const std::string& directory, const std::string& fi
   return directory + "/" + fileName;
 }
 
-std::string findSeriesSequel(const std::string& directory, const std::string& currentSeries,
-                             const std::string& currentSeriesIndex) {
+// Finds the next book in the series: the candidate whose series index is the SMALLEST one still
+// greater than the current book's.
+//
+// Streams the directory and keeps only the running best — one path string of state, no file list, no
+// sort. That matters more than it looks: this runs inside the reader with the secondary framebuffer
+// restored (~10.7 KB largest contiguous block, measured on X4), so materialising and sorting a vector
+// of every filename was the single largest allocation on the path. Streaming makes peak memory O(1)
+// in the folder size, which removed the need for a heap gate and a listing cap.
+//
+// Exhaustive over the folder, deliberately and without a candidate cap. Two earlier revisions tried
+// to bound the work and both were silently WRONG rather than merely incomplete:
+//   - skipping everything before the current file in sorted order breaks whenever filenames disagree
+//     with series numbering;
+//   - stopping after the first N entries breaks too, because directory order is filesystem order, so
+//     "the first N" is arbitrary — in a 30-book folder the real sequel can sit at position 25 and
+//     never be examined. That fails precisely on the large series folders this feature is for.
+// Exhaustive is affordable because each candidate is a metadata-only parse (~300 ms) rather than the
+// full load (~2 s) this used to do — see Epub::loadForMetadata(). A very large folder still costs
+// real time; the answer to that is moving the scan off the main loop, not truncating it into a wrong
+// answer. The watchdog feed below keeps a long scan from rebooting the device.
+std::string findSeriesSequel(const std::string& directory, const std::string& currentFilename,
+                             const std::string& currentSeries, const std::string& currentSeriesIndex) {
   const auto currentIndex = parseSeriesIndex(currentSeriesIndex);
   if (!currentIndex.has_value() || currentSeries.empty()) {
     return {};
   }
 
-  std::vector<std::string> files;
   auto root = Storage.open(directory.c_str());
   if (!root || !root.isDirectory()) {
     if (root) root.close();
     return {};
   }
 
+  std::string bestPath;
+  float bestIndex = std::numeric_limits<float>::infinity();
+  size_t examined = 0;
+
   root.rewindDirectory();
   char name[512];
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
     file.getName(name, sizeof(name));
-    if (file.isDirectory()) {
-      file.close();
-      continue;
-    }
-    std::string fileName = name;
-    if (!FsHelpers::hasEpubExtension(fileName)) {
-      file.close();
-      continue;
-    }
-    if (fileName.empty() || fileName[0] == '.') {
-      file.close();
-      continue;
-    }
-    files.push_back(fileName);
+    const bool isDir = file.isDirectory();
     file.close();
-  }
-  root.close();
-  if (files.empty()) return {};
-  std::sort(files.begin(), files.end(), naturalLess);
+    if (isDir) continue;
 
-  std::string bestPath;
-  float bestIndex = std::numeric_limits<float>::infinity();
-  for (const auto& fileName : files) {
+    const std::string fileName = name;
+    if (fileName.empty() || fileName[0] == '.' || !FsHelpers::hasEpubExtension(fileName)) {
+      continue;
+    }
+    // The current book is in this directory too; skip it rather than spending a parse on a book that
+    // can never be its own sequel.
+    if (fileName == currentFilename) {
+      continue;
+    }
+
+    ++examined;
+
+    // The scan runs synchronously in the main loop, so it blocks input and the idle task throughout,
+    // and it is unbounded in the folder size. Each candidate is a ZIP open + OPF parse, so a big
+    // folder is many seconds — feed the watchdog and let other tasks run between candidates. The
+    // pre-fix scan full-loaded every EPUB (~2 s each) with no yield at all, the suspected cause of
+    // the issue #104 reboot.
+    esp_task_wdt_reset();
+    yield();
+
     const std::string candidatePath = pathWithFilename(directory, fileName);
-    auto epub = std::unique_ptr<Epub>(new Epub(candidatePath, "/.crosspoint"));
-    epub->setSyntheticTocFallbackEnabled(SETTINGS.syntheticTocFallback != 0);
-    if (!epub->load(true, SETTINGS.embeddedStyle == 0)) {
+    Epub epub(candidatePath, "/.crosspoint");
+    epub.setSyntheticTocFallbackEnabled(SETTINGS.syntheticTocFallback != 0);
+    // Metadata-only: no spine/TOC book.bin build, no manifest index, no CSS parse.
+    if (!epub.loadForMetadata()) {
       continue;
     }
-    const std::string candidateSeries = epub->getSeries();
-    const std::string candidateSeriesIndex = epub->getSeriesIndex();
-    if (!caseInsensitiveEqual(candidateSeries, currentSeries)) {
+    if (!caseInsensitiveEqual(epub.getSeries(), currentSeries)) {
       continue;
     }
-    const auto candidateIndex = parseSeriesIndex(candidateSeriesIndex);
-    if (!candidateIndex.has_value()) {
-      continue;
-    }
-    if (candidateIndex.value() <= currentIndex.value()) {
+    const auto candidateIndex = parseSeriesIndex(epub.getSeriesIndex());
+    if (!candidateIndex.has_value() || candidateIndex.value() <= currentIndex.value()) {
       continue;
     }
     if (candidateIndex.value() < bestIndex) {
@@ -348,43 +372,51 @@ std::string findSeriesSequel(const std::string& directory, const std::string& cu
       bestPath = candidatePath;
     }
   }
+  root.close();
+
+  LOG_DBG("FIN", "Series-sequel scan: examined %zu candidate(s), next=%s", examined,
+          bestPath.empty() ? "(none)" : bestPath.c_str());
   return bestPath;
 }
 
+// Finds the book immediately after currentFilename in natural filename order — i.e. the SMALLEST
+// filename still greater than the current one.
+//
+// Like findSeriesSequel, this streams the directory keeping only the running best rather than listing
+// and sorting every entry, so peak memory is two short strings regardless of folder size. Opens no
+// files at all: filenames alone decide the answer.
 std::string findNextAlphabeticalBook(const std::string& directory, const std::string& currentFilename) {
-  std::vector<std::string> files;
   auto root = Storage.open(directory.c_str());
   if (!root || !root.isDirectory()) {
     if (root) root.close();
     return {};
   }
 
+  std::string best;
   root.rewindDirectory();
   char name[512];
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
     file.getName(name, sizeof(name));
-    if (file.isDirectory()) {
-      file.close();
-      continue;
-    }
-    std::string fileName = name;
-    if (fileName.empty() || fileName[0] == '.' || !isSupportedBookFile(fileName)) {
-      file.close();
-      continue;
-    }
-    files.push_back(fileName);
+    const bool isDir = file.isDirectory();
     file.close();
+    if (isDir) continue;
+
+    const std::string fileName = name;
+    if (fileName.empty() || fileName[0] == '.' || !isSupportedBookFile(fileName)) {
+      continue;
+    }
+    // Strictly after the current book, and the earliest such name seen so far.
+    if (!naturalLess(currentFilename, fileName)) {
+      continue;
+    }
+    if (best.empty() || naturalLess(fileName, best)) {
+      best = fileName;
+    }
   }
   root.close();
-  if (files.empty()) return {};
-  std::sort(files.begin(), files.end(), naturalLess);
 
-  for (size_t i = 0; i < files.size(); ++i) {
-    if (files[i] == currentFilename && i + 1 < files.size()) {
-      return pathWithFilename(directory, files[i + 1]);
-    }
-  }
-  return {};
+  if (best.empty()) return {};
+  return pathWithFilename(directory, best);
 }
 
 bool pathIsInCompleted(const std::string& bookPath) {
@@ -407,7 +439,7 @@ std::string findNextBookInDirectory(const std::string& currentBookPath, const st
   const std::string currentFilename = getFilename(currentBookPath);
 
   if (!currentBookSeries.empty() && !currentBookSeriesIndex.empty()) {
-    const std::string sequel = findSeriesSequel(directory, currentBookSeries, currentBookSeriesIndex);
+    const std::string sequel = findSeriesSequel(directory, currentFilename, currentBookSeries, currentBookSeriesIndex);
     if (!sequel.empty() && sequel != currentBookPath) {
       return sequel;
     }
@@ -508,14 +540,58 @@ FinishedBookActivity::FinishedBookActivity(GfxRenderer& renderer, MappedInputMan
   nextBookName_ = nextBookAvailable_ ? getFilename(nextBookPath_) : tr(STR_NOT_SET);
 }
 
+FinishedBookActivity::RowModel FinishedBookActivity::buildRowModel() const {
+  RowModel model;
+
+  model.actions.push_back(RowModel::Action::GoHome);
+  model.titles.push_back(tr(STR_GO_BACK_TO_HOME));
+  model.subtitles.push_back(tr(STR_GO_BACK_TO_HOME_DESC));
+  model.values.push_back(tr(STR_HOME));
+
+  if (nextBookAvailable_) {
+    // Subtitle prefers the loaded metadata; before loop() has loaded it, fall back to the filename so
+    // the row is never blank.
+    std::string subtitle = nextBookAuthor_;
+    if (!nextBookSeries_.empty()) {
+      if (!subtitle.empty()) subtitle += " • ";
+      subtitle += nextBookSeries_;
+    }
+    if (subtitle.empty()) {
+      subtitle = nextBookName_;
+    }
+    model.actions.push_back(RowModel::Action::OpenNext);
+    model.titles.push_back(nextBookTitle_.empty() ? tr(STR_OPEN_NEXT_BOOK) : nextBookTitle_);
+    model.subtitles.push_back(subtitle);
+    model.values.push_back(tr(STR_OPEN));
+  }
+
+  if (!currentBookAuthor_.empty() && OPDS_STORE.hasServers()) {
+    model.actions.push_back(RowModel::Action::SearchOpds);
+    model.titles.push_back(tr(STR_SEARCH_OPDS_FOR_AUTHOR));
+    model.subtitles.push_back(currentBookAuthor_);
+    model.values.push_back(tr(STR_SEARCH));
+  }
+
+  if (!pathIsInCompleted(currentBookPath_)) {
+    model.actions.push_back(RowModel::Action::ToggleMoveToCompleted);
+    model.titles.push_back(tr(STR_MOVE_FINISHED_TO_COMPLETED));
+    model.subtitles.push_back("");
+    model.values.push_back(moveFinishedBooksToCompleted_ ? tr(STR_STATE_ON) : tr(STR_STATE_OFF));
+  }
+
+  model.actions.push_back(RowModel::Action::ToggleForget);
+  model.titles.push_back(tr(STR_FORGET_BOOK));
+  model.subtitles.push_back(tr(STR_FORGET_BOOK_DESC));
+  model.values.push_back(removeFinishedBooksFromRecents_ ? tr(STR_STATE_ON) : tr(STR_STATE_OFF));
+
+  return model;
+}
+
 void FinishedBookActivity::onEnter() {
   Activity::onEnter();
-  const bool canMoveToCompleted = !pathIsInCompleted(currentBookPath_);
-  const bool canSearchOpds = !currentBookAuthor_.empty() && OPDS_STORE.hasServers();
-  const int optionCount = 1 + (nextBookAvailable_ ? 1 : 0) + (canSearchOpds ? 1 : 0) + (canMoveToCompleted ? 1 : 0) + 1;
-  selectedIndex_ = std::clamp(selectedIndex_, 0, optionCount - 1);
   moveFinishedBooksToCompleted_ = SETTINGS.moveFinishedBooksToCompleted;
   removeFinishedBooksFromRecents_ = SETTINGS.removeFinishedBooksFromRecents;
+  selectedIndex_ = std::clamp(selectedIndex_, 0, std::max(0, buildRowModel().count() - 1));
 
   if (nextBookAvailable_) {
     nextBookTitle_ = nextBookName_;
@@ -540,65 +616,49 @@ void FinishedBookActivity::loop() {
       continue;
     }
 
-    const bool canMoveToCompleted = !pathIsInCompleted(currentBookPath_);
-    const bool canSearchOpds = !currentBookAuthor_.empty() && OPDS_STORE.hasServers();
-    const int optionCount =
-        1 + (nextBookAvailable_ ? 1 : 0) + (canSearchOpds ? 1 : 0) + (canMoveToCompleted ? 1 : 0) + 1;
+    const RowModel model = buildRowModel();
+    const int optionCount = model.count();
+    if (optionCount <= 0) {
+      return;
+    }
+    selectedIndex_ = std::clamp(selectedIndex_, 0, optionCount - 1);
 
-    if (ev.button == MappedInputManager::Button::Back) {
+    const auto finishWith = [this](const BookFinished::FinishedBookAction action) {
       MenuResult menuResult;
-      menuResult.action = static_cast<int>(BookFinished::FinishedBookAction::GoHome);
+      menuResult.action = static_cast<int>(action);
       ActivityResult result(menuResult);
       setResult(std::move(result));
       finish();
+    };
+
+    if (ev.button == MappedInputManager::Button::Back) {
+      finishWith(BookFinished::FinishedBookAction::GoHome);
       return;
     }
 
     if (ev.button == MappedInputManager::Button::Confirm) {
-      if (selectedIndex_ == 0) {
-        MenuResult menuResult;
-        menuResult.action = static_cast<int>(BookFinished::FinishedBookAction::GoHome);
-        ActivityResult result(menuResult);
-        setResult(std::move(result));
-        finish();
-        return;
-      }
-
-      if (selectedIndex_ == 1 && nextBookAvailable_) {
-        MenuResult menuResult;
-        menuResult.action = static_cast<int>(BookFinished::FinishedBookAction::OpenNextBook);
-        ActivityResult result(menuResult);
-        setResult(std::move(result));
-        finish();
-        return;
-      }
-
-      const int opdsIndex = 1 + (nextBookAvailable_ ? 1 : 0);
-      if (selectedIndex_ == opdsIndex && canSearchOpds) {
-        MenuResult menuResult;
-        menuResult.action = static_cast<int>(BookFinished::FinishedBookAction::SearchOpdsForAuthor);
-        ActivityResult result(menuResult);
-        setResult(std::move(result));
-        finish();
-        return;
-      }
-
-      const int moveIndex = 1 + (nextBookAvailable_ ? 1 : 0) + (canSearchOpds ? 1 : 0);
-      if (selectedIndex_ == moveIndex && canMoveToCompleted) {
-        moveFinishedBooksToCompleted_ = !moveFinishedBooksToCompleted_;
-        SETTINGS.moveFinishedBooksToCompleted = moveFinishedBooksToCompleted_;
-        SETTINGS.saveToFile();
-        requestUpdate();
-        return;
-      }
-
-      const int removeIndex = 1 + (nextBookAvailable_ ? 1 : 0) + (canSearchOpds ? 1 : 0) + (canMoveToCompleted ? 1 : 0);
-      if (selectedIndex_ == removeIndex) {
-        removeFinishedBooksFromRecents_ = !removeFinishedBooksFromRecents_;
-        SETTINGS.removeFinishedBooksFromRecents = removeFinishedBooksFromRecents_;
-        SETTINGS.saveToFile();
-        requestUpdate();
-        return;
+      switch (model.actions[selectedIndex_]) {
+        case RowModel::Action::GoHome:
+          finishWith(BookFinished::FinishedBookAction::GoHome);
+          return;
+        case RowModel::Action::OpenNext:
+          finishWith(BookFinished::FinishedBookAction::OpenNextBook);
+          return;
+        case RowModel::Action::SearchOpds:
+          finishWith(BookFinished::FinishedBookAction::SearchOpdsForAuthor);
+          return;
+        case RowModel::Action::ToggleMoveToCompleted:
+          moveFinishedBooksToCompleted_ = !moveFinishedBooksToCompleted_;
+          SETTINGS.moveFinishedBooksToCompleted = moveFinishedBooksToCompleted_;
+          SETTINGS.saveToFile();
+          requestUpdate();
+          return;
+        case RowModel::Action::ToggleForget:
+          removeFinishedBooksFromRecents_ = !removeFinishedBooksFromRecents_;
+          SETTINGS.removeFinishedBooksFromRecents = removeFinishedBooksFromRecents_;
+          SETTINGS.saveToFile();
+          requestUpdate();
+          return;
       }
       return;
     }
@@ -720,57 +780,14 @@ void FinishedBookActivity::render(RenderLock&&) {
     y = std::max(y + previewHeight, infoY) + metrics.verticalSpacing;
   }
 
-  const bool currentBookIsCompleted = pathIsInCompleted(currentBookPath_);
-  const bool canMoveToCompleted = !currentBookIsCompleted;
-  const bool canSearchOpds = !currentBookAuthor_.empty() && OPDS_STORE.hasServers();
-  const int optionCount = 1 + (nextBookAvailable_ ? 1 : 0) + (canSearchOpds ? 1 : 0) + (canMoveToCompleted ? 1 : 0) + 1;
-
-  std::vector<std::string> rowTitles;
-  std::vector<std::string> rowSubtitles;
-  std::vector<std::string> rowValues;
-
-  rowTitles.push_back(tr(STR_GO_BACK_TO_HOME));
-  rowSubtitles.push_back(tr(STR_GO_BACK_TO_HOME_DESC));
-  rowValues.push_back(tr(STR_HOME));
-
-  if (nextBookAvailable_) {
-    std::string subtitle;
-    if (!nextBookAuthor_.empty()) {
-      subtitle = nextBookAuthor_;
-    }
-    if (!nextBookSeries_.empty()) {
-      if (!subtitle.empty()) subtitle += " • ";
-      subtitle += nextBookSeries_;
-    }
-    if (subtitle.empty()) {
-      subtitle = nextBookName_;
-    }
-    rowTitles.push_back(nextBookTitle_.empty() ? tr(STR_OPEN_NEXT_BOOK) : nextBookTitle_);
-    rowSubtitles.push_back(subtitle);
-    rowValues.push_back(tr(STR_OPEN));
-  }
-
-  if (canSearchOpds) {
-    rowTitles.push_back(tr(STR_SEARCH_OPDS_FOR_AUTHOR));
-    rowSubtitles.push_back(currentBookAuthor_);
-    rowValues.push_back(tr(STR_SEARCH));
-  }
-
-  if (canMoveToCompleted) {
-    rowTitles.push_back(tr(STR_MOVE_FINISHED_TO_COMPLETED));
-    rowSubtitles.push_back("");
-    rowValues.push_back(moveFinishedBooksToCompleted_ ? tr(STR_STATE_ON) : tr(STR_STATE_OFF));
-  }
-
-  rowTitles.push_back(tr(STR_FORGET_BOOK));
-  rowSubtitles.push_back(tr(STR_FORGET_BOOK_DESC));
-  rowValues.push_back(removeFinishedBooksFromRecents_ ? tr(STR_STATE_ON) : tr(STR_STATE_OFF));
+  const RowModel model = buildRowModel();
+  const int selected = std::clamp(selectedIndex_, 0, std::max(0, model.count() - 1));
 
   const Rect listRect{contentRect.x, y, contentRect.width, contentBottom - y};
   GUI.drawList(
-      renderer, listRect, optionCount, selectedIndex_, [&rowTitles](int index) { return rowTitles[index]; },
-      [&rowSubtitles](int index) { return rowSubtitles[index]; }, nullptr,
-      [&rowValues](int index) { return rowValues[index]; }, true);
+      renderer, listRect, model.count(), selected, [&model](int index) { return model.titles[index]; },
+      [&model](int index) { return model.subtitles[index]; }, nullptr,
+      [&model](int index) { return model.values[index]; }, true);
 
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);

--- a/src/activities/reader/FinishedBookActivity.h
+++ b/src/activities/reader/FinishedBookActivity.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "../Activity.h"
 #include "util/ButtonNavigator.h"
@@ -44,6 +45,24 @@ class FinishedBookActivity : public Activity {
   void render(RenderLock&&) override;
 
  private:
+  // The menu's rows are conditional (next-book, OPDS-search and move-to-/COMPLETED each appear only
+  // when applicable), so the row count and every row's index depend on the same four booleans. Those
+  // were previously re-derived independently in onEnter(), loop() and render(); any divergence
+  // between the count handed to GUI.drawList and the vectors its callbacks index is an out-of-bounds
+  // read. Building the model once per use keeps the count, the indices and the row content in sync
+  // by construction.
+  struct RowModel {
+    enum class Action { GoHome, OpenNext, SearchOpds, ToggleMoveToCompleted, ToggleForget };
+    std::vector<Action> actions;
+    std::vector<std::string> titles;
+    std::vector<std::string> subtitles;
+    std::vector<std::string> values;
+
+    int count() const { return static_cast<int>(actions.size()); }
+  };
+
+  RowModel buildRowModel() const;
+
   std::string currentBookPath_;
   std::string nextBookPath_;
   std::string currentBookAuthor_;

--- a/src/activities/reader/FinishedBookActivity.h
+++ b/src/activities/reader/FinishedBookActivity.h
@@ -45,6 +45,14 @@ class FinishedBookActivity : public Activity {
   void render(RenderLock&&) override;
 
  private:
+  // Selection movement goes through ButtonNavigator (as in StarredPagesActivity and the other
+  // child-of-reader lists), NOT through consumed button events. This activity sits on top of the
+  // reader on the activity stack, so main.cpp still sees "in the reader" and routes reader-scoped
+  // actions (Up/Down/Left/Right commonly map to PREV/NEXT_SECTION) to dispatchButtonAction()
+  // instead of delivering them here — consumeEvent() never sees them. ButtonNavigator reads the
+  // mapped input state directly and is unaffected.
+  ButtonNavigator buttonNavigator;
+
   // The menu's rows are conditional (next-book, OPDS-search and move-to-/COMPLETED each appear only
   // when applicable), so the row count and every row's index depend on the same four booleans. Those
   // were previously re-derived independently in onEnter(), loop() and render(); any divergence


### PR DESCRIPTION
Fixes the freeze reported in #104. **The reboot in that issue is not confirmed fixed** — see "Open question" below.

## Problem

Finishing a book scans its folder for the next book in the series. That scan called `Epub::load()` on **every EPUB in the directory** just to read `getSeries()` / `getSeriesIndex()` — a full spine/TOC index build plus CSS parse per candidate.

Measured on a 14-book Wheel of Time folder (X4, device log):

```
[104789] [EBP] Loading ePub: ... - Wheel of Time - 13 - Towers of Midnight.epub
[104888] [BMC] File does not exist: /.crosspoint/epub_2816275941/book.bin
[104888] [EBP] Cache not found, building spine/TOC cache
[105852] [EBP] Total indexing completed in 847 ms
[106841] [EBP] Loaded 56 CSS style rules from 1 files
[106879] [EBP] Loaded ePub: ... - Wheel of Time - 13 - Towers of Midnight.epub
```

...repeated per book: **~2 s each, ~28 s of blocked main loop**. It also left `book.bin` and CSS caches behind for books the user never opened.

## Changes

**1. Metadata-only loading.** New `Epub::loadForMetadata()` populates title/author/series/seriesIndex without building the spine/TOC `book.bin` — reuses an existing `book.bin`, else a metadata-only OPF parse (`OpfCacheMode::Disabled`). Modelled directly on the existing `loadForCover()` precedent. The next-book preview now uses `loadForCover()` rather than a full `load()` for the same reason.

**2. Streaming scans.** `findSeriesSequel()` and `findNextAlphabeticalBook()` now keep a running best over the directory instead of materialising and sorting a vector of every filename. Peak memory is O(1) in folder size — relevant because this runs with the reader's secondary framebuffer restored (~10.7 KB largest contiguous block, measured on X4).

**3. Watchdog feed** between candidates. The scan is synchronous in the main loop and unbounded in folder size.

**4. Button input on the finished-book screen.** Up/Down/Left/Right were handled through consumed button events, which never arrive: the screen sits on top of the reader, so `main.cpp` sees the stack-wide `isReaderActivity()` and routes reader-scoped actions (those buttons commonly map to PREV/NEXT_SECTION) to `dispatchButtonAction()` — a no-op while a child activity is current. Selection movement now goes through `ButtonNavigator`, matching `StarredPagesActivity` and the other child-of-reader lists; it reads mapped input directly and is unaffected. The header already included `ButtonNavigator.h` without declaring the member.

This was a pre-existing bug, not a regression from this PR — but it meant the screen's selection could never be moved, so it is fixed here rather than left behind a working scan.

**5. Row-model cleanup.** The finished-book menu derived its row count and each row's index independently in `onEnter()`, `loop()` and `render()`. Any divergence between the count passed to `GUI.drawList` and the vectors its callbacks index is an out-of-bounds read. Now built once.

## Result (device-verified, X4)

```
[28655] [BMC] Loaded cache data: 63 spine, 1 TOC entries
   ... 13 candidates ...
[29031] [FIN] Series-sequel scan: examined 13 candidate(s),
        next=.../Wheel of Time - 12 - Gathering Storm, The.epub
```

**13 candidates in ~376 ms** (~29 ms each) versus ~28 s before. Correct sequel selected, preview rendered, free heap flat at ~71 KB. No cache files created for unopened books.

## Design note: the scan is deliberately exhaustive

Two bounding strategies were tried and removed, because both give silently *wrong* answers rather than merely incomplete ones:

- **Skipping everything before the current file in sorted order** breaks whenever filenames disagree with series numbering.
- **Stopping after the first N entries** breaks because directory order is filesystem order — in a 30-book folder the real sequel can sit at position 25 and never be examined, failing precisely on the large series folders this feature exists for.

Exhaustive is affordable now that each candidate is ~29 ms (cached) / ~300 ms (cold) instead of ~2 s. If a folder ever gets large enough for this to feel slow, the fix is moving the scan off the main loop — not truncating it into a wrong answer.

## Open question: the reboot

The reporter saw "a freeze **or** reboot". **I reproduced and fixed the freeze; I never reproduced the reboot.** My 14-book folder froze ~28 s then displayed the menu correctly, and free heap stayed flat throughout — so it is not simply memory exhaustion across candidates.

The leading theory is that on a larger folder the block gets long enough to trip the task watchdog, which the yields here would address. But it could equally be one specific book tripping something else, in which case folder size is a red herring. Settling it needs a serial log tail from the reporter showing what follows the last `Loaded ePub:` line — a watchdog trigger, a `Guru Meditation Error`, or a backtrace.

So: the freeze fix is measured and verified. Treat the reboot as *plausibly* addressed, not proven.

## Testing

- Device-verified on X4 (log above): correct sequel, preview renders, no reboot, heap flat.
- Device-verified on X4: selection moves with Up/Down/Left/Right, Confirm and Back act correctly.
- `pio run -e default` clean — RAM 16.6%, Flash 96.0% (~2.4 KB smaller than before; the deleted sort/vector machinery outweighs the new metadata path).
- Not built: `slim` / `gh_release`. Host test suite not run.
