### PR TITLE
fix: Mirror wakeup button logic to sleep logic

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -305,17 +305,13 @@ void HalGPIO::waitForStablePowerRelease() {
   LOG_DBG("GPIO", "Power button stable-released after %lu ms", millis() - waitStart);
 }
 
-bool HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs) {
+bool HalGPIO::verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDurationMs) {
   constexpr unsigned long BOUNCE_TOLERANCE_MS = 100;
   constexpr unsigned long POLL_INTERVAL_MS = 10;
+  // Mirrors ButtonEventManager::DOUBLE_WINDOW_MS so a double-click-to-sleep gesture
+  // wakes on the same cadence it was configured with.
+  constexpr unsigned long DOUBLE_WINDOW_MS = 300;
 
-  // requiredDurationMs is compared against millis() directly — time since app start, NOT time
-  // since this call. That is deliberate: the press that caused the wake began before setup() ran,
-  // so boot time counts toward the hold rather than being charged to the user twice. The caveat
-  // is that millis() starts at app init and so excludes the ~200-300 ms bootloader, making the
-  // real-world hold needed that much longer than the configured value. Erring long is the safe
-  // direction — the failure mode being guarded against is a stray tap waking the device.
-  //
   // Must be called before any long-running init (it is the first statement of setup()) so a short
   // press cannot be hidden by boot work: a released button is detected below and returns
   // immediately, which is also why running this on every boot costs nothing on non-button resets.
@@ -324,15 +320,43 @@ bool HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs) {
     return false;
   }
 
+  if (gestures.shortAllowed) {
+    return true;
+  }
+
+  // requiredDurationMs (longHold) is compared against millis() directly — time since app
+  // start, NOT time since this call. That is deliberate: the press that caused the wake
+  // began before setup() ran, so boot time counts toward the hold rather than being
+  // charged to the user twice. The caveat is that millis() starts at app init and so
+  // excludes the ~200-300 ms bootloader, making the real-world hold needed that much
+  // longer than the configured value. Erring long is the safe direction — the failure
+  // mode being guarded against is a stray tap waking the device.
+  //
+  // Watch the first press through to release, classifying it exactly like the awake FSM
+  // (ButtonEventManager): held past requiredDurationMs is a long press; released earlier
+  // followed by a second press within DOUBLE_WINDOW_MS is a double click; otherwise it's
+  // a short tap. Whichever it turns out to be, accept it only if that gesture is enabled.
   unsigned long lastSeenPressed = millis();
   while (true) {
     const unsigned long now = millis();
     if (digitalRead(InputManager::POWER_BUTTON_PIN) == LOW) {
       lastSeenPressed = now;
-      if (now >= requiredDurationMs) {
+      if (gestures.longHold && now >= requiredDurationMs) {
         return true;
       }
     } else if (now - lastSeenPressed >= BOUNCE_TOLERANCE_MS) {
+      // Released before the long-hold threshold. A double-click gesture gets one more
+      // chance: a second press within the window after this release.
+      if (!gestures.doubleClick) {
+        return false;
+      }
+      const unsigned long releaseTime = now;
+      while (millis() - releaseTime < DOUBLE_WINDOW_MS) {
+        if (digitalRead(InputManager::POWER_BUTTON_PIN) == LOW) {
+          return true;
+        }
+        delay(POLL_INTERVAL_MS);
+      }
       return false;
     }
     delay(POLL_INTERVAL_MS);

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -153,9 +153,21 @@ class HalGPIO {
   // the 5 ms debounce being fooled by mechanical switch bounce during release.
   void waitForStablePowerRelease();
 
-  // Verify the raw power button remains held until requiredDurationMs after boot.
+  // Which power-button press pattern(s) are accepted as an intentional wake. Mirrors
+  // whichever press type(s) the user configured to put the device to sleep — several
+  // can be set at once (e.g. both short AND long press power off), in which case any
+  // one of the enabled gestures wakes it.
+  struct WakeGestures {
+    bool shortAllowed = false;  // any press/release, however brief, wakes the device
+    bool doubleClick = false;   // two presses with releases within the double-click window
+    bool longHold = true;       // sustained hold of requiredDurationMs (the safe default)
+  };
+
+  // Verify the raw power button was pressed in one of the patterns enabled by `gestures`,
+  // mirroring the press type(s) configured to put the device to sleep. requiredDurationMs
+  // is only used by the longHold gesture.
   // Call as early as possible so cold-boot initialization cannot hide a short press.
-  bool verifyPowerButtonWakeup(uint16_t requiredDurationMs);
+  bool verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDurationMs);
 
   // Check if USB is connected
   bool isUsbConnected() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -512,8 +512,31 @@ extern "C" __attribute__((constructor(101))) void heapProbePreCppCtors() {
 static BootHeapProbe s_probeMainLast(5);
 #endif
 
+// Maps the user's configured power-button sleep gesture(s) to the matching wake
+// gesture(s), so waking mirrors however the device was put to sleep: a long hold
+// wakes from a long-hold sleep, a double click wakes from a double-click sleep, and
+// so on. Several can be configured at once (e.g. short AND long both power off), in
+// which case any one of them wakes it. Relies on SETTINGS already having been loaded
+// via loadStartupFromNvs() — btnShortPower/btnDoublePower/btnLongPower are NVS-backed
+// specifically so this decision doesn't need the full settings file loaded from SD.
+static HalGPIO::WakeGestures wakeGestureFromSettings() {
+  using BA = CrossPointSettings::BUTTON_ACTION;
+  HalGPIO::WakeGestures gestures;
+  gestures.shortAllowed = SETTINGS.btnShortPower == BA::BTN_SLEEP;
+  gestures.doubleClick = SETTINGS.btnDoublePower == BA::BTN_SLEEP;
+  // Long-press-to-sleep is not user-remappable (loop()'s power-hold timer always owns
+  // it, independent of btnLongPower's value — see the "not user-remappable" comment at
+  // its call site), so long-hold-to-wake is unconditionally enabled to match.
+  gestures.longHold = true;
+  return gestures;
+}
+
 void setup() {
-  const bool powerButtonWakeVerified = gpio.verifyPowerButtonWakeup(CrossPointSettings::getPowerButtonDuration());
+  // Load just the settings we need before any other init, so the wake gesture mirrors
+  // whichever press type(s) the user configured to put the device to sleep.
+  SETTINGS.loadStartupFromNvs();
+  const bool powerButtonWakeVerified =
+      gpio.verifyPowerButtonWakeup(wakeGestureFromSettings(), CrossPointSettings::getPowerButtonDuration());
 
   // print_errors=true: the corrupt block's address and overwritten values go to the
   // boot console (USB-CDC on boot — the same channel the panic dumps reach), giving the
@@ -655,9 +678,6 @@ void setup() {
   }
 #endif
   logStartupMemory("after_hw_init");
-
-  // Load just the settings we need *before* initializing the SD card to speed up and reduce power on unverified wakes
-  SETTINGS.loadStartupFromNvs();
 
   if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
     LOG_DBG("MAIN", "Verifying power button press duration (required=%u ms)",


### PR DESCRIPTION
Wake-from-sleep now mirrors whatever gesture the user configured to put the device to sleep:

- [lib/hal/HalGPIO.h]: verifyPowerButtonWakeup now takes a WakeGestures{shortAllowed, doubleClick, longHold} struct instead of a single duration, and classifies the actual press (long hold vs. double-click vs. short tap) against whichever gestures are enabled — a double click is detected the same way the awake ButtonEventManager FSM does (second press within the 300ms double-click window after release).
- [src/main.cpp]: added wakeGestureFromSettings(), which reads the NVS-backed btnShortPower/btnDoublePower (already cached there for exactly this cheap-startup-check purpose) to enable short/double wake when those are mapped to Sleep. Long-hold-to-wake stays unconditionally enabled since long-press-to-sleep is hardcoded in loop()'s power-hold timer, not user-remappable. loadStartupFromNvs() was moved to the very top of setup() so this decision can be made before the verification call.

If more than one press type is configured to power off (e.g. both short and long), any of the configured gestures will wake it, per your earlier answer. Build and pio check both pass. This hasn't been tested on hardware — please verify a short-press-off/short-press-on and double-click-off/double-click-on round trip on an actual device.