### PR TITLE
perf: make scaled body text render at unscaled speed

### DIFF
--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -180,9 +180,27 @@ const uint8_t* FontDecompressor::getBitmap(const EpdFontData* fontData, const Ep
 
   if (group.uncompressedSize > stats.peakTempBytes) stats.peakTempBytes = group.uncompressedSize;
 
+  // OOM latch. This is the per-glyph-occurrence path, so a page whose prewarm did not cover
+  // it calls through here hundreds of times. The heap cannot recover mid-pass (the render
+  // lock is held throughout), so once an allocation of a given size has failed, every later
+  // request at or above that size fails too — retrying is pure waste. Measured on X4
+  // (2026-08-02, a render racing a background section build): 538 failed mallocs and 538
+  // identical ERR lines in 40 ms, 147 ms of getBitmap time against ~1 ms normally, and a
+  // page render of 129 ms against 43. Only the failing size class is latched out; a smaller
+  // group may still fit and is still attempted.
+  if (stats.fallbackOomBytes != 0 && group.uncompressedSize >= stats.fallbackOomBytes) {
+    stats.fallbackOomGlyphs++;
+    stats.getBitmapTimeUs += micros() - tStart;
+    return nullptr;
+  }
+
   uint8_t* groupBuf = static_cast<uint8_t*>(malloc(group.uncompressedSize));
   if (!groupBuf) {
-    LOG_ERR("FDC", "OOM: cannot allocate %lu bytes for group %u fallback", group.uncompressedSize, groupIndex);
+    // Logged once per size class per pass; the running total goes out in logStats().
+    LOG_ERR("FDC", "OOM: cannot allocate %lu bytes for group %u fallback; skipping this size and larger for the pass",
+            group.uncompressedSize, groupIndex);
+    stats.fallbackOomBytes = group.uncompressedSize;
+    stats.fallbackOomGlyphs++;
     stats.getBitmapTimeUs += micros() - tStart;
     return nullptr;
   }
@@ -587,6 +605,12 @@ void FontDecompressor::logStats(const char* label) {
   if (lruTotal > 0) {
     LOG_DBG("FDC", "[%s] LRU Fallback: hits=%lu misses=%lu (%.1f%%)", label, stats.fallbackCacheHits,
             stats.fallbackCacheMisses, 100.0f * stats.fallbackCacheHits / lruTotal);
+  }
+
+  // Degraded render: these glyphs drew nothing. One line per pass instead of one per glyph.
+  if (stats.fallbackOomGlyphs > 0) {
+    LOG_ERR("FDC", "[%s] fallback OOM: %u glyphs dropped (groups >=%lu bytes unavailable)", label,
+            stats.fallbackOomGlyphs, stats.fallbackOomBytes);
   }
 
   resetStats();

--- a/lib/EpdFont/FontDecompressor.h
+++ b/lib/EpdFont/FontDecompressor.h
@@ -45,6 +45,13 @@ class FontDecompressor {
     // LRU specific stats
     uint32_t fallbackCacheHits = 0;
     uint32_t fallbackCacheMisses = 0;
+
+    // Fallback-path OOM latch. Smallest group size (bytes) whose transient allocation
+    // failed during this pass, or 0 if none has. Lives in Stats so it is cleared by
+    // resetStats() — i.e. it lasts exactly one render phase, and the next phase retries
+    // with whatever heap is available by then. See getBitmap().
+    uint32_t fallbackOomBytes = 0;
+    uint16_t fallbackOomGlyphs = 0;  // glyphs that got no bitmap because of it
   };
   void logStats(const char* label = "FDC");
   void resetStats();

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -3,6 +3,7 @@
 #include <FontDecompressor.h>
 #include <HalGPIO.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <SdCardFont.h>
 #include <SmallCaps.h>
 #include <Utf8.h>
@@ -101,6 +102,84 @@ void GfxRenderer::insertFont(const int fontId, EpdFontFamily font) {
   if (!result.second) {
     LOG_ERR("GFX", "Font ID %d already registered, ignoring duplicate", fontId);
   }
+  invalidateScaledGlyphCache();
+}
+
+// Bits needed for a w x h 1-bit mask, plus one guard byte: bitmapExtract() reads
+// two bytes when a chunk straddles a byte boundary, so the final chunk of the
+// last row may touch one byte past the packed size.
+static inline uint16_t scaledGlyphMaskBytes(const int w, const int h) {
+  return static_cast<uint16_t>((static_cast<int>(w) * h + 7) / 8 + 1);
+}
+
+// Reinterpret a float's bits so cache keys compare exactly. Two words laid out
+// with the same CSS scale produce the same float, so this is a reliable identity
+// without the rounding risk of quantising the scale into a fixed-point key.
+static inline uint32_t floatBits(const float f) {
+  uint32_t bits;
+  memcpy(&bits, &f, sizeof(bits));
+  return bits;
+}
+
+const uint8_t* GfxRenderer::findScaledGlyphMask(const void* fontData, const uint32_t cp, const float scale,
+                                                const uint8_t sel, const int w, const int h) const {
+  if (!scaledGlyphArena_) return nullptr;
+  const uint32_t bits = floatBits(scale);
+  for (uint8_t i = 0; i < scaledGlyphCount_; i++) {
+    const ScaledGlyphEntry& e = scaledGlyphEntries_[i];
+    if (e.fontData == fontData && e.cp == cp && e.scaleBits == bits && e.sel == sel && e.w == w && e.h == h) {
+      return scaledGlyphArena_.get() + e.offset;
+    }
+  }
+  return nullptr;
+}
+
+uint8_t* GfxRenderer::allocScaledGlyphMask(const void* fontData, const uint32_t cp, const float scale,
+                                           const uint8_t sel, const int w, const int h) const {
+  // Dimensions are stored as uint8 and the mask must stay well under the arena;
+  // oversized glyphs render uncached rather than evicting the body-text set.
+  // Codepoints above the BMP are stored in a uint16 key, so they render uncached
+  // too — they are vanishingly rare in body text and never worth widening the key.
+  if (w <= 0 || h <= 0 || w > 255 || h > 255 || cp > 0xFFFF) return nullptr;
+  const uint16_t bytes = scaledGlyphMaskBytes(w, h);
+  if (bytes > SCALED_GLYPH_MAX_MASK_BYTES) return nullptr;
+
+  if (!scaledGlyphArena_) {
+    if (scaledGlyphOom_) return nullptr;  // already failed once; don't thrash the heap
+    auto entries = makeUniqueNoThrow<ScaledGlyphEntry[]>(SCALED_GLYPH_MAX_ENTRIES);
+    auto arena = makeUniqueNoThrow<uint8_t[]>(SCALED_GLYPH_ARENA_BYTES);
+    if (!entries || !arena) {
+      LOG_ERR("GFX", "OOM: scaled-glyph cache (%u + %u bytes); rendering scaled text uncached",
+              static_cast<unsigned>(SCALED_GLYPH_MAX_ENTRIES * sizeof(ScaledGlyphEntry)),
+              static_cast<unsigned>(SCALED_GLYPH_ARENA_BYTES));
+      scaledGlyphOom_ = true;
+      return nullptr;
+    }
+    scaledGlyphEntries_ = std::move(entries);
+    scaledGlyphArena_ = std::move(arena);
+    scaledGlyphCount_ = 0;
+    scaledGlyphUsed_ = 0;
+  }
+
+  if (scaledGlyphCount_ >= SCALED_GLYPH_MAX_ENTRIES || scaledGlyphUsed_ + bytes > SCALED_GLYPH_ARENA_BYTES) {
+    // Wholesale reset instead of LRU bookkeeping: the working set is one page's
+    // distinct glyphs, so a reset costs at most one re-resample each.
+    LOG_DBG("GFX", "Scaled-glyph cache reset (%u entries, %u bytes used)", scaledGlyphCount_, scaledGlyphUsed_);
+    invalidateScaledGlyphCache();
+  }
+
+  uint8_t* const mask = scaledGlyphArena_.get() + scaledGlyphUsed_;
+  memset(mask, 0, bytes);
+  ScaledGlyphEntry& e = scaledGlyphEntries_[scaledGlyphCount_++];
+  e.fontData = fontData;
+  e.cp = static_cast<uint16_t>(cp);
+  e.scaleBits = floatBits(scale);
+  e.offset = scaledGlyphUsed_;
+  e.sel = sel;
+  e.w = static_cast<uint8_t>(w);
+  e.h = static_cast<uint8_t>(h);
+  scaledGlyphUsed_ = static_cast<uint16_t>(scaledGlyphUsed_ + bytes);
+  return mask;
 }
 
 // Translate logical (x,y) coordinates to physical panel coordinates based on current orientation
@@ -910,36 +989,17 @@ static void renderCharImpl(const GfxRenderer& renderer, GfxRenderer::RenderMode 
   }
 }
 
-// Render a glyph at an arbitrary scale factor.
-// Used for heading font-size scaling (e.g. h1=1.6×, h2=1.4×, h3=1.2×) and per-word inline
-// sizes, including superscript/subscript (which carry an explicit size percentage instead
-// of a hardwired 50% — the SUP/SUB style bits only shift the baseline).
-// Upscaling (scale > 1.0) uses area-weighted coverage resampling so enlarged headings stay
-// anti-aliased and keep the body font's visual weight instead of the jagged, over-bold look
-// nearest-neighbor produced. Downscaling (scale < 1.0) keeps crisp nearest-neighbor point-
-// sampling.
-static void renderCharAtScale(const GfxRenderer& renderer, GfxRenderer::RenderMode renderMode,
-                              const EpdFontFamily& fontFamily, const uint32_t cp, int cursorX, int cursorY,
-                              const bool pixelState, const EpdFontFamily::Style style, const float scale,
-                              const uint8_t minRaw2Bit = 1) {
-  const EpdGlyph* glyph = fontFamily.getGlyph(cp, style);
-  if (!glyph) return;
-
-  const EpdFontData* fontData = fontFamily.getData(style);
-  const uint8_t* bitmap = renderer.getGlyphBitmap(fontData, glyph);
-  if (!bitmap) return;
-
-  const int srcW = glyph->width;
-  const int srcH = glyph->height;
-  if (srcW <= 0 || srcH <= 0) return;
-
-  const int dstW = static_cast<int>(srcW * scale + 0.5f);
-  const int dstH = static_cast<int>(srcH * scale + 0.5f);
-  if (dstW <= 0 || dstH <= 0) return;
-
-  const int baseX = cursorX + static_cast<int>(glyph->left * scale + 0.5f);
-  const int baseY = cursorY - static_cast<int>(glyph->top * scale + 0.5f);
-
+// Resample one glyph to `scale`, reporting every destination pixel that must be drawn to
+// `emit(dstX, dstY)`. Single source of truth for both consumers: the cache builder (which
+// records the pixels into a 1-bit mask) and the uncached fallback (which draws them
+// straight to the framebuffer). Keeping one copy of the maths is what stops the two from
+// drifting apart — the cached and uncached paths must produce identical pixels.
+//
+// `drawMask` is only consulted when scale >= 1; `minRaw2Bit` only when scale < 1.
+template <typename Emit>
+static inline void emitScaledGlyphPixels(const uint8_t* const bitmap, const bool is2Bit, const int srcW, const int srcH,
+                                         const int dstW, const int dstH, const float scale, const uint8_t minRaw2Bit,
+                                         const uint8_t drawMask, Emit&& emit) {
   // The ESP32-C3 has no FPU — every float op in a per-pixel loop is a soft-float call
   // costing hundreds of cycles. Both resampling paths therefore run in 16.16 fixed point:
   // the ONLY float operation per glyph is the one-time conversion of `scale` into a
@@ -951,7 +1011,6 @@ static void renderCharAtScale(const GfxRenderer& renderer, GfxRenderer::RenderMo
 
   // Per-source-pixel raw ink level: 2-bit fonts carry 4 AA levels (0..3); 1-bit fonts map
   // to 0 or 3. Shared by both resampling paths below.
-  const bool is2Bit = fontData->is2Bit;
   auto srcRaw = [&](const int sx, const int sy) -> uint8_t {
     const int pos = sy * srcW + sx;
     if (is2Bit) {
@@ -979,7 +1038,7 @@ static void renderCharAtScale(const GfxRenderer& renderer, GfxRenderer::RenderMo
         if (srcX >= srcW) break;
         const uint8_t raw = srcRaw(srcX, srcY);
         if (raw >= (is2Bit ? minRaw2Bit : minRaw1Bit)) {
-          renderer.drawPixel(baseX + dstX, baseY + dstY, pixelState);
+          emit(dstX, dstY);
         }
       }
     }
@@ -997,12 +1056,9 @@ static void renderCharAtScale(const GfxRenderer& renderer, GfxRenderer::RenderMo
   // decides, per render pass and darkness setting, whether this level draws into the current plane.
   // In grayscale render modes the enlarged heading therefore emits true gray edge pixels (MSB/LSB
   // planes) instead of a hard 1-bit threshold; in BW mode every non-white level draws, matching the
-  // body font's weight. Grayscale passes always clear the bit (draw false), exactly like the body
-  // per-pixel path — only the BW pass honors the caller's pixelState.
-  const uint8_t drawMask = drawMaskFor2BitMode(renderMode, renderer.getTextDarkness());
-  if (drawMask == 0) return;  // Maximum darkness suppresses grayscale passes entirely
-  const bool isBW = (drawMask == 0x0E);
-
+  // body font's weight. (The caller derives the pixel state from the same mask: grayscale passes
+  // clear the bit, only the BW pass honors the caller's pixelState.)
+  //
   // Area integration in fixed point. Overlap extents are 16.16 and bounded by
   // invScaleFP <= FP_ONE (scale >= 1); the raw x h x w product needs 64 bits, which
   // RV32IM handles with a few integer multiplies — still an order of magnitude cheaper
@@ -1040,10 +1096,90 @@ static void renderCharAtScale(const GfxRenderer& renderer, GfxRenderer::RenderMo
       // encoding so the drawMask logic is identical to the body-text per-pixel path.
       const uint8_t raw = static_cast<uint8_t>(std::min<int64_t>(3, (covered + dstPixelAreaFP / 2) / dstPixelAreaFP));
       if ((drawMask >> raw) & 0x01) {
-        renderer.drawPixel(baseX + dstX, baseY + dstY, isBW ? pixelState : false);
+        emit(dstX, dstY);
       }
     }
   }
+}
+
+// Render a glyph at an arbitrary scale factor.
+// Used for heading font-size scaling (e.g. h1=1.6×, h2=1.4×, h3=1.2×) and per-word inline
+// sizes, including superscript/subscript (which carry an explicit size percentage instead
+// of a hardwired 50% — the SUP/SUB style bits only shift the baseline). It is also the path
+// every word of body text takes when the book's stylesheet sets a font-size on it, which is
+// why the resampled mask is cached (see GfxRenderer::ScaledGlyphEntry).
+// Upscaling (scale > 1.0) uses area-weighted coverage resampling so enlarged headings stay
+// anti-aliased and keep the body font's visual weight instead of the jagged, over-bold look
+// nearest-neighbor produced. Downscaling (scale < 1.0) keeps crisp nearest-neighbor point-
+// sampling.
+static void renderCharAtScale(const GfxRenderer& renderer, GfxRenderer::RenderMode renderMode,
+                              const EpdFontFamily& fontFamily, const uint32_t cp, int cursorX, int cursorY,
+                              const bool pixelState, const EpdFontFamily::Style style, const float scale,
+                              const uint8_t minRaw2Bit = 1) {
+  const EpdGlyph* glyph = fontFamily.getGlyph(cp, style);
+  if (!glyph) return;
+
+  const EpdFontData* fontData = fontFamily.getData(style);
+  const uint8_t* bitmap = renderer.getGlyphBitmap(fontData, glyph);
+  if (!bitmap) return;
+
+  const int srcW = glyph->width;
+  const int srcH = glyph->height;
+  if (srcW <= 0 || srcH <= 0) return;
+
+  const int dstW = static_cast<int>(srcW * scale + 0.5f);
+  const int dstH = static_cast<int>(srcH * scale + 0.5f);
+  if (dstW <= 0 || dstH <= 0) return;
+
+  const int baseX = cursorX + static_cast<int>(glyph->left * scale + 0.5f);
+  const int baseY = cursorY - static_cast<int>(glyph->top * scale + 0.5f);
+  const bool is2Bit = fontData->is2Bit;
+
+  // Downscaling thresholds raw ink levels against minRaw2Bit and always honors the
+  // caller's pixelState; upscaling reconstructs a 2-bit AA level and lets the render
+  // mode's drawMask decide, with grayscale passes always clearing the bit. `sel` is
+  // whichever of the two varies the emitted pixel set, and so belongs in the cache key.
+  uint8_t drawMask = 0x0E;
+  bool writeState = pixelState;
+  if (scale >= 1.0f) {
+    drawMask = drawMaskFor2BitMode(renderMode, renderer.getTextDarkness());
+    if (drawMask == 0) return;  // Maximum darkness suppresses grayscale passes entirely
+    writeState = (drawMask == 0x0E) ? pixelState : false;
+  }
+  const uint8_t sel = (scale < 1.0f) ? minRaw2Bit : drawMask;
+
+  // Cached path: resample once per distinct (glyph, scale, sel), then draw every
+  // occurrence with the same 8-pixel-chunk blitter unscaled text uses. renderGlyphFastBW
+  // is not strip-aware, so a strip target falls through to the per-pixel path below
+  // (drawPixel is strip-aware) — same reason the unscaled 1-bit path guards on it.
+  if (!renderer.isStripActive()) {
+    // fontData already identifies the style variant (getData and getGlyph share
+    // getFont(style)), so the style bits are not part of the key.
+    const uint8_t* mask = renderer.findScaledGlyphMask(fontData, cp, scale, sel, dstW, dstH);
+    if (!mask) {
+      if (uint8_t* slot = renderer.allocScaledGlyphMask(fontData, cp, scale, sel, dstW, dstH)) {
+        emitScaledGlyphPixels(bitmap, is2Bit, srcW, srcH, dstW, dstH, scale, minRaw2Bit, drawMask,
+                              [slot, dstW](const int dstX, const int dstY) {
+                                const int bit = dstY * dstW + dstX;
+                                slot[bit >> 3] |= static_cast<uint8_t>(0x80 >> (bit & 7));
+                              });
+        mask = slot;
+      }
+    }
+    if (mask) {
+      renderGlyphFastBW(renderer.getFrameBuffer(), mask, dstW, dstH, baseX, baseY, writeState,
+                        renderer.getOrientation(), renderer.getDisplayWidth(), renderer.getDisplayHeight(),
+                        renderer.getDisplayWidthBytes());
+      return;
+    }
+  }
+
+  // Uncached fallback: a strip target is active, the glyph is too large to cache, or the
+  // arena could not be allocated. Emit straight to the framebuffer, one pixel at a time.
+  emitScaledGlyphPixels(bitmap, is2Bit, srcW, srcH, dstW, dstH, scale, minRaw2Bit, drawMask,
+                        [&renderer, baseX, baseY, writeState](const int dstX, const int dstY) {
+                          renderer.drawPixel(baseX + dstX, baseY + dstY, writeState);
+                        });
 }
 
 // IMPORTANT: This function is in critical rendering path and is called for every pixel. Please keep it as simple and

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -9,6 +9,7 @@ class SdCardFont;
 #include <atomic>
 #include <cstring>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -70,6 +71,63 @@ class GfxRenderer {
   // recording to the (non-const) FontCacheManager. Same pragmatic compromise
   // as before, concentrated in a single pointer instead of four fields.
   mutable FontCacheManager* fontCacheManager_ = nullptr;
+
+  // --- Scaled-glyph mask cache ----------------------------------------------
+  // Text drawn at a scale != 1.0 — i.e. every word of any book whose stylesheet
+  // puts a font-size on body text, which is most of them — is resampled per
+  // destination pixel by renderCharAtScale(). Uncached, that resample runs once
+  // per glyph *occurrence*: ~500 times a page against ~40 distinct glyphs.
+  // Measured 2026-08-02 (X4, "A Scandalous Deception", body text at 0.92em):
+  // 303 ms for the page's BW pass with the scaling, 39 ms with it off.
+  //
+  // Caching the resampled 1-bit coverage mask makes the resample once per
+  // distinct (glyph, scale, selector) and lets renderGlyphFastBW() — the same
+  // 8-pixel-chunk blitter unscaled text uses — draw every occurrence.
+  //
+  // Budget: 80 x 16B table + 3.5 KB arena ≈ 4.75 KB, two allocations made lazily
+  // on the first scaled glyph and released by releaseScaledGlyphCache(). It is
+  // a bump allocator that resets wholesale when full: no per-glyph allocation,
+  // nothing to fragment, and a page whose working set overflows the arena
+  // degrades toward the uncached path instead of growing.
+  //
+  // Not internally synchronised: it is written only from glyph rasterisation,
+  // which every caller (render task, loop-task pre-render, deferred AA) already
+  // serialises behind RenderLock — the same lock that protects the framebuffer
+  // these masks are blitted into.
+  //
+  // Keyed by (font, codepoint, scale, sel), NOT by EpdGlyph address: SD-card
+  // fonts rebuild their glyph array every page and serve overflow codepoints
+  // from an 8-entry ring, so the same address means different glyphs over time.
+  // The resampled pixels are a pure function of this key, which makes it both
+  // stable and exact. Style is deliberately absent: EpdFontFamily::getData() and
+  // getGlyph() both resolve through getFont(style), so the EpdFontData pointer
+  // already identifies the variant.
+  struct ScaledGlyphEntry {
+    const void* fontData;  // EpdFontData for the style (stable per font object)
+    uint32_t scaleBits;    // exact float bits of the scale factor (no quantisation)
+    uint16_t cp;           // codepoint; above the BMP renders uncached (see alloc)
+    uint16_t offset;       // byte offset into scaledGlyphArena_
+    uint8_t sel;           // minRaw2Bit (scale < 1) or drawMask (scale >= 1)
+    uint8_t w;
+    uint8_t h;
+  };
+  // Keeps the documented budget honest if a field is ever added.
+  static_assert(sizeof(ScaledGlyphEntry) <= 16, "scaled-glyph entry grew; update the cache budget comment");
+  // Sized from measurement, not guesswork: a page of this corpus needs 45-58
+  // distinct renditions (three font groups x ~40 glyphs, per the prewarm logs)
+  // averaging ~40 bytes of mask each. 48 entries reset on every pass — the table,
+  // not the arena, was the binding constraint.
+  static constexpr uint8_t SCALED_GLYPH_MAX_ENTRIES = 80;
+  static constexpr uint16_t SCALED_GLYPH_ARENA_BYTES = 3584;
+  // One outsized glyph (a large heading) must not evict a page's whole body-text
+  // working set, so anything above this renders uncached.
+  static constexpr uint16_t SCALED_GLYPH_MAX_MASK_BYTES = 512;
+  mutable std::unique_ptr<ScaledGlyphEntry[]> scaledGlyphEntries_;
+  mutable std::unique_ptr<uint8_t[]> scaledGlyphArena_;
+  mutable uint8_t scaledGlyphCount_ = 0;
+  mutable uint16_t scaledGlyphUsed_ = 0;
+  mutable bool scaledGlyphOom_ = false;  // arena allocation failed; do not retry every glyph
+
   mutable std::atomic<unsigned int> refreshOverride = REFRESH_OVERRIDE_NONE;
   // Atomically consume a pending setNextDisplayRefreshMode() override: if one is set, clear it
   // and return its mode; otherwise return `requested`. Shared by displayBuffer() and
@@ -111,14 +169,28 @@ class GfxRenderer {
   // Setup
   void begin();  // must be called right after display.begin()
   void insertFont(int fontId, EpdFontFamily font);
-  void removeFont(int fontId) { fontMap.erase(fontId); }
+  void removeFont(int fontId) {
+    fontMap.erase(fontId);
+    invalidateScaledGlyphCache();
+  }
   void setFontCacheManager(FontCacheManager* m) { fontCacheManager_ = m; }
   FontCacheManager* getFontCacheManager() const { return fontCacheManager_; }
   bool isFontCacheScanning() const;
   const std::map<int, EpdFontFamily>& getFontMap() const { return fontMap; }
-  void registerSdCardFont(int fontId, SdCardFont* font) { sdCardFonts_[fontId] = font; }
-  void unregisterSdCardFont(int fontId) { sdCardFonts_.erase(fontId); }
-  void clearSdCardFonts() { sdCardFonts_.clear(); }
+  // Each of these can retire an EpdFontData a cached scaled mask is keyed on, so
+  // they all drop the cache (see ScaledGlyphEntry).
+  void registerSdCardFont(int fontId, SdCardFont* font) {
+    sdCardFonts_[fontId] = font;
+    invalidateScaledGlyphCache();
+  }
+  void unregisterSdCardFont(int fontId) {
+    sdCardFonts_.erase(fontId);
+    invalidateScaledGlyphCache();
+  }
+  void clearSdCardFonts() {
+    sdCardFonts_.clear();
+    invalidateScaledGlyphCache();
+  }
   const std::map<int, SdCardFont*>& getSdCardFonts() const { return sdCardFonts_; }
   bool isSdCardFont(int fontId) const { return sdCardFonts_.count(fontId) > 0; }
 
@@ -502,6 +574,29 @@ class GfxRenderer {
   // Font helpers
   const uint8_t* getGlyphBitmap(const EpdFontData* fontData, const EpdGlyph* glyph) const;
 
+  // Scaled-glyph mask cache (see ScaledGlyphEntry). Public only because the glyph
+  // pipeline lives in free functions in GfxRenderer.cpp; treat as internal.
+  // find returns the cached mask for an exact key match, alloc reserves a zeroed
+  // mask of w*h bits for the caller to fill, or nullptr when the glyph is too
+  // large to cache or the arena could not be allocated.
+  const uint8_t* findScaledGlyphMask(const void* fontData, uint32_t cp, float scale, uint8_t sel, int w, int h) const;
+  uint8_t* allocScaledGlyphMask(const void* fontData, uint32_t cp, float scale, uint8_t sel, int w, int h) const;
+
+  // Drop every cached mask, keeping the arena. MUST run whenever a font is added
+  // or removed: entries are keyed by EpdFontData address, which a later font
+  // object could reuse.
+  void invalidateScaledGlyphCache() const {
+    scaledGlyphCount_ = 0;
+    scaledGlyphUsed_ = 0;
+  }
+  // Give the ~4 KB arena back. The cache re-allocates lazily if rendering resumes.
+  void releaseScaledGlyphCache() const {
+    scaledGlyphEntries_.reset();
+    scaledGlyphArena_.reset();
+    scaledGlyphOom_ = false;
+    invalidateScaledGlyphCache();
+  }
+
   // Low level functions
   uint8_t* getFrameBuffer() const;
   size_t getBufferSize() const;
@@ -514,6 +609,7 @@ class GfxRenderer {
   void releaseFrameBuffers() {
     display.releaseBuffers();
     frameBuffer = nullptr;
+    releaseScaledGlyphCache();
   }
 
   // Release both display buffers and install a caller-owned scratch buffer as
@@ -524,6 +620,7 @@ class GfxRenderer {
   bool releaseFrameBuffersWithScratch(uint8_t* scratch, size_t scratchSize) {
     if (!scratch || scratchSize < static_cast<size_t>(panelWidthBytes) * panelHeight) return false;
     display.releaseBuffers();
+    releaseScaledGlyphCache();
     memset(scratch, 0, scratchSize);
     frameBuffer = scratch;
     return true;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -101,11 +101,25 @@ std::optional<int> parsePrintedPageLabel(const std::string& label) {
 constexpr int PAGE_TURN_LABELS[] = {1, 1, 3, 6, 12};
 
 // Pre-render of the next page within the current chapter only runs when heap is healthy.
-// 56 KB, evidence-based (X3, 2026-06-11): normal foreground renders complete fine from
-// ~52 KB free, and post-render free heap sits at ~57-65 KB — the previous 64 KB floor
-// silently disabled Background A whenever steady free dipped to ~65 KB (e.g. right
-// after a cache rebuild), which also starved Background B behind it.
-constexpr uint32_t PRE_RENDER_MIN_FREE_HEAP_BYTES = 56 * 1024;
+// 44 KB, derived from what the pass actually consumes rather than from what happens to be
+// free — this floor was set the other way twice and was wrong both times:
+//   2026-06-11 (X3): 64 KB silently disabled Background A whenever steady free dipped to
+//     ~65 KB (e.g. right after a cache rebuild), which also starved Background B behind it.
+//     Lowered to 56 KB.
+//   2026-08-02 (X3): the scaled-glyph mask cache (~4.75 KB, see GfxRenderer) moved steady
+//     free down ~5 KB, so even the post-AA peak (~54.9 KB) fell under 56 KB and A stopped
+//     running for entire sessions — silently, which is why the skips below now log.
+// Measured 2026-08-02 (X3, prerender_begin/after_load/end snapshots, 4 consecutive pages):
+//   Page::deserialize      10504-10636 B  (the dominant cost, and the only one that had
+//                                          never been measured)
+//   prewarm buffers        -448..+1872 B  (net ~neutral: replaces the previous page's)
+//   deepest transient      peakTemp, up to 8467 B on this font, inside prewarm decompress
+//   => ~23 KB of headroom below the entry point, nothing retained afterwards (the Page dies
+//      with the pass; only framebuffer pixels survive).
+// 44 KB therefore troughs at ~21 KB worst case, above the ~16 KB the sliced section build
+// reserves, and leaves X3 (which enters at 53-55 KB) ~10 KB of margin instead of ~2. The
+// transient is also held under RenderLock, so no other reader work can allocate into the dip.
+constexpr uint32_t PRE_RENDER_MIN_FREE_HEAP_BYTES = 44 * 1024;
 
 // Background B (next-section pre-build) heap gates. Unlike the foreground indexing path,
 // B runs with the secondary framebuffer live (~52 KB less headroom). Refuse rather than
@@ -2380,25 +2394,44 @@ void EpubReaderActivity::renderPreRenderPass(const RenderLayout& layout) {
   const bool buildActive = section->hasActiveBuild();
   const int availablePages =
       buildActive ? static_cast<int>(section->activeBuildPageCount()) : static_cast<int>(section->pageCount);
+  // Both refusals below used to be silent, which cost a whole debugging session: an X3
+  // sitting just under the heap floor disabled Background A for every page of a run with
+  // nothing in the log to distinguish "declined" from "never scheduled". They log at DBG
+  // and fire at most once per requested pass, so they cannot spam.
   if (nextPage >= availablePages) {
+    LOG_DBG("ERS", "PreRender skipped: next=%d >= available=%d (buildActive=%d)", nextPage, availablePages,
+            buildActive ? 1 : 0);
     return;
   }
-  if (esp_get_free_heap_size() < PRE_RENDER_MIN_FREE_HEAP_BYTES) {
+  const uint32_t freeHeap = esp_get_free_heap_size();
+  if (freeHeap < PRE_RENDER_MIN_FREE_HEAP_BYTES) {
+    LOG_DBG("ERS", "PreRender skipped: free=%lu < floor=%lu", static_cast<unsigned long>(freeHeap),
+            static_cast<unsigned long>(PRE_RENDER_MIN_FREE_HEAP_BYTES));
     return;
   }
 #if DEBUG_BACKGROUND_WORK
   bgCounters_.aRuns++;
 #endif
+  // Heap telemetry for the floor above. The three snapshots bracket the only two consumers:
+  //   begin -> after_load  = Page::deserialize (elements + TextBlock arenas), the one cost
+  //                          the floor was never set from any measurement of;
+  //   after_load -> end    = the prewarm buffers, whose own sizes the FDC "[prewarm] mem:"
+  //                          line already reports (pageBuf / pageGlyphs / peakTemp).
+  // The Page dies with `p` at the end of this function, so `end` also shows what is retained
+  // (nothing but the pixels in the framebuffer).
+  logReaderMemSnapshot("prerender_begin");
   const int savedPage = section->currentPage;
   section->currentPage = nextPage;
   auto p = buildActive ? section->loadPageFromActiveBuild(static_cast<uint16_t>(nextPage))
                        : section->loadPageFromSectionFile();
   section->currentPage = savedPage;
+  logReaderMemSnapshot("prerender_after_load");
   if (p && !p->hasImages()) {
     const unsigned long preRenderStart = millis();
     section->currentPage = nextPage;
     renderPageContentOnly(*p, layout.marginTop, layout.marginRight, layout.marginBottom, layout.marginLeft);
     section->currentPage = savedPage;
+    logReaderMemSnapshot("prerender_end");
     const unsigned long preRenderDuration = millis() - preRenderStart;
     preRenderedPage = {true, currentSpineIndex, nextPage, preRenderDuration, millis()};
 #if DEBUG_BACKGROUND_WORK
@@ -3102,6 +3135,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   // refresh / RED-RAM baseline only reintroduces ghosting.
   if (renderer.isX3() && pendingGrayscale_.active && pendingPreRender && !usePreRenderedBuffer &&
       classifyRenderPass() == RenderPass::PreRender) {
+    // Logged so the pre-render chain has no silent link left: a deferred pass that is
+    // held here and then never re-kicked is otherwise indistinguishable from one that was
+    // never armed. Fires at most once or twice per page, X3 only.
+    LOG_DBG("ERS", "PreRender deferred: AA owed");
     return;
   }
 


### PR DESCRIPTION
## The regression, and when it started

Any book whose stylesheet sets a `font-size` on body text renders **~6x slower** than one that
doesn't. `TextBlock::render()` routes every word with `scale != 1.0f` to `GfxRenderer`'s
`renderCharAtScale()`, which resamples per destination pixel and emits each through `drawPixel()`
— a `rotateCoordinates()` switch plus a bounds check per pixel — instead of the masked 8-pixel-chunk
blitter unscaled text uses.

This has been live since **915bb6c2 "Phase 1 + 2 (prep + cssgaps)" (2026-06-01)**, which introduced
`renderCharAtScale`, `drawTextScaled` and `fontSizeMultiplier` together: from that commit a
paragraph-level `font-size` began scaling body text, so every word of such a book took the per-pixel
path. The original was worse still — a soft-float division per pixel on an FPU-less C3; the later
fixed-point rewrite improved the constant but kept the per-pixel emit. **c80603ce "Add support for
different font sizes" (2026-07-06)** widened it to per-word/span sizes.

So: roughly two months, and it affects most commercially produced EPUBs. The test book
(*A Scandalous Deception*) carries `font-size: 0.92em` on its body paragraphs.

It was never visible as a regression because it presents as "this device is slow", not as "this book
is slow" — and comparing two books, or two panels, silently compares two different code paths. An
earlier round of this investigation wrongly concluded X3 hardware was 11x slower than X4 for exactly
that reason.

## What changed

**1. `perf(gfx)`: cache resampled masks for scaled glyphs**

Uncached, the resample runs once per glyph *occurrence*: ~500 times a page against ~40 distinct
glyphs. Now cached per (font, codepoint, scale, selector), with `renderGlyphFastBW()` drawing every
occurrence. The resampling maths moved into `emitScaledGlyphPixels()`, a template with two sinks
(cache builder, uncached fallback) so the two paths cannot drift.

Keyed by `EpdFontData`, **not** by `EpdGlyph` address — SD-card fonts rebuild their glyph array per
page and serve overflow codepoints from an 8-entry ring, so glyph addresses get recycled. Dropped on
any font register/remove.

Budget **~4.75 KB** (80 x 16B table + 3.5 KB arena), allocated lazily on the first scaled glyph and
released with the framebuffers. Bump allocator, wholesale reset when full: no per-glyph allocation,
nothing to fragment, and an overflowing page degrades toward the uncached path rather than growing.
Static RAM unchanged; an unscaled book never allocates it.

**2. `fix(reader)`: derive the pre-render heap floor from measured cost**

`PRE_RENDER_MIN_FREE_HEAP_BYTES` had been set from "what happens to be free" twice and was wrong
both times — and the cache's 4.75 KB tipped X3 under the 56 KB floor, silently disabling
Background A for whole sessions. Every refusal returned without logging, so a declined pre-render
and one never armed looked identical.

Three paths now report at DBG, and three heap snapshots bracket the pass's consumers. Measured over
four consecutive X3 pages: `Page::deserialize` **10504-10636 B** (dominant, never previously
measured), prewarm net **-448..+1872 B**, deepest transient `peakTemp` **<= 8467 B** — so ~23 KB of
headroom needed, nothing retained. Floor set to **44 KB**: troughs at ~21 KB, above the ~16 KB the
sliced section build reserves, and leaves X3 ~10 KB of margin instead of ~2.

**3. `fix(font)`: latch fallback OOM instead of retrying it per glyph**

`getBitmap()`'s fallback mallocs a whole group transiently, per glyph occurrence, and the heap
cannot recover mid-pass. Measured during a render racing a background build: **538 failed mallocs
and 538 identical ERR lines in 40 ms**, 147 ms of getBitmap time against ~1 ms, 129 ms page render
against 43. Now latches the smallest failed size (smaller groups still attempted), scoped to one
render phase via `Stats`/`resetStats()` so it can never wedge a session, and collapses to one line
plus a total. Behaviour is unchanged — those glyphs rendered nothing before either.

## Measured results

Same book, same chapter, same device, before vs after:

| | X3 before | X3 after | X4 before | X4 after |
|---|---|---|---|---|
| BW render | 480-546 ms | **83-106 ms** | 303 ms | **105 ms** |
| AA planes (2) | 847-957 ms | **187-213 ms** | 556 ms | **68 ms** |
| pre-render | 480-556 ms | **50-99 ms** | 430-500 ms | **50-63 ms** |
| page render | 935-1000 ms | **545 ms** | 1244 ms | **714 ms** |

Per glyph the rasteriser goes from ~0.88 ms to ~0.16 ms, matching what the same page costs with
embedded styles switched off — i.e. scaled text now renders at unscaled speed, without changing
anyone's layout (turning styles off re-paginates 52 -> 58 pages; this doesn't).

Both panels are now **waveform-bound**. An X3 page turn is ~436 ms of which 385 ms is the panel
waveform; Background A hits on every turn.

## Testing

Built clean (`pio run -e default`); flashed and exercised on both X3 and X4, portrait and landscape,
with logs at each step. No host-test coverage exists for this path — `test/` stubs out
`GfxRenderer.h` — so correctness rests on the single-resampler structure plus on-device comparison.

## Known follow-ups (not in this PR)

- The mask cache still resets ~1x/page: a page needs 45-58 distinct renditions across three font
  groups and consecutive pages accumulate ~80-100, so the cross-page union exceeds the 80-entry
  table. Second-chance compaction (keep entries touched since the last compaction, compact the
  arena, drop the rest) would recover ~20-50 ms/pass at no extra memory.
- Recovering a *correct* render under heap pressure, rather than a fast degraded one, needs a
  per-glyph fallback allocation instead of a whole-group one.
