### PR TITLE
fix(reader): unify page-turn input and let navigation preempt the AA pass

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -1,5 +1,6 @@
 #include "Page.h"
 
+#include <CooperativeAbort.h>
 #include <GfxRenderer.h>
 #include <Logging.h>
 #include <Serialization.h>
@@ -342,15 +343,25 @@ bool Page::allImagesArePlaceholders(const bool forceLoadLargeImages, const bool 
   return anyImage;
 }
 
-void Page::renderTextOnly(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) const {
+bool Page::renderTextOnly(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset,
+                          const bool abortable) const {
   for (auto& element : elements) {
     // Scan every non-image element so prewarm covers text from table fragments
     // and other composite text containers, not only plain PageLine entries.
     if (element->getTag() == TAG_PageImage) {
       continue;
     }
+    // Per-element granularity: a page is tens of elements, so the smallest uninterruptible
+    // unit becomes one line instead of a whole plane (~440 ms measured on both devices).
+    // Deliberately no markAborted() here — the grayscale pass reports its own outcome through
+    // GrayscaleTimings::aborted, and setting the shared latch would be read by the image
+    // decoders' retry logic, which this has nothing to do with.
+    if (abortable && CooperativeAbort::shouldAbortLongTask()) {
+      return false;
+    }
     element->render(renderer, fontId, xOffset, yOffset);
   }
+  return true;
 }
 
 bool Page::serialize(FsFile& file) const {

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -144,7 +144,16 @@ class Page {
   // monochromeOutput=true: 1-bit Atkinson BW cache (AA off); false: 4-level Bayer cache (AA on)
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset, bool forceLoadLargeImages = true,
               bool monochromeOutput = true) const;
-  void renderTextOnly(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
+  // Renders every non-image element. With abortable=true the element loop polls
+  // CooperativeAbort::shouldAbortLongTask() and stops early, returning false; otherwise it
+  // always runs to completion and returns true.
+  //
+  // Only the anti-aliasing plane renders may pass true. The prewarm SCAN passes must never
+  // abort: they exist so the following replay finds every glyph bitmap resident, and a partial
+  // scan leaves the replay dereferencing a metadata-only entry (null bitmap base). Nor may the
+  // pre-render pass abort — a half-drawn look-ahead page still gets marked ready and would be
+  // flushed to the panel by the next buffer-display turn.
+  bool renderTextOnly(GfxRenderer& renderer, int fontId, int xOffset, int yOffset, bool abortable = false) const;
   // Replay the 4-level grayscale image cache into the current renderer mode (GRAYSCALE_LSB / MSB).
   // Called by AA grayscale passes after renderTextOnly() so images get proper gray tones.
   // No-op for images without a grayscale cache (they degrade gracefully to BW-only).

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -314,7 +314,32 @@ class GfxRenderer {
     unsigned long planesMs = 0;   // LSB render+copy + MSB render+copy
     unsigned long displayMs = 0;  // displayGrayBuffer() waveform
     unsigned long restoreMs = 0;  // cleanupGrayscaleWithPreviousBuffer() SPI write
+    bool aborted = false;         // dropped at the mid-pass abort point; no gray flush happened
   };
+
+  // Both plane passes below take a shouldAbort predicate, evaluated once at the last point
+  // where the pass can still be dropped without the user seeing anything: after the LSB plane
+  // has been rendered into the framebuffer but before the first grayscale byte reaches the
+  // controller. Aborting there costs only the framebuffer reseed that the normal tail performs
+  // anyway, and gives back the MSB render, both plane writes and the gray flush — which is the
+  // whole net cost of anti-aliasing. Pass a predicate that answers "is this page already on its
+  // way out"; return false to always complete.
+
+  // Abandon a grayscale pass without flushing it, and report it as aborted. Reseeds the
+  // framebuffer and controller baseline from the previous-frame slot, exactly as a completed
+  // pass's tail does. Valid at either gate: plane data may already sit in controller RAM, but
+  // only displayGrayBuffer() runs the gray waveform, so nothing has reached the panel and the
+  // BW page stays displayed.
+  GrayscaleTimings abandonGrayscalePass(const unsigned long planesMs) {
+    GrayscaleTimings t;
+    t.planesMs = planesMs;
+    const unsigned long tAbort = millis();
+    setRenderMode(BW);
+    cleanupGrayscaleWithPreviousBuffer();
+    t.restoreMs = millis() - tAbort;
+    t.aborted = true;
+    return t;
+  }
 
   // Render both grayscale planes sequentially into the BW framebuffer, streaming
   // each plane to the controller immediately after rendering it. No extra allocation
@@ -332,19 +357,29 @@ class GfxRenderer {
   // Returns wall-clock timings for each of the three phases.
   //
   // Signature: void renderFn(RenderMode mode)
-  template <typename RenderFn>
-  GrayscaleTimings renderGrayscalePlanesSequential(RenderFn renderFn) {
+  template <typename RenderFn, typename AbortFn>
+  GrayscaleTimings renderGrayscalePlanesSequential(RenderFn renderFn, AbortFn shouldAbort) {
     GrayscaleTimings t;
     const unsigned long t0 = millis();
 
     clearScreen(0x00);
     setRenderMode(GRAYSCALE_LSB);
     renderFn(GRAYSCALE_LSB);
+    if (shouldAbort()) {
+      return abandonGrayscalePass(millis() - t0);
+    }
     copyGrayscaleLsbBuffers();
 
     clearScreen(0x00);
     setRenderMode(GRAYSCALE_MSB);
     renderFn(GRAYSCALE_MSB);
+    // The MSB render is as long as the LSB one and can bail just as late, so it needs its own
+    // gate: without it a plane abandoned part-way was still copied and flushed, putting a
+    // half-drawn overlay on screen (seen on X3 as a COMPLETED pass with planes=545ms against a
+    // normal ~890ms). Checked before the copy so no partial plane even reaches the controller.
+    if (shouldAbort()) {
+      return abandonGrayscalePass(millis() - t0);
+    }
     copyGrayscaleMsbBuffers();
 
     const unsigned long t1 = millis();
@@ -378,8 +413,8 @@ class GfxRenderer {
   // Caller contract: an async refresh MUST be in flight, and the glyphs the
   // renderFn draws must already be prewarmed (a cache miss would issue SD reads
   // — allowed — but a display/SPI call in renderFn is not).
-  template <typename RenderFn>
-  GrayscaleTimings renderGrayscalePlanesInterleaved(RenderFn renderFn) {
+  template <typename RenderFn, typename AbortFn>
+  GrayscaleTimings renderGrayscalePlanesInterleaved(RenderFn renderFn, AbortFn shouldAbort) {
     GrayscaleTimings t;
     const unsigned long t0 = millis();
 
@@ -392,10 +427,23 @@ class GfxRenderer {
     display.finishDisplayAsync();
     const unsigned long tWaveDone = millis();
 
+    // Abort point. This is the ideal place for it on the interleaved path: the BW page is now
+    // fully on screen, and the LSB render just spent was paid for out of the waveform wait
+    // rather than out of the page-turn budget — so dropping the pass here reclaims the entire
+    // net cost of the AA and forfeits nothing that was actually charged to the user.
+    if (shouldAbort()) {
+      return abandonGrayscalePass(tLsbDone - t0);
+    }
+
     copyGrayscaleLsbBuffers();
     clearScreen(0x00);
     setRenderMode(GRAYSCALE_MSB);
     renderFn(GRAYSCALE_MSB);
+    // Second gate, same reason as in the sequential pass: an MSB render that bailed part-way
+    // must never be copied or flushed. Checked before the copy.
+    if (shouldAbort()) {
+      return abandonGrayscalePass((tLsbDone - t0) + (millis() - tWaveDone));
+    }
     copyGrayscaleMsbBuffers();
 
     const unsigned long t1 = millis();

--- a/src/ButtonEventManager.cpp
+++ b/src/ButtonEventManager.cpp
@@ -14,8 +14,30 @@ int ButtonEventManager::buttonToIndex(const Button button) {
   return -1;
 }
 
+ButtonEventManager::Button ButtonEventManager::pairedAlias(const Button button) {
+  switch (button) {
+    case Button::Up:
+      return Button::PageBack;
+    case Button::PageBack:
+      return Button::Up;
+    case Button::Down:
+      return Button::PageForward;
+    case Button::PageForward:
+      return Button::Down;
+    default:
+      return button;
+  }
+}
+
+// Both names of an aliased pair must answer the same, because they are one physical
+// button driving two FSMs. If they disagreed, one name would fire Short immediately
+// while the other waited out the double-click window, and an activity accepting either
+// name would act on the un-delayed event — silently defeating the configured double
+// action. That is why Up/Down resolve to the PageBack/PageForward settings (there are
+// no separate btnDoubleUp/Down) and why the forced mask is tested across the pair.
 bool ButtonEventManager::hasDoubleAction(const Button button) const {
-  if (forcedDoubleMask & (1 << static_cast<int>(button))) {
+  const uint32_t pairMask = (1u << static_cast<int>(button)) | (1u << static_cast<int>(pairedAlias(button)));
+  if (forcedDoubleMask & pairMask) {
     return true;
   }
   using BA = CrossPointSettings::BUTTON_ACTION;
@@ -28,8 +50,10 @@ bool ButtonEventManager::hasDoubleAction(const Button button) const {
       return SETTINGS.btnDoubleLeft != BA::BTN_DEFAULT;
     case Button::Right:
       return SETTINGS.btnDoubleRight != BA::BTN_DEFAULT;
+    case Button::Up:
     case Button::PageBack:
       return SETTINGS.btnDoublePageBack != BA::BTN_DEFAULT;
+    case Button::Down:
     case Button::PageForward:
       return SETTINGS.btnDoublePageForward != BA::BTN_DEFAULT;
     case Button::Power:
@@ -72,7 +96,6 @@ void ButtonEventManager::drain() {
     b.releaseTime = 0;
   }
   eventHead = eventTail = 0;
-  longPressDispatchedMask = 0;
   // Drop edges the sampler queued for the outgoing activity so they don't bleed in.
   input.flushRawEdges();
 }
@@ -166,12 +189,6 @@ void ButtonEventManager::update() {
       const Button btn = ALL_BUTTONS[i];
       if (input.rawIndex(btn) != edge.button) {
         continue;
-      }
-      // A fresh press clears the long-press-dispatched suppression for this button
-      // (it survives through the release so detectPageTurn can skip the release
-      // page-turn, then resets on the next press).
-      if (edge.pressed) {
-        longPressDispatchedMask &= ~(1u << static_cast<int>(btn));
       }
       applyEdge(i, btn, edge.pressed, edge.timeMs);
     }

--- a/src/ButtonEventManager.h
+++ b/src/ButtonEventManager.h
@@ -25,6 +25,13 @@ ButtonEventManager& globalButtonEvents();
 //
 // Activities query consumeEvent() each loop tick to receive pending events.
 // drain() resets all state machines — call it on activity transitions.
+//
+// Aliased buttons: Up/PageBack and Down/PageForward are two logical names for the
+// SAME physical side button (see MappedInputManager::rawIndex). Each name runs its
+// own FSM, so one press emits one event per name — by design, so list-style
+// activities can match Up/Down while readers match PageBack/PageForward. An activity
+// must therefore accept only ONE name per pair in a given condition, or it will
+// handle the same press twice.
 
 class ButtonEventManager {
  public:
@@ -72,19 +79,9 @@ class ButtonEventManager {
   bool isShortPending(Button button) const;
 
   // Returns true if a double-click action is configured for this button.
-  // ButtonEventManager queries CrossPointSettings internally.
+  // ButtonEventManager queries CrossPointSettings internally. Answers identically for
+  // both names of an aliased pair, so one physical button always has one wait policy.
   bool hasDoubleAction(Button button) const;
-
-  // Called by the global dispatcher (main.cpp) when a Long event is consumed for a
-  // non-default action on a navigation button. Suppresses the release-based page turn
-  // that would otherwise fire when the button is released after the long action.
-  void markLongPressDispatched(Button button) { longPressDispatchedMask |= (1u << static_cast<int>(button)); }
-
-  // Returns true if markLongPressDispatched was called for this button since the last
-  // update(). detectPageTurn() uses this to skip wasReleased-based page turns.
-  bool wasLongPressDispatched(Button button) const {
-    return (longPressDispatchedMask & (1u << static_cast<int>(button))) != 0;
-  }
 
  private:
   static constexpr int NUM_BUTTONS = 9;
@@ -94,7 +91,6 @@ class ButtonEventManager {
   };
 
   uint32_t forcedDoubleMask = 0;
-  uint32_t longPressDispatchedMask = 0;
 
   enum class State { Idle, Pressed, ReleasedOnce, DoublePressed };
 
@@ -115,6 +111,9 @@ class ButtonEventManager {
   MappedInputManager& input;
 
   void pushEvent(Button button, PressType type);
+  // The other logical name for the same physical button (Up<->PageBack,
+  // Down<->PageForward); the button itself when it has no alias.
+  static Button pairedAlias(Button button);
   // Advance one button's FSM on a discrete press/release edge captured at time t.
   void applyEdge(int idx, Button btn, bool pressed, unsigned long t);
   // Advance one button's FSM on elapsed time (long-press-while-held, double-window

--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -10,6 +10,8 @@ void Activity::requestUpdate(bool immediate) { activityManager.requestUpdate(imm
 
 void Activity::requestUpdateAndWait() { activityManager.requestUpdateAndWait(); }
 
+bool Activity::isUpdateSuperseded() const { return activityManager.isUpdateSuperseded(); }
+
 // "Up and out" — return to whichever parent launched this flow. If no return hint
 // is set (typical for activities launched via a plain goTo*()), falls back to Home.
 void Activity::onGoHome() { activityManager.returnFromChild(); }

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -43,6 +43,11 @@ class Activity {
   // Request an immediate render and block until it completes.
   virtual void requestUpdateAndWait();
 
+  // True when another render has already been queued while this one is still running.
+  // See ActivityManager::isUpdateSuperseded() for the contract — advisory only, and
+  // meant to be read from render() as late as possible.
+  bool isUpdateSuperseded() const;
+
   virtual bool skipLoopDelay() { return false; }
   virtual bool preventAutoSleep() { return false; }
   virtual bool isReaderActivity() const { return false; }

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -553,6 +553,22 @@ void ActivityManager::requestUpdateAndWait() {
   ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 }
 
+bool ActivityManager::isUpdateSuperseded() const {
+  // Requested on the loop task but not yet converted into a task notification (that happens
+  // at the end of ActivityManager::loop()).
+  if (requestedUpdate) {
+    return true;
+  }
+  if (!renderTaskHandle) {
+    return false;
+  }
+  // renderTaskLoop() takes its wake-up with ulTaskNotifyTake(pdTRUE, ...), which zeroes the
+  // notification value before render() is entered. Anything counted here was therefore posted
+  // by a requestUpdate() that landed *during* the current render. Clearing no bits (mask 0)
+  // makes this a pure read.
+  return ulTaskNotifyValueClear(renderTaskHandle, 0) > 0;
+}
+
 // RenderLock
 
 RenderLock::RenderLock() {

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -187,6 +187,14 @@ class ActivityManager {
   // Trigger a render and block until it completes.
   // Must NOT be called from the render task or while holding a RenderLock.
   void requestUpdateAndWait();
+
+  // True when a further render has already been requested while the current one is still
+  // running — the frame being rendered is superseded before it is even on screen. Intended
+  // to be called FROM the render task, as late as possible, so a long but purely cosmetic
+  // tail of a render (the reader's anti-aliasing touch-up) can be dropped for a page that
+  // is about to be replaced. Never skip anything the next frame depends on: the answer is
+  // advisory and can flip to true a moment after it is read.
+  bool isUpdateSuperseded() const;
 };
 
 extern ActivityManager activityManager;  // singleton, to be defined in main.cpp

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -293,7 +293,7 @@ void EpubReaderActivity::onEnter() {
   pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
 
   // Drop any input events that arrived from the activity that launched us (e.g. a wake-up power
-  // button hold) before they reach detectPageTurn() — see ReaderUtils::InputDrainGuard.
+  // button hold) before they reach the page-turn handling — see ReaderUtils::InputDrainGuard.
   inputDrainGuard.arm();
 
   if (!epub) {
@@ -518,8 +518,8 @@ void EpubReaderActivity::loop() {
     }
   }
 
-  bool delayedPrevTurn = false;
-  bool delayedNextTurn = false;
+  bool buttonPrevTurn = false;
+  bool buttonNextTurn = false;
   using BA = CrossPointSettings::BUTTON_ACTION;
 
   ButtonEventManager::ButtonEvent ev;
@@ -564,9 +564,8 @@ void EpubReaderActivity::loop() {
     // (prev for Left/PageBack, next for Right/PageForward). Non-default long
     // actions are dispatched by the global handler in main.cpp and never reach
     // here, so a Long event arriving for these buttons with the setting at
-    // BTN_DEFAULT is the built-in case. markLongPressDispatched() suppresses the
-    // wasReleased-based page turn that detectPageTurn() would otherwise fire when
-    // the button is released after the skip.
+    // BTN_DEFAULT is the built-in case. The FSM emits no Short for a press that
+    // already produced a Long, so the release cannot also turn the page.
     if (ev.type == ButtonEventManager::PressType::Long) {
       const bool prevChapter =
           (ev.button == MappedInputManager::Button::PageBack && SETTINGS.btnLongPageBack == BA::BTN_DEFAULT) ||
@@ -575,40 +574,40 @@ void EpubReaderActivity::loop() {
           (ev.button == MappedInputManager::Button::PageForward && SETTINGS.btnLongPageForward == BA::BTN_DEFAULT) ||
           (ev.button == MappedInputManager::Button::Right && SETTINGS.btnLongRight == BA::BTN_DEFAULT);
       if (prevChapter || nextChapter) {
-        globalButtonEvents().markLongPressDispatched(ev.button);
         onButtonAction(nextChapter ? BA::BTN_NEXT_SECTION : BA::BTN_PREV_SECTION);
         return;
       }
     }
 
+    // Page turns for all four navigation buttons come from the event queue, so a burst of
+    // presses during a slow slice (AA pass, pre-render, section build) is replayed press by
+    // press instead of collapsing into one. A non-default short action never arrives here —
+    // main.cpp dispatches it globally — but the setting is re-checked so a future caller
+    // that pushes events directly cannot turn a remapped button into a page turn.
     if (ev.type == ButtonEventManager::PressType::Short) {
-      if ((ev.button == MappedInputManager::Button::PageBack && SETTINGS.btnShortPageBack == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::PageBack)) ||
-          (ev.button == MappedInputManager::Button::Left && SETTINGS.btnShortLeft == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::Left))) {
-        delayedPrevTurn = true;
+      if ((ev.button == MappedInputManager::Button::PageBack && SETTINGS.btnShortPageBack == BA::BTN_DEFAULT) ||
+          (ev.button == MappedInputManager::Button::Left && SETTINGS.btnShortLeft == BA::BTN_DEFAULT)) {
+        buttonPrevTurn = true;
         continue;
       }
-      if ((ev.button == MappedInputManager::Button::PageForward && SETTINGS.btnShortPageForward == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::PageForward)) ||
-          (ev.button == MappedInputManager::Button::Right && SETTINGS.btnShortRight == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::Right))) {
-        delayedNextTurn = true;
+      if ((ev.button == MappedInputManager::Button::PageForward && SETTINGS.btnShortPageForward == BA::BTN_DEFAULT) ||
+          (ev.button == MappedInputManager::Button::Right && SETTINGS.btnShortRight == BA::BTN_DEFAULT)) {
+        buttonNextTurn = true;
         continue;
       }
     }
   }
 
-  auto [prevTriggered, nextTriggered] = ReaderUtils::detectPageTurn(mappedInput);
+  auto [prevTriggered, nextTriggered] = ReaderUtils::detectTiltPageTurn();
   if (!prevTriggered && !nextTriggered) {
-    if (!delayedPrevTurn && !delayedNextTurn) {
+    if (!buttonPrevTurn && !buttonNextTurn) {
       // Input-idle and no page turn pending: hand the idle slice to the background
       // routines (deferred AA, then Background A pre-render, then Background B).
       serviceBackgroundWork();
       return;
     }
-    prevTriggered = delayedPrevTurn;
-    nextTriggered = delayedNextTurn;
+    prevTriggered = buttonPrevTurn;
+    nextTriggered = buttonNextTurn;
   }
   if (!prevTriggered && !nextTriggered) {
     return;
@@ -719,12 +718,23 @@ void EpubReaderActivity::runDeferredGrayscalePass() {
   const int marginLeft = pendingGrayscale_.marginLeft;
   const int contentTop = pendingGrayscale_.contentTop;
   const Page* pagePtr = pendingGrayscale_.page.get();
-  const auto gt = renderer.renderGrayscalePlanesSequential([&](GfxRenderer::RenderMode) {
-    pagePtr->renderTextOnly(renderer, fontId, marginLeft, contentTop);
-    pagePtr->renderImagesFromGrayscaleCache(renderer, marginLeft, contentTop);
-  });
+  // This pass runs ON the loop task, so while it is in flight no input is sampled or
+  // dispatched at all (measured: 1237 ms max loop duration on X3). The plane render therefore
+  // aborts per element, and a bailed plane forces the pass to abort regardless of what the
+  // predicate says — never let a partially drawn plane reach the panel.
+  bool planeAborted = false;
+  const auto gt = renderer.renderGrayscalePlanesSequential(
+      [&](GfxRenderer::RenderMode) {
+        if (!pagePtr->renderTextOnly(renderer, fontId, marginLeft, contentTop, /*abortable=*/true)) {
+          planeAborted = true;
+          return;
+        }
+        pagePtr->renderImagesFromGrayscaleCache(renderer, marginLeft, contentTop);
+      },
+      [&] { return planeAborted || aaPreemptedByNavigation(); });
   pendingGrayscale_.page.reset();
-  LOG_DBG("ERS", "Deferred AA: planes=%lums gray=%lums restore=%lums", gt.planesMs, gt.displayMs, gt.restoreMs);
+  LOG_DBG("ERS", "Deferred AA%s: planes=%lums gray=%lums restore=%lums", gt.aborted ? " ABORTED" : "", gt.planesMs,
+          gt.displayMs, gt.restoreMs);
   checkHeapIntegrity("after_deferred_aa");
   // The AA cleanup just reseeded frameBuffer from frameBufferActive (the current page),
   // so the buffer state is now correct for a pre-render. On X3, render() holds off the
@@ -2338,6 +2348,9 @@ bool EpubReaderActivity::renderBufferDisplayPass(const RenderLayout& layout) {
     // Page load failed or was an image page — caller falls through to full render.
     return false;
   }
+  // Same reason as in renderContents(): pin the page identity before the pass does any work.
+  lastRenderedPageIndex_ = section->currentPage;
+  lastRenderedPageCount_ = section->pageCount;
   currentPageFootnotes = std::move(p->footnotes);
   displayPreRenderedPage(*p, layout.marginTop, layout.marginRight, layout.marginBottom, layout.marginLeft);
 
@@ -2351,7 +2364,8 @@ bool EpubReaderActivity::renderBufferDisplayPass(const RenderLayout& layout) {
     requestUpdate();
   }
   LOG_DBG("ERS", "Page summary: spine=%d page=%d/%d prerendered=1 refresh=%s mode=0x%02X", currentSpineIndex,
-          section->currentPage, section->pageCount, refreshModeName(lastPageRefreshMode_), lastPageDisplayModeByte_);
+          lastRenderedPageIndex_, lastRenderedPageCount_, refreshModeName(lastPageRefreshMode_),
+          lastPageDisplayModeByte_);
   return true;
 }
 
@@ -2963,7 +2977,7 @@ void EpubReaderActivity::renderNormalPass(RenderLock& lock, const RenderLayout& 
         "ERS",
         "Page summary: spine=%d page=%d/%d prerendered=0 refresh=%s mode=0x%02X renderMs=%lu "
         "prewarmMs=%lu bwMs=%lu displayMs=%lu fontHits=%lu fontMisses=%lu fontHitPct=%lu glyphCalls=%lu glyphUs=%lu",
-        currentSpineIndex, section->currentPage, section->pageCount, refreshModeName(lastPageRefreshMode_),
+        currentSpineIndex, lastRenderedPageIndex_, lastRenderedPageCount_, refreshModeName(lastPageRefreshMode_),
         lastPageDisplayModeByte_, lastRenderStats.requestRenderMs, lastRenderStats.phases.prewarmMs,
         lastRenderStats.phases.bwRenderMs, lastRenderStats.phases.displayMs, lastRenderStats.fontCacheHits,
         lastRenderStats.fontCacheMisses, fontHitRatePct, lastRenderStats.fontGetBitmapCalls,
@@ -3232,6 +3246,11 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
                                         const int orientedMarginLeft) {
   const auto t0 = millis();
   logReaderMemSnapshot("render_start");
+  // Pin the page identity now, while it still describes what this pass is about to draw.
+  if (section) {
+    lastRenderedPageIndex_ = section->currentPage;
+    lastRenderedPageCount_ = section->pageCount;
+  }
   auto* fcm = renderer.getFontCacheManager();
   fcm->resetStats();
 
@@ -3398,7 +3417,24 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   // Inline AA is X4-only: X4 waits out the waveform inside the trigger, so the
   // async split hands that window to the plane renders. X3 returns pre-waveform
   // from its trigger already and keeps the deferred loop-task pass.
-  const bool inlineAaThisRender = aaEnabledForThisRender && !renderer.isX3();
+  //
+  // The inline pass runs under the render lock with no cancellation point, and it is not
+  // cheap: only its LSB plane render overlaps the waveform, while the plane SPI writes, the
+  // gray flush and the restore write are all additive. So drop it outright when the page is
+  // already on its way out — otherwise a burst of turns pays that in full for every
+  // intermediate page it immediately discards. Evaluated here, as late as possible, so a
+  // gesture that begins during the (long) BW render still counts.
+  //
+  // X3's deferred pass needs no equivalent gate and keeps its original arming: it is only
+  // ever run from the idle loop (which a pending turn makes unreachable) and pageTurn()
+  // clears it, so it is already cancellable by design.
+  const bool aaPreempted = aaEnabledForThisRender && !renderer.isX3() && aaPreemptedByNavigation();
+  if (aaPreempted) {
+    LOG_DBG("ERS", "Inline AA skipped: page preempted by navigation");
+  }
+  const bool inlineAaThisRender = aaEnabledForThisRender && !renderer.isX3() && !aaPreempted;
+  const bool deferredAaThisRender = aaEnabledForThisRender && renderer.isX3();
+  lastRenderStats.textAntiAliasing = inlineAaThisRender || deferredAaThisRender;
   if (inlineAaThisRender) {
     renderer.triggerDisplayAsync(pageRefreshMode);
   } else {
@@ -3431,16 +3467,31 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
     renderer.setFastGrayscaleLut(SETTINGS.fastAntiAliasing);
     const int aaFontId = getEffectiveReaderFontId();
     const Page* pagePtr = page.get();
-    const auto gt = renderer.renderGrayscalePlanesInterleaved([&](GfxRenderer::RenderMode) {
-      pagePtr->renderTextOnly(renderer, aaFontId, orientedMarginLeft, contentTop);
-      pagePtr->renderImagesFromGrayscaleCache(renderer, orientedMarginLeft, contentTop);
-    });
-    LOG_DBG("ERS", "Inline AA: planes=%lums gray=%lums restore=%lums", gt.planesMs, gt.displayMs, gt.restoreMs);
+    // The per-element abort buys no wall-clock here — this plane render is overlapped with the
+    // BW waveform, so bailing early just idles in finishDisplayAsync() for the remainder. It is
+    // still worth setting: latching planeAborted means the pass aborts even if the input signal
+    // has been drained by the loop task before the predicate below is evaluated.
+    bool planeAborted = false;
+    const auto gt = renderer.renderGrayscalePlanesInterleaved(
+        [&](GfxRenderer::RenderMode) {
+          if (!pagePtr->renderTextOnly(renderer, aaFontId, orientedMarginLeft, contentTop, /*abortable=*/true)) {
+            planeAborted = true;
+            return;
+          }
+          pagePtr->renderImagesFromGrayscaleCache(renderer, orientedMarginLeft, contentTop);
+        },
+        // Re-checked here because the up-front gate can only see the gesture as it stands when
+        // the render begins; the pass itself is ~1 s long, so most presses during a burst land
+        // after that decision and would otherwise be unstoppable.
+        [&] { return planeAborted || aaPreemptedByNavigation(); });
+    LOG_DBG("ERS", "Inline AA%s: planes=%lums gray=%lums restore=%lums", gt.aborted ? " ABORTED" : "", gt.planesMs,
+            gt.displayMs, gt.restoreMs);
     checkHeapIntegrity("after_inline_aa");
-    lastRenderStats.usedGrayscale = true;
+    lastRenderStats.usedGrayscale = !gt.aborted;
+    lastRenderStats.textAntiAliasing = !gt.aborted;
     lastRenderStats.phases = {tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, 0, gt.planesMs, 0,
                               gt.displayMs,  gt.restoreMs,         millis() - t0};
-  } else if (aaEnabledForThisRender) {
+  } else if (deferredAaThisRender) {
     // Deferred grayscale (X3): store context before releasing the lock, so
     // loop() can run the AA pass once the waveform ends. The page is kept
     // alive via shared_ptr.
@@ -3545,6 +3596,32 @@ void EpubReaderActivity::renderPageContentOnly(const Page& page, const int orien
   // Status bar intentionally omitted — superimposed at display time with live values.
 }
 
+bool EpubReaderActivity::aaPreemptedByNavigation() const {
+  // 1) An update is already queued — a turn has completed and its render is waiting.
+  if (isUpdateSuperseded()) {
+    return true;
+  }
+  // 2) The sampler has seen a press the loop task has not drained yet. Covers the first
+  //    ~10 ms of a gesture, before the press reaches the live-state snapshot below.
+  if (mappedInput.hasPendingInput()) {
+    return true;
+  }
+  // 3) A navigation button is down. This is the window the queued-update signal alone
+  //    misses: a page turn is only classified on RELEASE, so between press and release
+  //    nothing else indicates that the page on screen is about to be replaced — which is
+  //    exactly when the AA pass would start and then be unstoppable.
+  //
+  //    Bounded by LONG_PRESS_MS: past that threshold the Long event has already fired and
+  //    been acted on (chapter skip, or whatever the button is mapped to), so continuing to
+  //    hold no longer predicts a further turn. Without the bound, a chapter skip performed
+  //    with the button still held would suppress the AA of the page it lands on and nothing
+  //    would render it again.
+  using B = MappedInputManager::Button;
+  const bool navigationHeld = mappedInput.isPressed(B::PageForward) || mappedInput.isPressed(B::PageBack) ||
+                              mappedInput.isPressed(B::Left) || mappedInput.isPressed(B::Right);
+  return navigationHeld && mappedInput.getHeldTime() < ButtonEventManager::LONG_PRESS_MS;
+}
+
 void EpubReaderActivity::displayPreRenderedPage(const Page& page, const int orientedMarginTop,
                                                 const int orientedMarginRight, const int orientedMarginBottom,
                                                 const int orientedMarginLeft) {
@@ -3578,7 +3655,19 @@ void EpubReaderActivity::displayPreRenderedPage(const Page& page, const int orie
   lastPageRefreshMode_ = renderer.getLastRefreshMode();
   lastPageDisplayModeByte_ = renderer.getLastDisplayModeByte();
 
-  if (getEffectiveTextAntiAliasing() && renderer.hasSecondaryBuffer() && !secondaryBufferDegraded_) {
+  // Same gate as renderContents(), and this is the path that matters most for it: a fast
+  // forward burst is exactly what hits the pre-render cache, and the replay below costs a
+  // glyph re-warm scan, two plane renders, the plane SPI writes and a gray flush — all on a
+  // page the next turn is about to replace. It is inline and uncancellable on both devices,
+  // so unlike renderContents() this gate applies to X3 too. The BW refresh above has already
+  // completed, so checking here also catches a gesture that began during it. Skipping leaves
+  // precisely the state the AA-disabled path leaves (no plane render means nothing for the
+  // grayscale cleanup to undo), so no buffer or RED-RAM baseline is disturbed.
+  const bool aaPreempted = aaPreemptedByNavigation();
+  if (aaPreempted) {
+    LOG_DBG("ERS", "AA replay skipped: page preempted by navigation");
+  }
+  if (!aaPreempted && getEffectiveTextAntiAliasing() && renderer.hasSecondaryBuffer() && !secondaryBufferDegraded_) {
     const int fontId = getEffectiveReaderFontId();
     // Re-warm the page's glyph BITMAPS before the AA replay. The pre-render pass warmed
     // them, but background work since may have dropped or re-wired the cache (B's
@@ -3593,9 +3682,18 @@ void EpubReaderActivity::displayPreRenderedPage(const Page& page, const int orie
       scope.endScanAndPrewarm();
     }
     renderer.setFastGrayscaleLut(SETTINGS.fastAntiAliasing);
-    renderer.renderGrayscalePlanesSequential(
-        [&](GfxRenderer::RenderMode) { page.renderTextOnly(renderer, fontId, orientedMarginLeft, contentTop); });
-    // timings not recorded for the pre-rendered path
+    // No waveform to hide behind on this path (displayBuffer() above already returned), so the
+    // per-element abort translates directly into saved wall-clock on both devices.
+    bool planeAborted = false;
+    const auto gt = renderer.renderGrayscalePlanesSequential(
+        [&](GfxRenderer::RenderMode) {
+          planeAborted = !page.renderTextOnly(renderer, fontId, orientedMarginLeft, contentTop, /*abortable=*/true);
+        },
+        [&] { return planeAborted || aaPreemptedByNavigation(); });
+    if (gt.aborted) {
+      LOG_DBG("ERS", "AA replay aborted mid-pass: page preempted by navigation");
+    }
+    // timings not otherwise recorded for the pre-rendered path
   }
   checkHeapIntegrity("after_bufferdisplay_aa");
 }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -181,6 +181,13 @@ class EpubReaderActivity final : public Activity {
   // by the page summary so it reflects the page, not the AA pass.
   HalDisplay::RefreshMode lastPageRefreshMode_ = HalDisplay::RefreshMode::FAST_REFRESH;
   uint8_t lastPageDisplayModeByte_ = 0;
+  // Page index/count of the page a display pass actually rendered, captured when that pass
+  // begins. The page summary MUST log these rather than section->currentPage: pageTurn() runs
+  // on the loop task without the render lock, so a turn arriving mid-render advances
+  // currentPage before the summary is emitted and the render gets labelled with the page it is
+  // about to be replaced by — which reads as the same page rendering twice.
+  int lastRenderedPageIndex_ = 0;
+  int lastRenderedPageCount_ = 0;
   // True when secondary display buffer allocation failed; while set we prefer
   // conservative refresh policy and skip grayscale AA to reduce ghosting.
   bool secondaryBufferDegraded_ = false;
@@ -590,6 +597,13 @@ class EpubReaderActivity final : public Activity {
   // that was last rendered into the buffer (needed for image AA re-render).
   void displayPreRenderedPage(const Page& page, int orientedMarginTop, int orientedMarginRight,
                               int orientedMarginBottom, int orientedMarginLeft);
+  // True when the page currently being rendered is already on its way out, so its
+  // anti-aliasing touch-up (cosmetic, and uncancellable once started) should be dropped.
+  // Covers the whole gesture, not just its tail: the sampler seeing a press edge, a
+  // navigation button being held, and an update already queued by a completed turn.
+  // Advisory — call it from the render task as late as possible, and never gate anything
+  // the next frame depends on it.
+  bool aaPreemptedByNavigation() const;
   // If the frame buffer currently holds a pre-rendered next page, redraw the current page
   // into it (no status bar, no flush). Restores the invariant other activities — notably
   // SleepActivity's OVERLAY mode — rely on when transitioning out of the reader.

--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -40,17 +40,17 @@ void EpubReaderFootnotesActivity::loop() {
       return;
     }
 
-    // Previous: Up / Left / PageBack
-    if ((ev.button == MappedInputManager::Button::Up || ev.button == MappedInputManager::Button::Left ||
-         ev.button == MappedInputManager::Button::PageBack) &&
+    // Previous: side-back button / Left. PageBack and Up are two names for the same physical
+    // button and the FSM emits an event for each, so matching both moved the selection by two
+    // per press — match only the PageBack name (see the aliasing note in ButtonEventManager.h).
+    if ((ev.button == MappedInputManager::Button::PageBack || ev.button == MappedInputManager::Button::Left) &&
         ev.type == ButtonEventManager::PressType::Short) {
       advanceSelection(-1);
       continue;
     }
 
-    // Next: Down / Right / PageForward
-    if ((ev.button == MappedInputManager::Button::Down || ev.button == MappedInputManager::Button::Right ||
-         ev.button == MappedInputManager::Button::PageForward) &&
+    // Next: side-forward button / Right (same aliasing caveat as above).
+    if ((ev.button == MappedInputManager::Button::PageForward || ev.button == MappedInputManager::Button::Right) &&
         ev.type == ButtonEventManager::PressType::Short) {
       advanceSelection(1);
       continue;

--- a/src/activities/reader/LineReaderActivity.cpp
+++ b/src/activities/reader/LineReaderActivity.cpp
@@ -18,7 +18,7 @@ void LineReaderActivity::onEnter() {
   Activity::onEnter();
 
   // See ReaderUtils::InputDrainGuard — prevents wake-up power-button hold from leaking into
-  // the first detectPageTurn() call as a page turn or chapter skip.
+  // the first page-turn check as a page turn or chapter skip.
   inputDrainGuard.arm();
 
   if (!txt) {
@@ -114,7 +114,7 @@ void LineReaderActivity::loop() {
     }
   }
 
-  auto [prevTriggered, nextTriggered] = ReaderUtils::detectPageTurn(mappedInput);
+  auto [prevTriggered, nextTriggered] = ReaderUtils::detectTiltPageTurn();
   if (prevTriggered) {
     goToPreviousPage();
   } else if (nextTriggered) {

--- a/src/activities/reader/MdReaderActivity.cpp
+++ b/src/activities/reader/MdReaderActivity.cpp
@@ -743,7 +743,9 @@ void MdReaderActivity::renderPage() {
     // Same AA pass as EpubReaderActivity — see TxtReaderActivity::renderPage()
     // for why the legacy store/restore helper ghosted after swapBuffers().
     renderer.setFastGrayscaleLut(SETTINGS.fastAntiAliasing);
-    renderer.renderGrayscalePlanesSequential([&](GfxRenderer::RenderMode) { renderLines(); });
+    // Never aborts: the navigation-preempt gate is currently EPUB-only (see
+    // EpubReaderActivity::aaPreemptedByNavigation), so this pass keeps its previous behaviour.
+    renderer.renderGrayscalePlanesSequential([&](GfxRenderer::RenderMode) { renderLines(); }, [] { return false; });
   }
 }
 

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 
-#include "ButtonEventManager.h"
 #include "MappedInputManager.h"
 
 namespace ReaderUtils {
@@ -58,8 +57,8 @@ inline void applyOrientation(GfxRenderer& renderer, const uint8_t orientation) {
 
 // Suppresses input processing on activity entry until the user has released all buttons and a
 // clean frame (no pending press/release events) has been observed. Without this, the power-button
-// hold used to wake the device leaks into detectPageTurn() and triggers a page turn or chapter
-// skip (the wake-hold easily exceeds skipChapterMs).
+// hold used to wake the device leaks into the reader's page-turn handling and triggers a page turn
+// or chapter skip (the wake-hold easily exceeds skipChapterMs).
 // Each reader holds an instance, calls arm() in onEnter(), and calls shouldDrain() at the top
 // of loop() — returning early when it returns true.
 struct InputDrainGuard {
@@ -88,13 +87,18 @@ struct PageTurnResult {
   bool next;
 };
 
-inline PageTurnResult detectPageTurn(const MappedInputManager& input) {
-  // Only treat wasReleased as a page turn when the button's short-press action is default.
-  // Non-default short-press actions are dispatched by the global dispatcher in main.cpp;
-  // counting wasReleased as well would double-fire the action.
-  // Also suppress immediate page-turns if a double-click action is configured for the button,
-  // because the button event system delays short events until the double-click window expires.
-  using BA = CrossPointSettings::BUTTON_ACTION;
+// Tilt gestures only. Button page turns come from ButtonEventManager's Short events,
+// which every reader handles in its consumeEvent() loop.
+//
+// Buttons used to be read here from MappedInputManager::wasReleased() instead. That is a
+// per-tick bitmask (HalGPIO::accumPressed_/accumReleased_, OR-ed by the sampler and cleared
+// on every gpio.update()), so every release landing inside one slow loop iteration collapsed
+// into a single page turn and the surplus presses were dropped. The event queue replays each
+// debounced edge discretely with its own timestamp, so nothing is lost. Left/Right already
+// took the queue path (they carry a double-click action by default, which suppressed the
+// wasReleased branch) while Up/Down took the snapshot path — the two behaved visibly
+// differently under fast repeated presses. One path for all four keeps them identical.
+inline PageTurnResult detectTiltPageTurn() {
   using TA = CrossPointSettings::TILT_GESTURE_ACTION;
   const bool tiltNegative = SETTINGS.tiltPageTurn && halTiltSensor.wasTiltedForward();
   const bool tiltPositive = SETTINGS.tiltPageTurn && halTiltSensor.wasTiltedBack();
@@ -113,27 +117,7 @@ inline PageTurnResult detectPageTurn(const MappedInputManager& input) {
   if (tiltNegative) {
     applyTiltAction(SETTINGS.tiltNegativeAction);
   }
-  const bool prevButtonReleased = (SETTINGS.btnShortPageBack == BA::BTN_DEFAULT &&
-                                   !globalButtonEvents().hasDoubleAction(MappedInputManager::Button::PageBack) &&
-                                   !globalButtonEvents().wasLongPressDispatched(MappedInputManager::Button::PageBack) &&
-                                   input.wasReleased(MappedInputManager::Button::PageBack)) ||
-                                  (SETTINGS.btnShortLeft == BA::BTN_DEFAULT &&
-                                   !globalButtonEvents().hasDoubleAction(MappedInputManager::Button::Left) &&
-                                   !globalButtonEvents().wasLongPressDispatched(MappedInputManager::Button::Left) &&
-                                   input.wasReleased(MappedInputManager::Button::Left));
-  const bool nextButtonReleased =
-      (SETTINGS.btnShortPageForward == BA::BTN_DEFAULT &&
-       !globalButtonEvents().hasDoubleAction(MappedInputManager::Button::PageForward) &&
-       !globalButtonEvents().wasLongPressDispatched(MappedInputManager::Button::PageForward) &&
-       input.wasReleased(MappedInputManager::Button::PageForward)) ||
-      (SETTINGS.btnShortRight == BA::BTN_DEFAULT &&
-       !globalButtonEvents().hasDoubleAction(MappedInputManager::Button::Right) &&
-       !globalButtonEvents().wasLongPressDispatched(MappedInputManager::Button::Right) &&
-       input.wasReleased(MappedInputManager::Button::Right));
-
-  const bool prev = tiltPrev || prevButtonReleased;
-  const bool next = tiltNext || nextButtonReleased;
-  return {prev, next};
+  return {tiltPrev, tiltNext};
 }
 
 inline void displayWithRefreshCycle(const GfxRenderer& renderer, int& pagesUntilFullRefresh) {

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -307,7 +307,9 @@ void TxtReaderActivity::renderPage() {
     // the write framebuffer instead would diff the next fast refresh against
     // the previous page and ghost heavily.
     renderer.setFastGrayscaleLut(SETTINGS.fastAntiAliasing);
-    renderer.renderGrayscalePlanesSequential([&](GfxRenderer::RenderMode) { renderLines(); });
+    // Never aborts: the navigation-preempt gate is currently EPUB-only (see
+    // EpubReaderActivity::aaPreemptedByNavigation), so this pass keeps its previous behaviour.
+    renderer.renderGrayscalePlanesSequential([&](GfxRenderer::RenderMode) { renderLines(); }, [] { return false; });
   }
   // scope destructor clears font cache via FontCacheManager
 }

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -32,7 +32,7 @@ void XtcReaderActivity::onEnter() {
   Activity::onEnter();
 
   // See ReaderUtils::InputDrainGuard — prevents wake-up power-button hold from leaking into
-  // the first detectPageTurn() call as a page turn or chapter skip.
+  // the first page-turn check as a page turn or chapter skip.
   inputDrainGuard.arm();
 
   if (!xtc) {
@@ -78,8 +78,8 @@ void XtcReaderActivity::loop() {
     return;
   }
 
-  bool delayedPrevTurn = false;
-  bool delayedNextTurn = false;
+  bool buttonPrevTurn = false;
+  bool buttonNextTurn = false;
   using BA = CrossPointSettings::BUTTON_ACTION;
 
   ButtonEventManager::ButtonEvent ev;
@@ -112,8 +112,8 @@ void XtcReaderActivity::loop() {
     }
 
     // Built-in default for a long-press on a page-turn button is chapter skip.
-    // onButtonAction() no-ops when the XTC has no chapters. markLongPressDispatched()
-    // suppresses the release-driven page turn that would otherwise also fire.
+    // onButtonAction() no-ops when the XTC has no chapters. The FSM emits no Short for a
+    // press that already produced a Long, so the release cannot also turn the page.
     // (Mirrors EpubReaderActivity; non-default long actions are dispatched by main.cpp.)
     if (ev.type == ButtonEventManager::PressType::Long) {
       const bool prevChapter =
@@ -123,37 +123,36 @@ void XtcReaderActivity::loop() {
           (ev.button == MappedInputManager::Button::PageForward && SETTINGS.btnLongPageForward == BA::BTN_DEFAULT) ||
           (ev.button == MappedInputManager::Button::Right && SETTINGS.btnLongRight == BA::BTN_DEFAULT);
       if (prevChapter || nextChapter) {
-        globalButtonEvents().markLongPressDispatched(ev.button);
         onButtonAction(nextChapter ? BA::BTN_NEXT_SECTION : BA::BTN_PREV_SECTION);
         return;
       }
     }
 
+    // Page turns for all four navigation buttons come from the event queue (see
+    // EpubReaderActivity::loop for why). A non-default short action never arrives here —
+    // main.cpp dispatches it globally — but the setting is re-checked so a future caller
+    // that pushes events directly cannot turn a remapped button into a page turn.
     if (ev.type == ButtonEventManager::PressType::Short) {
-      if ((ev.button == MappedInputManager::Button::PageBack && SETTINGS.btnShortPageBack == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::PageBack)) ||
-          (ev.button == MappedInputManager::Button::Left && SETTINGS.btnShortLeft == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::Left))) {
-        delayedPrevTurn = true;
+      if ((ev.button == MappedInputManager::Button::PageBack && SETTINGS.btnShortPageBack == BA::BTN_DEFAULT) ||
+          (ev.button == MappedInputManager::Button::Left && SETTINGS.btnShortLeft == BA::BTN_DEFAULT)) {
+        buttonPrevTurn = true;
         continue;
       }
-      if ((ev.button == MappedInputManager::Button::PageForward && SETTINGS.btnShortPageForward == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::PageForward)) ||
-          (ev.button == MappedInputManager::Button::Right && SETTINGS.btnShortRight == BA::BTN_DEFAULT &&
-           globalButtonEvents().hasDoubleAction(MappedInputManager::Button::Right))) {
-        delayedNextTurn = true;
+      if ((ev.button == MappedInputManager::Button::PageForward && SETTINGS.btnShortPageForward == BA::BTN_DEFAULT) ||
+          (ev.button == MappedInputManager::Button::Right && SETTINGS.btnShortRight == BA::BTN_DEFAULT)) {
+        buttonNextTurn = true;
         continue;
       }
     }
   }
 
-  auto [prevTriggered, nextTriggered] = ReaderUtils::detectPageTurn(mappedInput);
+  auto [prevTriggered, nextTriggered] = ReaderUtils::detectTiltPageTurn();
   if (!prevTriggered && !nextTriggered) {
-    if (!delayedPrevTurn && !delayedNextTurn) {
+    if (!buttonPrevTurn && !buttonNextTurn) {
       return;
     }
-    prevTriggered = delayedPrevTurn;
-    nextTriggered = delayedNextTurn;
+    prevTriggered = buttonPrevTurn;
+    nextTriggered = buttonNextTurn;
   }
 
   if (!prevTriggered && !nextTriggered) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1048,7 +1048,10 @@ void loop() {
           }
           break;
         default:
-          break;  // Up/Down have no FSMs — ButtonEventManager never emits these
+          break;  // Up/Down are the PageBack/PageForward buttons under their list-navigation
+                  // names. The FSM emits both names for one press, and the PageBack/PageForward
+                  // event above already carries the configured action — so these fall through
+                  // to the activity, which is what list-style activities match on.
       }
       return BA::BTN_DEFAULT;
     };
@@ -1092,13 +1095,6 @@ void loop() {
       if (action == BA::BTN_DEFAULT || (isReaderScopedAction(action) && !activityManager.isReaderActivity())) {
         defaultEvents.push_back(ev);
         continue;
-      }
-
-      // When a non-default Long action fires for a page-turn button, mark it so that
-      // detectPageTurn() suppresses the wasReleased-based page turn on button release.
-      if (ev.type == ButtonEventManager::PressType::Long &&
-          (ev.button == B::Left || ev.button == B::Right || ev.button == B::PageBack || ev.button == B::PageForward)) {
-        buttonEventManager.markLongPressDispatched(ev.button);
       }
 
       switch (static_cast<BA>(action)) {
@@ -1181,10 +1177,10 @@ void loop() {
           activityManager.dispatchButtonAction(BA::BTN_QUICK_OVERRIDES);
           break;
         case BA::BTN_IGNORE:
-          // Explicit "do nothing": swallow the event so neither a global action nor
-          // the activity's built-in behaviour fires. For a long-press on a page-turn
-          // button the markLongPressDispatched() above also suppresses the
-          // release-driven page turn, so the press is fully inert.
+          // Explicit "do nothing": swallow the event so neither a global action nor the
+          // activity's built-in behaviour fires. A press that produced a Long emits no
+          // Short, so a long-press mapped to Ignore is fully inert — the release cannot
+          // leak through as a page turn.
           break;
         default:
           break;


### PR DESCRIPTION
## The reported symptom in issue #93 

> the left/right buttons seem to be registered earlier, e.g. when clicking a right button in quick succession the reader does not do the AA pass but immediately goes to the next page, the up/down buttons seem to outwait the AA pass before they register a next press

Both halves of that turned out to be real, with separate causes.

## 1. Two different page-turn paths

`btnDoubleLeft`/`btnDoubleRight` ship as `PAGE_BACK_10`/`PAGE_FORWARD_10`, so `detectPageTurn()` suppressed Left/Right and they turned pages from the `ButtonEventManager` queue. Up/Down (`PageBack`/`PageForward`, no double action by default) turned from `MappedInputManager::wasReleased()` — a per-tick bitmask that OR-collapses every release landing inside one slow loop iteration. Presses taken during a slow slice were dropped on the side buttons and preserved on the front ones.

All four now turn from the event queue, which replays each debounced edge discretely with its own timestamp. `detectPageTurn()` becomes `detectTiltPageTurn()` and handles tilt only.

`markLongPressDispatched()` and its mask are removed — they existed only to stop the snapshot path firing a turn on the release after a long press, and the FSM already emits no `Short` for a press that produced a `Long`.

**Behaviour change:** Up/Down now behave like Left/Right always did — every press during a slow slice is replayed rather than N presses collapsing into one turn.

## 2. Three more input bugs found in the same area

- `hasDoubleAction()` now answers identically for both names of an aliased pair. `Up`/`PageBack` and `Down`/`PageForward` are one physical button driving two FSMs; they disagreed about whether to wait out the double-click window, so an activity accepting either name got the un-delayed event and a configured double action was silently defeated.
- **The footnote list advanced by two per side-button press** — it matched `Up || Left || PageBack`, and one press emits both `Up` and `PageBack`. Now matches one name per pair.
- Corrected the comment in `main.cpp` claiming `ButtonEventManager` never emits `Up`/`Down`. They are in `ALL_BUTTONS` and are emitted on every side-button press.

## 3. The AA pass now yields to navigation

Anti-aliasing is a cosmetic touch-up that was being paid in full for pages already on their way out. It is dropped at three points of increasing granularity:

| where | what it catches |
|---|---|
| before the pass | `aaPreemptedByNavigation()` — a queued update, an undrained press, or a navigation button held (bounded by `LONG_PRESS_MS` so a chapter skip with the button still down doesn't suppress the AA of the page it lands on) |
| between planes | a press arriving during the ~440 ms LSB render, before any grayscale byte reaches the controller |
| per element | `CooperativeAbort` inside `Page::renderTextOnly`, using the hook already installed for the image decoders |

Only the AA plane renders opt into aborting. The prewarm **scan** passes must complete or the replay dereferences an unwarmed glyph bitmap, and an aborted pre-render would still be marked `ready` and flushed by the next buffer-display turn.

A plane that bailed forces the pass to abandon regardless of the predicate, and both passes gate after the MSB render as well as the LSB one — without that second gate a half-drawn plane was copied and flushed (caught on X3 as a *completed* pass with `planes=545ms` against a normal ~890 ms).

### Measured on device

| | before | after |
|---|---|---|
| X4 page turn, preempted | 1507–1554 ms | **965–1057 ms** |
| X3 deferred pass | 1215 ms | **218–505 ms** |
| X3 max loop duration (input starvation — that pass runs on the loop task) | 1237 ms | **510–586 ms** |

X4's inline pass overlaps its LSB render with the waveform, so the per-element abort buys robustness there rather than time; the win is on X3 and on the pre-render replay, neither of which has a waveform to hide behind.