### PR TITLE
feat: preview image files inline in web file browser

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -248,6 +248,31 @@
       max-width: 920px;
     }
 
+    .modal.image-preview-mode {
+      max-width: 640px;
+    }
+
+    .image-preview-stage {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      overflow: auto;
+      margin-bottom: 15px;
+      border-radius: 6px;
+    }
+
+    .image-preview-stage img {
+      max-width: 100%;
+      max-height: 65vh;
+      object-fit: contain;
+    }
+
+    #imagePreviewDownload {
+      display: inline-block;
+      width: auto;
+      text-decoration: none;
+    }
+
     .picker-columns.picker-active {
       display: flex;
       flex-direction: row;
@@ -2118,6 +2143,21 @@
     </div>
   </div>
 
+  <!-- Image Preview Modal -->
+  <div class="modal-overlay" id="imagePreviewModal">
+    <div class="modal image-preview-mode">
+      <button class="modal-close" onclick="closeImagePreview()">&times;</button>
+      <h3>🖼️ Preview</h3>
+      <div class="folder-form">
+        <p class="file-info"><strong id="imagePreviewName"></strong></p>
+        <div class="image-preview-stage">
+          <img id="imagePreviewImg" alt="">
+        </div>
+        <a id="imagePreviewDownload" class="move-btn-confirm" rel="noopener noreferrer" target="_blank" href="#">Download</a>
+      </div>
+    </div>
+  </div>
+
   <script>
     // get current path from query parameter
     const currentPath = decodeURIComponent(new URLSearchParams(window.location.search).get('path') || '/');
@@ -2231,6 +2271,7 @@
             if (overlay.id === 'deleteModal') return closeDeleteModal();
             if (overlay.id === 'renameModal') return closeRenameModal();
             if (overlay.id === 'moveModal') return closeMoveModal();
+            if (overlay.id === 'imagePreviewModal') return closeImagePreview();
             overlay.classList.remove('open');
           }
         });
@@ -2375,14 +2416,19 @@
           const ext = file.name.includes('.') ? file.name.split('.').pop().toLowerCase() : '';
           const isXtc = ext === 'xtc' || ext === 'xtch';
           const isMd = ext === 'md';
-          const fileIcon = file.isEpub ? '📗' : isXtc ? '📘' : isMd ? '📝' : '📄';
+          const fileIsImage = isImageFile(file.name);
+          const fileIcon = file.isEpub ? '📗' : isXtc ? '📘' : isMd ? '📝' : fileIsImage ? '🖼️' : '📄';
           const fileBadge = file.isEpub ? 'EPUB' : isXtc ? 'XTC' : ext === 'txt' ? 'TXT' : isMd ? 'MD' : '';
           const rowClass = file.isEpub ? 'epub-file' : isXtc ? 'xtc-file' : '';
 
           fileTableContent += `<tr class="${rowClass}">`;
           fileTableContent += `<td style="text-align:center"><input type="checkbox" class="select-item" data-path="${encodeURIComponent(filePath)}" data-name="${escapeHtml(file.name)}" data-type="file"></td>`;
           fileTableContent += `<td><span class="file-icon">${fileIcon}</span>`;
-          fileTableContent += `<a rel="noopener noreferrer" target="_blank" href="/download?path=${encodeURIComponent(filePath)}" class="file-link">${escapeHtml(displayFileName(file.name))}</a>`;
+          if (fileIsImage) {
+            fileTableContent += `<a href="${downloadUrl(filePath)}" class="file-link image-preview-link">${escapeHtml(displayFileName(file.name))}</a>`;
+          } else {
+            fileTableContent += `<a rel="noopener noreferrer" target="_blank" href="${downloadUrl(filePath)}" class="file-link">${escapeHtml(displayFileName(file.name))}</a>`;
+          }
           if (fileBadge) fileTableContent += `<span class="epub-badge">${fileBadge}</span>`;
           fileTableContent += '</td>';
           fileTableContent += `<td>${file.name.includes('.') ? file.name.split('.').pop().toUpperCase() : '-'}</td>`;
@@ -3223,6 +3269,14 @@
 
     // Initialize quality settings handlers
     document.addEventListener('DOMContentLoaded', function () {
+      // Delegated so it survives file-table re-renders (avoids inline onclick with untrusted names).
+      document.getElementById('file-table').addEventListener('click', function (e) {
+        const link = e.target.closest('.image-preview-link');
+        if (!link) return;
+        e.preventDefault();
+        openImagePreview(link.getAttribute('href'), link.textContent);
+      });
+
       const qualitySlider = document.getElementById('qualitySlider');
       const qualityInput = document.getElementById('qualityInput');
 
@@ -3596,6 +3650,30 @@
       if (showFileExtensions) return name;
       const dot = name.lastIndexOf('.');
       return dot > 0 ? name.substring(0, dot) : name;
+    }
+
+    // Image preview
+    function isImageFile(name) {
+      return /\.(png|jpe?g|bmp|gif|webp)$/i.test(name);
+    }
+
+    function downloadUrl(filePath) {
+      return `/download?path=${encodeURIComponent(filePath)}`;
+    }
+
+    function openImagePreview(url, name) {
+      const img = document.getElementById('imagePreviewImg');
+      document.getElementById('imagePreviewName').textContent = name;
+      img.src = url;
+      img.alt = name;
+      document.getElementById('imagePreviewDownload').href = url;
+      document.getElementById('imagePreviewModal').classList.add('open');
+    }
+
+    function closeImagePreview() {
+      document.getElementById('imagePreviewModal').classList.remove('open');
+      // Clear src to free the decoded image and avoid showing the stale one on reopen.
+      document.getElementById('imagePreviewImg').src = '';
     }
 
     // CrossPoint version (fetched from API)


### PR DESCRIPTION
Clicking an image file (png/jpg/bmp/gif/webp) in the web file browser now opens an in-page preview modal instead of forcing a download. Uses an <img> against the existing /download endpoint, which ignores the device's Content-Disposition: attachment header, so no firmware change is required. A Download button remains for saving the file.

Image links use a stable class + real download href opened through a delegated click listener, avoiding inline onclick with untrusted names.

Ported from crosspoint-reader PR #2429 by Pietro Campagnano.

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_
