### PR TITLE
fix: Trim heap before WiFi init, not just before TLS

### DIFF
--- a/src/activities/NetworkMemoryTrim.cpp
+++ b/src/activities/NetworkMemoryTrim.cpp
@@ -1,0 +1,19 @@
+#include "NetworkMemoryTrim.h"
+
+#include <FontCacheManager.h>
+#include <GfxRenderer.h>
+#include <Logging.h>
+
+void trimMemoryForNetworkSession(const GfxRenderer& renderer, const char* logTag) {
+  if (auto* cache = renderer.getFontCacheManager()) {
+    cache->clearCache();
+  }
+  if (renderer.hasSecondaryBuffer()) {
+    // Seed the controller baseline while frameBufferActive is still valid.
+    if (!renderer.isX3()) renderer.syncRedRamFromFrameBuffer();
+    if (renderer.releaseSecondaryBuffer()) {
+      LOG_DBG(logTag, "Released secondary framebuffer before network session (~52 KB contiguous)");
+      renderer.setSingleBufferFastDiff(true);
+    }
+  }
+}

--- a/src/activities/NetworkMemoryTrim.h
+++ b/src/activities/NetworkMemoryTrim.h
@@ -1,0 +1,37 @@
+#pragma once
+
+class GfxRenderer;
+
+// Frees the ~52 KB secondary framebuffer and the font cache before a network
+// session, so both esp_wifi_init and any later TLS handshake can obtain the
+// large contiguous blocks they need on a constrained heap.
+//
+// CALL THIS BEFORE THE RADIO COMES UP — not just before TLS. Association is
+// already allocation-heavy: bringing up the WiFi stack needs its own tens of KB
+// for RX/TX buffers and the WPA supplicant. Two observed failure modes when the
+// ~52 KB buffer is still resident: phy_init aborts outright with "failed to
+// allocate memory for RF calibration data", or esp_wifi allocations return null
+// and association fails silently, surfacing as a plain connect timeout with no
+// association event. This matters most for
+// activities launched from SettingsActivity, which stays on the activity stack
+// below its children with four per-category SettingInfo vectors (~78 entries,
+// each holding two nested vectors) resident and interleaved across the heap.
+// Activities launched from Home do not carry that and have more headroom.
+//
+// Only the secondary buffer is released; the primary write target stays so the
+// caller can keep rendering status and result screens. That is the difference
+// from the web-server session, which releases both because it never draws
+// again. Implements Pattern 1a
+// from docs/secondary-buffer-management.md: RED RAM is seeded while
+// frameBufferActive is still valid, so setSingleBufferFastDiff(true) diffs
+// against a valid baseline rather than stale controller content (X4; no-op on
+// X3).
+//
+// There is no reallocSecondaryBuffer() pairing. Every current caller
+// silentRestart()s on exit, and the reboot rebuilds clean state. If you add a
+// caller that keeps running afterwards, follow the full Scenario 1 procedure in
+// the doc instead of using this helper.
+//
+// Idempotent: safe to call again before TLS to drop font cache that status
+// screens repopulated since the first call.
+void trimMemoryForNetworkSession(const GfxRenderer& renderer, const char* logTag);

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -2,7 +2,6 @@
 
 #include <ArduinoJson.h>
 #include <Epub.h>
-#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
@@ -22,6 +21,7 @@
 #include "MappedInputManager.h"
 #include "OpdsFormatLabel.h"
 #include "SilentRestart.h"
+#include "activities/NetworkMemoryTrim.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/KeyboardEntryActivity.h"
 #include "components/UITheme.h"
@@ -33,22 +33,6 @@
 
 namespace {
 constexpr int PAGE_ITEMS = 23;
-
-// Mirrors KOReaderSyncActivity::trimMemoryBeforeTls: frees the ~52 KB secondary
-// framebuffer and clears the font cache right before the first HTTPS request.
-// TLS needs a large contiguous block (~36 KB); the secondary buffer is a
-// resident allocation that can prevent the allocator from finding it even when
-// total free heap looks sufficient. Safe here because onExit() always silentRestart()s,
-// so the secondary buffer never needs to be reallocated.
-void trimMemoryBeforeTls(const GfxRenderer& renderer) {
-  if (auto* cache = renderer.getFontCacheManager()) {
-    cache->clearCache();
-  }
-  if (renderer.hasSecondaryBuffer() && renderer.releaseSecondaryBuffer()) {
-    LOG_DBG("OPDS", "Released secondary framebuffer before TLS (~52 KB contiguous)");
-    renderer.setSingleBufferFastDiff(true);
-  }
-}
 
 // Hard ceiling on entries held from a single feed. Each entry costs 4 bytes in
 // the in-RAM entryOffsets index; the bodies live on the SD cache file. Well-behaved
@@ -631,7 +615,7 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
   // Trim memory once per session before the first TLS connection, regardless of
   // whether we arrived here via the WiFi-first path or directly from a cache hit.
   if (!memoryTrimmed) {
-    trimMemoryBeforeTls(renderer);
+    trimMemoryForNetworkSession(renderer, "OPDS");
     memoryTrimmed = true;
   }
 

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -1,6 +1,5 @@
 #include "KOReaderSyncActivity.h"
 
-#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalClock.h>
 #include <I18n.h>
@@ -15,6 +14,7 @@
 #include "KOReaderDocumentId.h"
 #include "MappedInputManager.h"
 #include "SilentRestart.h"
+#include "activities/NetworkMemoryTrim.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -28,35 +28,6 @@ void logSyncMemSnapshot(const char* stage) {
   const uint32_t freeHeap = esp_get_free_heap_size();
   const uint32_t contigHeap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
   LOG_DBG("KOSync", "Sync mem[%s]: free=%lu contig=%lu", stage, freeHeap, contigHeap);
-}
-
-// Frees renderer-owned caches inside the standalone sync activity right before
-// network work. The reader activity is already gone by this point, but sync UI
-// rendering (status popups, compare screen, result screen) can repopulate font
-// caches and chip away at the largest free block needed for TLS.
-void trimMemoryBeforeTls(const GfxRenderer& renderer) {
-  if (auto* cacheManager = renderer.getFontCacheManager()) {
-    cacheManager->clearCache();
-    cacheManager->resetStats();
-    LOG_DBG("KOSync", "Cleared font cache before TLS");
-  }
-  // Release the ~52 KB secondary (previous-frame) framebuffer for the duration of the sync.
-  // TLS needs a large *contiguous* block (~36 KB); the secondary buffer is a big resident
-  // allocation that fragments the heap so the largest free block can't reach that threshold
-  // even when total free looks sufficient. Sync UI (status popups) renders fine on the primary
-  // buffer alone, and the device silently reboots after a sync (see resumeReader -> silentRestart),
-  // so it never needs to be reallocated in-place — the reboot rebuilds clean state.
-  if (renderer.hasSecondaryBuffer()) {
-    if (renderer.releaseSecondaryBuffer()) {
-      LOG_DBG("KOSync", "Released secondary framebuffer before TLS (~52 KB contiguous)");
-      // The controller still holds the last displayed frame in RED RAM, and the
-      // sync UI only ever issues plain BW full-frame redraws, so fast
-      // differential refresh can continue against that baseline instead of
-      // downgrading every status update to a half/full waveform (X4 only; X3
-      // fast differential is unaffected by the release).
-      renderer.setSingleBufferFastDiff(true);
-    }
-  }
 }
 
 bool shouldSyncNtpNow() {
@@ -105,7 +76,7 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
   requestUpdate();
 
   logSyncMemSnapshot("before_performSync");
-  trimMemoryBeforeTls(renderer);
+  trimMemoryForNetworkSession(renderer, "KOSync");
   logSyncMemSnapshot("after_trim_before_performSync");
 
   performSync();
@@ -421,7 +392,7 @@ void KOReaderSyncActivity::performUpload() {
 
   // Sync UI rendering can repopulate glyph caches after the initial GET / compare
   // phase, so trim again right before the upload request.
-  trimMemoryBeforeTls(renderer);
+  trimMemoryForNetworkSession(renderer, "KOSync");
   logSyncMemSnapshot("after_trim_before_updateProgress");
 
   // Capture upload-phase memory separately from fetch phase to diagnose failures

--- a/src/activities/settings/DetectTimezoneActivity.cpp
+++ b/src/activities/settings/DetectTimezoneActivity.cpp
@@ -1,7 +1,6 @@
 #include "DetectTimezoneActivity.h"
 
 #include <ArduinoJson.h>
-#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalClock.h>
 #include <I18n.h>
@@ -13,6 +12,7 @@
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "SilentRestart.h"
+#include "activities/NetworkMemoryTrim.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -207,6 +207,12 @@ bool detectTimezoneSetting(uint8_t& outSetting, std::string& outIana, bool& outD
 void DetectTimezoneActivity::onEnter() {
   Activity::onEnter();
 
+  // Free the heap the WiFi stack needs before it is brought up, not after -
+  // association itself is the allocation-heavy step, well ahead of TLS. Matters
+  // most here because SettingsActivity is still on the stack below us with its
+  // per-category SettingInfo vectors resident, fragmenting the heap.
+  trimMemoryForNetworkSession(renderer, "CLK");
+
   if (WiFi.status() == WL_CONNECTED) {
     onWifiSelectionComplete(true);
     return;
@@ -250,13 +256,9 @@ void DetectTimezoneActivity::onWifiSelectionCancelled() { finish(); }
 
 void DetectTimezoneActivity::performDetect() {
   wifiWasUsed_ = true;
-  if (auto* cache = renderer.getFontCacheManager()) {
-    cache->clearCache();
-  }
-  if (renderer.hasSecondaryBuffer() && renderer.releaseSecondaryBuffer()) {
-    LOG_DBG("CLK", "Released secondary framebuffer before TLS (~52 KB contiguous)");
-    renderer.setSingleBufferFastDiff(true);
-  }
+  // Re-trim: the status screens rendered since onEnter can have repopulated the
+  // font cache. Idempotent - the secondary buffer is already gone by now.
+  trimMemoryForNetworkSession(renderer, "CLK");
 
   uint8_t detected = SETTINGS.timeZone;
   detectedTimezone.clear();

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -1,7 +1,6 @@
 #include "FontDownloadActivity.h"
 
 #include <ArduinoJson.h>
-#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
@@ -14,26 +13,12 @@
 #include "MappedInputManager.h"
 #include "SdCardFontGlobals.h"
 #include "SilentRestart.h"
+#include "activities/NetworkMemoryTrim.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/ConfirmationActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
-
-namespace {
-// Release large allocations before TLS so the wolfSSL handshake can get
-// contiguous buffers on constrained heaps. See OtaUpdateActivity for the
-// reference pattern.
-void trimMemoryBeforeTls(const GfxRenderer& renderer) {
-  if (auto* cache = renderer.getFontCacheManager()) {
-    cache->clearCache();
-  }
-  if (renderer.hasSecondaryBuffer() && renderer.releaseSecondaryBuffer()) {
-    LOG_DBG("FONT", "Released secondary framebuffer before TLS (~52 KB contiguous)");
-    renderer.setSingleBufferFastDiff(true);
-  }
-}
-}  // namespace
 
 FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
     : Activity("FontDownload", renderer, mappedInput), fontInstaller_(sdFontSystem.registry()) {}
@@ -42,7 +27,19 @@ FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputMan
 
 void FontDownloadActivity::onEnter() {
   Activity::onEnter();
-  WiFi.mode(WIFI_STA);
+
+  // Free the heap the WiFi stack needs before it is brought up, not after -
+  // association itself is the allocation-heavy step, well ahead of TLS. Matters
+  // most here because SettingsActivity is still on the stack below us with its
+  // per-category SettingInfo vectors resident, fragmenting the heap.
+  // WifiSelectionActivity sets WIFI_STA itself, so no radio work happens here.
+  trimMemoryForNetworkSession(renderer, "FONT");
+
+  if (WiFi.status() == WL_CONNECTED) {
+    onWifiSelectionComplete(true);
+    return;
+  }
+
   startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
                          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
 }
@@ -74,7 +71,9 @@ void FontDownloadActivity::onWifiSelectionComplete(const bool success) {
   }
   requestUpdateAndWait();
 
-  trimMemoryBeforeTls(renderer);
+  // Re-trim: the status screens rendered since onEnter can have repopulated the
+  // font cache. Idempotent - the secondary buffer is already gone by now.
+  trimMemoryForNetworkSession(renderer, "FONT");
 
   if (!fetchAndParseManifest()) {
     RenderLock lock(*this);

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -1,6 +1,5 @@
 #include "KOReaderAuthActivity.h"
 
-#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <Logging.h>
@@ -10,39 +9,10 @@
 #include "KOReaderSyncClient.h"
 #include "MappedInputManager.h"
 #include "SilentRestart.h"
+#include "activities/NetworkMemoryTrim.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-
-namespace {
-// Release the secondary (previous-frame) framebuffer + font cache before the
-// network session. This must happen BEFORE WiFi association, not just before
-// TLS: bringing up the WiFi stack needs its own tens of KB for RX/TX buffers and
-// the WPA supplicant, and with the ~52 KB buffer still resident association
-// fails silently (esp_wifi allocations return null, surfacing as a plain
-// connect timeout with no association event).
-//
-// Only the secondary buffer goes — the primary write buffer stays so the
-// activity can keep rendering status/success/failure feedback. That is the
-// difference from the web-server session, which releases both because it never
-// draws again. Per docs/secondary-buffer-management.md Scenario 1 / Pattern 1a,
-// RED RAM is seeded first so setSingleBufferFastDiff(true) diffs against a valid
-// baseline instead of stale controller content.
-//
-// No reallocSecondaryBuffer() pairing: every exit path silently restarts back
-// into KOReader settings (see onExit), and the reboot rebuilds clean state.
-void trimMemoryForNetworkSession(const GfxRenderer& renderer) {
-  if (auto* cache = renderer.getFontCacheManager()) cache->clearCache();
-  if (renderer.hasSecondaryBuffer()) {
-    // Seed the controller baseline while frameBufferActive is still valid.
-    if (!renderer.isX3()) renderer.syncRedRamFromFrameBuffer();
-    if (renderer.releaseSecondaryBuffer()) {
-      LOG_DBG("KOSync", "Released secondary framebuffer before network session (~52 KB contiguous)");
-      renderer.setSingleBufferFastDiff(true);
-    }
-  }
-}
-}  // namespace
 
 void KOReaderAuthActivity::onWifiSelectionComplete(const bool success) {
   if (!success) {
@@ -124,7 +94,7 @@ void KOReaderAuthActivity::onEnter() {
 
   // Free the heap the WiFi stack needs before it is brought up, not after —
   // association itself is the allocation-heavy step, well ahead of TLS.
-  trimMemoryForNetworkSession(renderer);
+  trimMemoryForNetworkSession(renderer, "KOSync");
 
   // Check if already connected
   if (WiFi.status() == WL_CONNECTED) {

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -1,31 +1,16 @@
 #include "OtaUpdateActivity.h"
 
-#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <WiFi.h>
 
 #include "MappedInputManager.h"
 #include "SilentRestart.h"
+#include "activities/NetworkMemoryTrim.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "network/OtaUpdater.h"
-
-namespace {
-// Ported from crosspoint-reader/crosspoint-reader: release large allocations
-// before TLS so the wolfSSL handshake can get contiguous buffers on
-// constrained heaps.
-void trimMemoryBeforeTls(const GfxRenderer& renderer) {
-  if (auto* cache = renderer.getFontCacheManager()) {
-    cache->clearCache();
-  }
-  if (renderer.hasSecondaryBuffer() && renderer.releaseSecondaryBuffer()) {
-    LOG_DBG("OTA", "Released secondary framebuffer before TLS (~52 KB contiguous)");
-    renderer.setSingleBufferFastDiff(true);
-  }
-}
-}  // namespace
 
 void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
   if (!success) {
@@ -42,7 +27,9 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
   }
   requestUpdateAndWait();
 
-  trimMemoryBeforeTls(renderer);
+  // Re-trim: the status screens rendered since onEnter can have repopulated the
+  // font cache. Idempotent - the secondary buffer is already gone by now.
+  trimMemoryForNetworkSession(renderer, "OTA");
 
   const auto res = updater.checkForUpdate();
   if (res != OtaUpdater::OK) {
@@ -74,9 +61,17 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
 void OtaUpdateActivity::onEnter() {
   Activity::onEnter();
 
-  // Turn on WiFi immediately
-  LOG_DBG("OTA", "Turning on WiFi...");
-  WiFi.mode(WIFI_STA);
+  // Free the heap the WiFi stack needs before it is brought up, not after -
+  // association itself is the allocation-heavy step, well ahead of TLS. Matters
+  // most here because SettingsActivity is still on the stack below us with its
+  // per-category SettingInfo vectors resident, fragmenting the heap.
+  // WifiSelectionActivity sets WIFI_STA itself, so no radio work happens here.
+  trimMemoryForNetworkSession(renderer, "OTA");
+
+  if (WiFi.status() == WL_CONNECTED) {
+    onWifiSelectionComplete(true);
+    return;
+  }
 
   // Launch WiFi selection subactivity
   LOG_DBG("OTA", "Launching WifiSelectionActivity...");

--- a/src/activities/weather/WeatherActivity.cpp
+++ b/src/activities/weather/WeatherActivity.cpp
@@ -1,6 +1,5 @@
 #include "WeatherActivity.h"
 
-#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <Logging.h>
@@ -17,25 +16,12 @@
 #include "MappedInputManager.h"
 #include "SilentRestart.h"
 #include "WeatherSettingsActivity.h"
+#include "activities/NetworkMemoryTrim.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 
 namespace {
-// Frees the ~52 KB secondary framebuffer and clears the font cache before the
-// first HTTPS request. TLS needs a large contiguous block (~36 KB); the
-// secondary buffer is a resident allocation that can block it even when total
-// free heap looks sufficient. Safe because onExit() always silentRestart()s.
-void trimMemoryBeforeTls(const GfxRenderer& renderer) {
-  if (auto* cache = renderer.getFontCacheManager()) {
-    cache->clearCache();
-  }
-  if (renderer.hasSecondaryBuffer() && renderer.releaseSecondaryBuffer()) {
-    LOG_DBG("WEA", "Released secondary framebuffer before TLS (~52 KB contiguous)");
-    renderer.setSingleBufferFastDiff(true);
-  }
-}
-
 inline bool getBitmapBit(const uint8_t* bitmap, const int size, const int x, const int y) {
   const int rowBytes = size / 8;
   const int idx = y * rowBytes + (x / 8);
@@ -336,7 +322,7 @@ void WeatherActivity::fetchWeather() {
     return;
   }
 
-  trimMemoryBeforeTls(renderer);
+  trimMemoryForNetworkSession(renderer, "WEA");
   LOG_DBG("WEA", "fetchWeather[3] WeatherClient::getWeather before");
   weatherData = WeatherClient::getWeather(WEATHER_SETTINGS, true);
   LOG_DBG("WEA", "fetchWeather[4] WeatherClient::getWeather after valid=%d", weatherData.valid ? 1 : 0);


### PR DESCRIPTION
## Problem

OTA update crashed on entry when reached via Settings -> System -> Check for updates:

```
[51486] [DBG] [OTA] Turning on WiFi...
E (56100) phy_init: failed to allocate memory for RF calibration data
abort() was called at PC 0x42163f71 on core 0
```

`trimMemoryBeforeTls()` — which frees the ~52 KB secondary framebuffer and the font
cache — ran in `onWifiSelectionComplete()`, i.e. **after** `esp_wifi_init` had already
run. Bringing up the radio is itself allocation-heavy (RX/TX buffers, WPA supplicant,
PHY/RF calibration), well ahead of any TLS handshake, so calibration had nothing to
allocate from. Free heap read ~53 KB at the crash, but largest contiguous was ~28 KB.

## Why only some activities were affected

`SettingsActivity::onEnter()` builds four per-category `SettingInfo` vectors (~78
reserved entries, each holding two nested `std::vector`s, plus a `std::string` per
discovered SD font family). `startActivityForResult` **pushes** rather than destroys,
so all of that stays resident and interleaved beneath the child activity.

That cleanly separates the two groups:

| Launched from | Activities | Status |
|---|---|---|
| SettingsActivity | OTA, font download, timezone detect | crashed / at risk |
| Home | weather, web server | fine — never carry the settings vectors |

Weather and the web server were surviving the same late trim on headroom, not by design.

## Changes

**Move the trim into `onEnter`, before the radio comes up**, for the Settings-launched
activities, following the existing `KOReaderAuthActivity` pattern (which already did this
correctly and is unchanged apart from the helper call).

`OtaUpdateActivity` and `FontDownloadActivity` also dropped their own
`WiFi.mode(WIFI_STA)` calls — `WifiSelectionActivity::startWifiScan()` sets the mode
itself, so `onEnter` no longer touches the radio at all. Both gained the
already-connected short-circuit.

**Consolidate seven near-duplicate copies** of the helper into
`activities/NetworkMemoryTrim.{h,cpp}`. The copies had drifted — weather and OPDS were
missing the `syncRedRamFromFrameBuffer()` seed that `setSingleBufferFastDiff(true)`
requires, so on X4 they were fast-diffing against a stale controller baseline. See
Pattern 1a in `docs/secondary-buffer-management.md`. Routing them through the shared
helper fixes that as a side effect.

`KOReaderSyncActivity`s copy also called `resetStats()`; that is diagnostic counters
only, no heap effect, so dropping it is behaviour-neutral.

## Deliberately unchanged

- **CrossPointWebServerActivity** releases *both* buffers because it never draws again
  (Scenario 2, not Pattern 1a). It still has an unguarded `WiFi.mode()`, but launches
  from Home and is confirmed working.
- **CalibreConnectActivity** / **SerialTransferActivity** drop the secondary buffer plus
  the SD reader font — a superset with its own rationale.

#