### PR TITLE
feat: Establish baseline font size for better size matching

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -30,7 +30,8 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 63;  // bumped: drop-cap float zones + ink-metric cap placement
+constexpr uint8_t SECTION_FILE_VERSION = 64;  // bumped: main-text font-size normalization
+                                              // v63: drop-cap float zones + ink-metric cap placement
                                               // (62 was consumed by an earlier iteration of this feature)
                                               // v61: TextBlock no longer serializes the block-spacing
                                               // fields (margins/padding/indent + their defined flags);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -326,6 +326,75 @@ void ChapterHtmlSlimParser::applySupSubDefaultSize(StyleStackEntry& entry) {
   }
 }
 
+namespace {
+bool isRootFontSizeElement(const char* tagName) { return strcmp(tagName, "html") == 0 || strcmp(tagName, "body") == 0; }
+
+float saneFontSizeBaseline(float value) {
+  if (value < 0.25f || value > 4.0f) return 1.0f;
+  return value;
+}
+}  // namespace
+
+void ChapterHtmlSlimParser::initializeFontSizeBaseline() {
+  if (!cssParser) return;
+
+  if (!hasRootFontSizeBaseline_) {
+    const CssStyle bodyStyle = cssParser->resolveStyle("body", "");
+    if (bodyStyle.hasFontSizeMultiplier() && bodyStyle.fontSizeMultiplier != 1.0f) {
+      rootFontSizeBaseline_ = saneFontSizeBaseline(bodyStyle.fontSizeMultiplier);
+      hasRootFontSizeBaseline_ = rootFontSizeBaseline_ != 1.0f;
+    } else {
+      const CssStyle htmlStyle = cssParser->resolveStyle("html", "");
+      if (htmlStyle.hasFontSizeMultiplier() && htmlStyle.fontSizeMultiplier != 1.0f) {
+        rootFontSizeBaseline_ = saneFontSizeBaseline(htmlStyle.fontSizeMultiplier);
+        hasRootFontSizeBaseline_ = rootFontSizeBaseline_ != 1.0f;
+      }
+    }
+  }
+
+  if (!hasMainTextFontSizeBaseline_) {
+    const CssStyle paragraphStyle = cssParser->resolveStyle("p", "");
+    if (paragraphStyle.hasFontSizeMultiplier() && paragraphStyle.fontSizeMultiplier != 1.0f) {
+      mainTextFontSizeBaseline_ = saneFontSizeBaseline(paragraphStyle.fontSizeMultiplier);
+      hasMainTextFontSizeBaseline_ = mainTextFontSizeBaseline_ != 1.0f;
+      return;
+    }
+
+    const CssStyle listStyle = cssParser->resolveStyle("li", "");
+    if (listStyle.hasFontSizeMultiplier() && listStyle.fontSizeMultiplier != 1.0f) {
+      mainTextFontSizeBaseline_ = saneFontSizeBaseline(listStyle.fontSizeMultiplier);
+      hasMainTextFontSizeBaseline_ = mainTextFontSizeBaseline_ != 1.0f;
+    }
+  }
+}
+
+void ChapterHtmlSlimParser::observeFontSizeBaseline(const char* tagName, const CssStyle& cssStyle) {
+  if (!cssStyle.hasFontSizeMultiplier()) return;
+
+  // Only the root context (html/body, including class/inline sizing such as the
+  // Calibre `body.calibreN { font-size: … }` wrapper) is observed live. The
+  // main-text baseline stays tag-level (see initializeFontSizeBaseline): a
+  // class-styled paragraph like a decorative opener is indistinguishable here
+  // from ordinary prose, so treating the first sized <p> as the baseline would
+  // wrongly shrink/grow the real body text.
+  if (!hasRootFontSizeBaseline_ && isRootFontSizeElement(tagName) && cssStyle.fontSizeMultiplier != 1.0f) {
+    rootFontSizeBaseline_ = saneFontSizeBaseline(cssStyle.fontSizeMultiplier);
+    hasRootFontSizeBaseline_ = rootFontSizeBaseline_ != 1.0f;
+  }
+}
+
+CssStyle ChapterHtmlSlimParser::normalizeFontSizeForElement(const char* tagName, const CssStyle& cssStyle) const {
+  if (!cssStyle.hasFontSizeMultiplier()) return cssStyle;
+
+  CssStyle normalized = cssStyle;
+  if (hasRootFontSizeBaseline_ && isRootFontSizeElement(tagName)) {
+    normalized.fontSizeMultiplier = 1.0f;
+  }
+  if (hasMainTextFontSizeBaseline_ && isHeaderOrBlock(tagName) && strcmp(tagName, "br") != 0) {
+    normalized.fontSizeMultiplier /= mainTextFontSizeBaseline_;
+  }
+  return normalized;
+}
 bool ChapterHtmlSlimParser::ensureHeapForTextLayout(const char* phase) {
   if (streamFailed) {
     return false;
@@ -941,6 +1010,9 @@ void ChapterHtmlSlimParser::startElement(void* userData, const char* name, const
     self->depth += 1;
     return;
   }
+
+  self->observeFontSizeBaseline(name, cssStyle);
+  cssStyle = self->normalizeFontSizeForElement(name, cssStyle);
 
   // Buffered table rendering: accumulate cells in memory, emit as PageTableFragment on </table>.
   if (strcmp(name, "table") == 0) {
@@ -2375,6 +2447,8 @@ void ChapterHtmlSlimParser::endElement(void* userData, const char* name) {
 ChapterHtmlSlimParser::~ChapterHtmlSlimParser() = default;
 
 bool ChapterHtmlSlimParser::setup(const size_t totalInflatedSize) {
+  initializeFontSizeBaseline();
+
   auto paragraphAlignmentBlockStyle = BlockStyle();
   paragraphAlignmentBlockStyle.textAlignDefined = true;
   // Resolve None sentinel to Justify for initial block (no CSS context yet)

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -117,6 +117,15 @@ class ChapterHtmlSlimParser final : public Print {
   // exactly the FontDecompressor's four page slots. The first block to resolve off-body
   // claims the slot; blocks that would need a different font keep the scale fallback.
   int32_t auxFontId_ = 0;
+  // EPUBs often set their running prose to a nominal CSS size such as 10pt,
+  // 87%, or 0.875em. The reader's selected font size is our body size. Root
+  // (html/body) sizes are normalized as inherited context; the main-text
+  // baseline comes from tag-level paragraph/list rules so prose maps to 1.0
+  // and headings/notes remain proportional to that prose size.
+  float rootFontSizeBaseline_ = 1.0f;
+  bool hasRootFontSizeBaseline_ = false;
+  float mainTextFontSizeBaseline_ = 1.0f;
+  bool hasMainTextFontSizeBaseline_ = false;
   float lineCompression;
   bool extraParagraphSpacing;
   uint8_t paragraphAlignment;
@@ -285,6 +294,9 @@ class ChapterHtmlSlimParser final : public Print {
   // Apply kSupSubDefaultSizePct when the entry resolves to sup/sub. Call BEFORE
   // applyCssFontSizeToEntry so publisher CSS (e.g. `.sup { font-size: 0.7em }`) wins.
   static void applySupSubDefaultSize(StyleStackEntry& entry);
+  void initializeFontSizeBaseline();
+  void observeFontSizeBaseline(const char* tagName, const CssStyle& cssStyle);
+  CssStyle normalizeFontSizeForElement(const char* tagName, const CssStyle& cssStyle) const;
   bool ensureHeapForTextLayout(const char* phase);
   void startNewTextBlock(const BlockStyle& blockStyle);
   bool flushPartWordBuffer();


### PR DESCRIPTION
# Objective
The EPUB's main body-text size is normalized to the reader's selected size, while headings/footnotes stay proportional.

- Root (html/body) sizes are forced to 1.0 so they don't shrink/grow inherited prose. This correctly handles the common Calibre ``body.calibreN { font-size: … }`` wrapper pattern via the live observeFontSizeBaseline path.
- Block/heading sizes are divided by the main-text baseline, so ``h1 { 1.5em }`` over ``p { 0.8 }`` prose stays at the authored 1.875 ratio to body text.

# Known limitation (by design)

Prose sized only via a class on every paragraph (no body/html/tag-level rule) is intentionally not normalized, since a single styled paragraph can't be distinguished from a decorative one in this single-pass streaming parser. The body/wrapper and tag-level paths cover the common real-world cases.