### PR TITLE
fix: load Settings page data sequentially and yield during chunk writes

### DIFF
--- a/src/network/ChunkedResponse.h
+++ b/src/network/ChunkedResponse.h
@@ -66,6 +66,9 @@ class ChunkedResponse {
     esp_task_wdt_reset();
     server->sendContent(buffer.get(), used);
     used = 0;
+    // Yield so WiFi and the other tasks get to run: sendContent() is a blocking
+    // network write that can stall for seconds under concurrent connections.
+    yield();
     esp_task_wdt_reset();
   }
 

--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -588,8 +588,6 @@
     btn.textContent = 'Save Settings';
   }
 
-  loadSettings();
-
  // --- Wi-Fi Network Management ---
   // Renders an editable list of saved Wi-Fi networks using /api/wifi endpoints.
   // Password fields are never pre-filled; when left blank during edit, existing
@@ -841,8 +839,14 @@
     }
   }
   
-  loadWifiNetworks();
-  loadOpdsServers();
+  // Sequential, not concurrent: the device's web server handles one client
+  // connection at a time, and three simultaneous fetches on page load can
+  // stall long enough inside a single response to trip the firmware watchdog.
+  (async () => {
+    await loadSettings();
+    await loadWifiNetworks();
+    await loadOpdsServers();
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a crash where opening the web UI's Settings page can reboot the device via watchdog panic. Cherry-picked from upstream [crosspoint-reader/crosspoint-reader#2831](https://github.com/crosspoint-reader/crosspoint-reader/pull/2831).
* **What changes are included?** Two parts:
  * `SettingsPage.html` fired three unawaited `fetch()` calls on page load (`/api/settings`, `/api/wifi`, `/api/opds`), opening simultaneous connections to a server (Arduino's `WebServer`) that handles one client at a time. A concurrent second/third connection can stall a response mid-stream for seconds — long enough to trip the firmware watchdogs. These now run sequentially via a small async IIFE. Same end state, no page-visible behavior change.
  * `ChunkedResponse::flush()` now calls `yield()` around its blocking `sendContent()` write.

## Additional Context

**How this differs from the upstream PR.** Upstream added `yield()` + watchdog resets after each per-entry `sendContent()` in `handleGetSettings()`, `handleGetOpdsServers()`, and `handleGetWifiNetworks()`. That doesn't port directly here: those three loops were already refactored onto `ChunkedJsonArray`/`ChunkedResponse` (the CrossInk `1d6b82f` port), so there is no per-entry `sendContent()` left to patch, and upstream's `resetTaskWatchdogIfSubscribed()` helper doesn't exist in this fork — we call `esp_task_wdt_reset()` directly.

`ChunkedResponse::flush()` already bracketed its `sendContent()` with `esp_task_wdt_reset()` on both sides, so the watchdog half was covered. It was missing the `yield()` — the part that actually lets the WiFi task drain during a stalled write rather than just resetting the timer around it. Adding it there lands in the shared buffered path, so it now covers **every** streamed list response (file listings, WebDAV PROPFIND), not just the three settings endpoints.

Worth noting the JS fix alone is not sufficient — upstream's second commit records that the Settings page still crashed with a watchdog panic after sequencing, which is why the C++ half matters more than the upstream PR body's "just sequencing" framing suggests.

**Risk:** low. No new endpoints, no changed request/response shapes, no new allocations. The `yield()` is on a path that already yielded implicitly via `sendContent()`.

**Memory/flash:** no meaningful change. Build (`pio run -e default`) succeeds at RAM 16.6%, Flash 96.2% — the flash figure is pre-existing and not affected by this change, but it is tight.

## Testing performed

* Verified on an X4: Settings page loads cleanly.
* `pio run -e default` builds successfully; confirmed the pre-build `scripts/build_html.py` step regenerated the gzipped `SettingsPageHtml.generated.h` (generated headers are gitignored in this fork, so it does not appear in the diff).
* Upstream additionally root-caused this live on an X4 with per-entry heap/timing logs and reproduced the crash 2/2 with concurrent fetches; see the linked PR for that evidence.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — applicability analysis, fork-specific adaptation, and this PR description by Claude (Opus 5). Original upstream fix by Jesse Vincent, credited via `Co-authored-by`.