### PR TITLE
fix: serialize display and SD on the shared SPI bus

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -5,6 +5,8 @@
 #include <Logging.h>
 #include <esp_heap_caps.h>
 
+#include "HalSpiBus.h"
+
 // Global HalDisplay instance, bracketed by static-init heap probes (slots 0/1).
 static BootHeapProbe s_probePreDisplay(0);
 HalDisplay display;
@@ -29,7 +31,10 @@ void HalDisplay::begin(bool seamless) {
   // just brackets the wait.
   einkDisplay.setBusyWaitHooks([] { powerManager.enterWaveformWait(); }, [] { powerManager.exitWaveformWait(); });
 
-  einkDisplay.begin();
+  {
+    HalSpiBus::Lock spiLock;
+    einkDisplay.begin();
+  }
 
   // Request resync after specific wakeup events to ensure clean display state.
   // Skip when seamless=true so the current panel content is preserved (Quick Resume).
@@ -85,6 +90,8 @@ void HalDisplay::requestResync(uint8_t settlePasses) {
 }
 
 void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+
   lastRefreshMode = mode;
   lastDisplayModeByte = refreshModeToByte(mode);
 
@@ -99,6 +106,8 @@ void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen)
 }
 
 void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+
   lastRefreshMode = mode;
   lastDisplayModeByte = refreshModeToByte(mode);
 
@@ -112,7 +121,10 @@ void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen
   einkDisplay.refreshDisplay(convertRefreshMode(mode), turnOffScreen);
 }
 
-void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
+void HalDisplay::deepSleep() {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.deepSleep();
+}
 
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
@@ -175,16 +187,31 @@ void HalDisplay::setSingleBufferFastDiff(bool enabled) {
 }
 
 void HalDisplay::triggerDisplay(RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
   einkDisplay.triggerDisplay(static_cast<EInkDisplay::RefreshMode>(mode), turnOffScreen);
 }
 
-void HalDisplay::completeDisplay() { einkDisplay.completeDisplay(); }
+void HalDisplay::completeDisplay() {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.completeDisplay();
+}
 
+// The async split locks each half separately rather than spanning the pair.
+// triggerDisplayAsync() returns while the waveform runs, and that gap is
+// deliberately used for CPU/RAM work (see GfxRenderer.h and the inline-AA path
+// in EpubReaderActivity) - holding the bus across it would serialize away the
+// overlap the split exists to create. It is safe to drop the lock in between:
+// during the waveform the controller scans its own RAM and the panel is not
+// driving SPI.
 void HalDisplay::triggerDisplayAsync(RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
   einkDisplay.triggerDisplayAsync(convertRefreshMode(mode), turnOffScreen);
 }
 
-void HalDisplay::finishDisplayAsync() { einkDisplay.finishDisplayAsync(); }
+void HalDisplay::finishDisplayAsync() {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.finishDisplayAsync();
+}
 
 bool HalDisplay::isRefreshPending() const { return einkDisplay.isRefreshPending(); }
 bool HalDisplay::isRedRamSynced() const { return einkDisplay.isRedRamSynced(); }
@@ -211,9 +238,13 @@ void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.
 
 void HalDisplay::cleanupGrayscaleWithPreviousBuffer() { einkDisplay.cleanupGrayscaleWithPreviousBuffer(); }
 
-void HalDisplay::displayGrayBuffer(bool turnOffScreen) { einkDisplay.displayGrayBuffer(turnOffScreen); }
+void HalDisplay::displayGrayBuffer(bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.displayGrayBuffer(turnOffScreen);
+}
 
 void HalDisplay::displayWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
   einkDisplay.displayWindow(x, y, w, h, turnOffScreen);
 }
 

--- a/lib/hal/HalSpiBus.cpp
+++ b/lib/hal/HalSpiBus.cpp
@@ -1,0 +1,44 @@
+#include "HalSpiBus.h"
+
+#include <Logging.h>
+
+namespace {
+// A single SPI transaction is short (a panel refresh is driven in chunks, an SD
+// transfer is block-sized), so anything past this means a lock-order mistake or
+// a wedged transfer. Waiting forever would turn that into a silent hang; time
+// out, log, and proceed unlocked so the failure is diagnosable in a log rather
+// than presenting as a frozen device.
+constexpr TickType_t SPI_LOCK_TIMEOUT_TICKS = pdMS_TO_TICKS(5000);
+}  // namespace
+
+HalSpiBus::HalSpiBus() {
+  mutex = xSemaphoreCreateRecursiveMutex();
+  if (mutex == nullptr) {
+    LOG_ERR("SPI", "Failed to create SPI bus mutex - display/SD access is unserialized");
+  }
+}
+
+HalSpiBus& HalSpiBus::getInstance() {
+  static HalSpiBus spiBus;
+  return spiBus;
+}
+
+void HalSpiBus::begin() { (void)getInstance(); }
+
+HalSpiBus::Lock::Lock() {
+  auto& bus = HalSpiBus::getInstance();
+  if (bus.mutex == nullptr) {
+    LOG_ERR("SPI", "SPI bus mutex not initialized, proceeding unlocked");
+    return;
+  }
+  if (xSemaphoreTakeRecursive(bus.mutex, SPI_LOCK_TIMEOUT_TICKS) != pdTRUE) {
+    LOG_ERR("SPI", "Timed out acquiring SPI bus mutex - proceeding unlocked (possible lock-order bug)");
+    return;
+  }
+  acquired = true;
+}
+
+HalSpiBus::Lock::~Lock() {
+  if (!acquired) return;
+  xSemaphoreGiveRecursive(HalSpiBus::getInstance().mutex);
+}

--- a/lib/hal/HalSpiBus.h
+++ b/lib/hal/HalSpiBus.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+// Serializes access to the SPI bus shared by the e-ink panel and the SD card.
+//
+// The two devices share the physical bus (see SPI_MISO in HalGPIO.h, "shared
+// between SD card and display"). HalStorage already serializes SD access with
+// storageMutex, but HalDisplay took no lock at all, and the two run on
+// different tasks: the render task drives the panel from
+// ActivityManager::renderTaskLoop(), while the main task runs
+// currentActivity->loop() *without* the render lock (deliberately - see the
+// note in ActivityManager::loop()). Many activities do SD I/O from loop().
+//
+// A display refresh interleaving with a concurrent SD transfer can therefore
+// confuse SdSpiCard's unsynchronised m_spiActive state machine, surfacing as
+// corrupted reads or a FreeRTOS panic - a signature easily misfiled as heap
+// corruption.
+//
+// Lock ordering is SPI-outer, storage-inner: HalStorage::StorageLock acquires
+// this lock as its outermost member (construction order guarantees it), and
+// display code takes only this lock, so the global order is consistent and
+// deadlock-free.
+//
+// The mutex is recursive so a storage path that re-enters the bus lock cannot
+// self-deadlock. Note this does NOT make HalStorage's own storageMutex
+// recursive - that one stays plain, because no storage path nests it today
+// (~FsFile calls SdFat's close() directly, not the locking HalFile::close()).
+class HalSpiBus {
+ public:
+  class Lock {
+   public:
+    Lock();
+    ~Lock();
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+
+   private:
+    bool acquired = false;
+  };
+
+  static HalSpiBus& getInstance();
+
+  // Create the mutex up front. Call once from setup() before the first display
+  // or storage access. Lock construction falls back to lazy creation, but doing
+  // it explicitly keeps mutex allocation out of the first refresh path.
+  static void begin();
+
+ private:
+  HalSpiBus();
+
+  SemaphoreHandle_t mutex = nullptr;
+
+  friend class Lock;
+};

--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -11,6 +11,8 @@
 #include <ctime>
 #include <new>
 
+#include "HalSpiBus.h"
+
 #define SDCard SDCardManager::getInstance()
 
 HalStorage HalStorage::instance;
@@ -27,7 +29,12 @@ bool HalStorage::begin() {
     storageMutex = xSemaphoreCreateMutex();
     assert(storageMutex != nullptr);
   }
-  if (!SDCard.begin()) return false;
+  {
+    // SD init drives the shared bus, so it must be serialized against the
+    // display too - the render task is already running by this point.
+    HalSpiBus::Lock spiLock;
+    if (!SDCard.begin()) return false;
+  }
   FsDateTime::setCallback([](uint16_t* date, uint16_t* time) {
     if (!HalClock::isSynced()) {
       *date = FS_DATE(1980, 1, 1);
@@ -55,6 +62,13 @@ class HalStorage::StorageLock {
  public:
   StorageLock() { xSemaphoreTake(HalStorage::getInstance().storageMutex, portMAX_DELAY); }
   ~StorageLock() { xSemaphoreGive(HalStorage::getInstance().storageMutex); }
+
+ private:
+  // Declared first so it is acquired before storageMutex and released after it:
+  // the bus stays locked for the whole SD operation, and the lock order is
+  // always SPI-outer/storage-inner, matching display code (which takes only the
+  // SPI lock). Do not reorder this below any other member.
+  HalSpiBus::Lock spiLock;
 };
 
 #define HAL_STORAGE_WRAPPED_CALL(method, ...) \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <HalDisplay.h>
 #include <HalGPIO.h>
 #include <HalPowerManager.h>
+#include <HalSpiBus.h>
 #include <HalStorage.h>
 #include <HalSystem.h>
 #include <HalTiltSensor.h>
@@ -601,6 +602,9 @@ void setup() {
   }
 
   HalSystem::begin();
+  // Create the shared-SPI-bus mutex before anything can touch the panel or the
+  // SD card, so no first-use allocation happens inside a refresh or read path.
+  HalSpiBus::begin();
   gpio.begin();
   powerManager.begin();
   halTiltSensor.begin();


### PR DESCRIPTION
## Summary

The e-ink panel and the SD card share one physical SPI bus (see `SPI_MISO` in `HalGPIO.h`, *"shared between SD card and display"*), but only one side took a lock. `HalStorage` serialized SD access with `storageMutex`; `HalDisplay` took no lock at all.

The two run on **different tasks**: the render task drives the panel from `ActivityManager::renderTaskLoop()`, while the main task runs `currentActivity->loop()` *without* the render lock (deliberately — see the note in `ActivityManager::loop()`), and many activities do SD I/O from `loop()`. A display refresh interleaving with a concurrent SD transfer can confuse `SdSpiCard`'s unsynchronised `m_spiActive` state machine, surfacing as corrupted reads or a FreeRTOS panic — a signature that is easy to misfile as heap corruption.

This adds `HalSpiBus`: a recursive-mutex singleton with an RAII `Lock`. `HalDisplay` acquires it around every panel operation; `HalStorage::StorageLock` acquires it as its **outermost member**, so the global lock order is always **SPI-outer, storage-inner** and therefore deadlock-free.

This is adopted from upstream crosspoint-reader PR [#2837](https://github.com/crosspoint-reader/crosspoint-reader/pull/2837) by @Uri-Tauber (credited via `Co-authored-by`).

## Changes vs. the upstream PR

Our tree differs from crosspoint's in ways that matter here, so this is not a straight cherry-pick.

### 1. Storage reentrance: our `storageMutex` is **not** recursive

This is the significant one. Upstream's `HalStorage` uses `xSemaphoreCreateRecursiveMutex()` / `xSemaphoreTakeRecursive()`, so its PR text can say the recursive bus mutex means *"a storage path that re-enters `StorageLock` (e.g. `HalFile::Impl close`) does not self-deadlock."*

In this tree `storageMutex` is a **plain** mutex (`xSemaphoreCreateMutex` / `xSemaphoreTake`, [HalStorage.cpp:29](lib/hal/HalStorage.cpp#L29)). So that reasoning does not carry over: making the *bus* lock recursive does nothing for storage reentrance, because a nested `StorageLock` would still deadlock on the inner plain mutex.

What we did:

- Kept the bus mutex **recursive** anyway. It is cheap, and it guards reentrance on the display side and any future path that takes the bus lock twice — which we cannot rule out across the whole HAL.
- **Did not** convert `storageMutex` to recursive. Auditing the paths, nothing nests `StorageLock` today: `~FsFile` calls SdFat's `close()` directly, not the locking `HalFile::close()`. Changing the storage mutex's type is a separate concern with its own risk, and this PR is scoped to the bus.
- Documented the distinction explicitly in the `HalSpiBus.h` header comment and at the `StorageLock` member, so the next reader does not inherit upstream's (for us, incorrect) assumption that reentering `StorageLock` is safe.

If a nesting path is ever introduced, the fix is to make `storageMutex` recursive at that point — deliberately, not by accident.

### 2. `HalStorage::begin()` now takes the bus lock

Upstream comments that `begin()`/`ready()` are *"only called from setup, no need to acquire mutex"*, and its `begin()` locks the bus but the surrounding reasoning is setup-only.

In our tree the render task is **already running** by the time `HalStorage::begin()` is called, so SD init genuinely races the panel. `begin()` locks the bus around `SDCard.begin()` for that reason, with a comment stating it.

### 3. Lock acquisition times out instead of waiting forever

Upstream takes the mutex with `portMAX_DELAY`. We use a **5s timeout**, then log an error and proceed unlocked:

```cpp
if (xSemaphoreTakeRecursive(bus.mutex, SPI_LOCK_TIMEOUT_TICKS) != pdTRUE) {
  LOG_ERR("SPI", "Timed out acquiring SPI bus mutex - proceeding unlocked (possible lock-order bug)");
  return;
}
```

A single SPI transaction is short (refreshes are driven in chunks, SD transfers are block-sized), so anything past 5s means a lock-order mistake or a wedged transfer. `portMAX_DELAY` turns that into a silent hang — a frozen device with no diagnostic. Degrading to unlocked-with-an-error keeps the failure visible in a log. This trades a hard hang for a bounded window of the exact corruption we are fixing, which we consider the better failure mode for a bug that should never fire.

### 4. The async refresh split locks each half separately

Our `HalDisplay` has an async path upstream's version at that revision does not: `triggerDisplayAsync()` / `finishDisplayAsync()`. Each takes the lock **separately** rather than one lock spanning the pair.

`triggerDisplayAsync()` returns while the waveform runs, and that gap is deliberately used for CPU/RAM work (see `GfxRenderer.h` and the inline-AA path in `EpubReaderActivity`). Holding the bus across it would serialize away the exact overlap the split exists to create. Dropping the lock in between is safe: during the waveform the controller scans its own RAM and the panel is not driving SPI. This rationale is in a comment above `triggerDisplayAsync()`.

Also locked here beyond upstream's set, since our `HalDisplay` has them: `triggerDisplay`, `completeDisplay`, `displayWindow`.

### 5. Explicit `HalSpiBus::begin()` from `setup()`

Upstream relies purely on lazy `getInstance()` construction. We call `HalSpiBus::begin()` in `setup()` right after `HalSystem::begin()`, before anything can touch the panel or the SD card, so mutex allocation never happens inside a first refresh or read path. Lazy construction is retained as a fallback.

Note this is placed *after* `HalSystem::begin()` on purpose — `HalStorage.cpp` already documents that creating a semaphore too early corrupts TLSF heap metadata.

## Testing

- `pio run -e default` — SUCCESS. RAM 16.7% (54564 B), Flash 96.2%.
- Cost is one recursive mutex (~90 B) plus a take/give per panel op and per SD op; both are already-serialized coarse-grained operations, so the added contention is on paths that could not safely run concurrently anyway.

## Note for upstream

Point 1 above is worth reporting back on [#2837](https://github.com/crosspoint-reader/crosspoint-reader/pull/2837) — see the separate comment.
