### PR TITLE
perf(boot): instrument the boot sequence, then cut 0.5s (X4) / 3.1s (X3) off it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,10 @@
 [submodule "freeink-sdk"]
 	path = freeink-sdk
-	url = https://github.com/Free-Ink/freeink-sdk.git
-	branch = main
+	# TEMPORARY: pointed at the jpirnay fork branch carrying the X3 single-initial-full-sync
+	# fix, which is not on upstream main yet. Revert both lines to
+	#   url = https://github.com/Free-Ink/freeink-sdk.git
+	#   branch = main
+	# once Free-Ink/freeink-sdk#31 is merged and the pointer can move to an upstream commit.
+	# Until then a --recursive clone must fetch from the fork: upstream does not have this SHA.
+	url = https://github.com/jpirnay/freeink-sdk.git
+	branch = x3-single-initial-full-sync

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -102,7 +102,16 @@ void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen)
   }
   pendingX3SettlePasses = 0;
 
+  // Panel time, measured at the one place every paint funnels through. The boot trace
+  // (main.cpp) shows the splash costing seconds; without this the host-side compose and
+  // the waveform itself are indistinguishable inside that number. FAST/HALF/FULL are
+  // reported separately because promotions happen inside the driver (a FAST can be
+  // upgraded to HALF on a cold panel), so the mode asked for is not always what ran.
+  const unsigned long refreshStart = millis();
   einkDisplay.displayBuffer(convertRefreshMode(mode), turnOffScreen);
+  LOG_DBG("DISP", "displayBuffer mode=%s took %lu ms",
+          mode == RefreshMode::FAST_REFRESH ? "FAST" : (mode == RefreshMode::HALF_REFRESH ? "HALF" : "FULL"),
+          millis() - refreshStart);
 }
 
 void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen) {

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -305,7 +305,25 @@ void HalGPIO::waitForStablePowerRelease() {
   LOG_DBG("GPIO", "Power button stable-released after %lu ms", millis() - waitStart);
 }
 
-bool HalGPIO::verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDurationMs) {
+const char* HalGPIO::wakeVerdictName(WakeVerdict verdict) {
+  switch (verdict) {
+    case WakeVerdict::NotPressed:
+      return "not-pressed";
+    case WakeVerdict::ShortPress:
+      return "short";
+    case WakeVerdict::LongHold:
+      return "long-hold";
+    case WakeVerdict::DoubleClick:
+      return "double-click";
+    case WakeVerdict::ReleasedEarly:
+      return "released-early";
+    case WakeVerdict::NoSecondPress:
+      return "no-second-press";
+  }
+  return "?";
+}
+
+HalGPIO::WakeCheck HalGPIO::verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDurationMs) {
   constexpr unsigned long BOUNCE_TOLERANCE_MS = 100;
   constexpr unsigned long POLL_INTERVAL_MS = 10;
   // Mirrors ButtonEventManager::DOUBLE_WINDOW_MS so a double-click-to-sleep gesture
@@ -315,13 +333,16 @@ bool HalGPIO::verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDu
   // Must be called before any long-running init (it is the first statement of setup()) so a short
   // press cannot be hidden by boot work: a released button is detected below and returns
   // immediately, which is also why running this on every boot costs nothing on non-button resets.
+  const unsigned long gateStart = millis();
+  const auto stamp = [](unsigned long ms) { return static_cast<uint16_t>(ms > UINT16_MAX ? UINT16_MAX : ms); };
+
   pinMode(InputManager::POWER_BUTTON_PIN, INPUT_PULLUP);
   if (digitalRead(InputManager::POWER_BUTTON_PIN) != LOW) {
-    return false;
+    return {WakeVerdict::NotPressed, stamp(millis()), 0};
   }
 
   if (gestures.shortAllowed) {
-    return true;
+    return {WakeVerdict::ShortPress, stamp(millis()), stamp(millis() - gateStart)};
   }
 
   // requiredDurationMs (longHold) is compared against millis() directly — time since app
@@ -342,22 +363,23 @@ bool HalGPIO::verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDu
     if (digitalRead(InputManager::POWER_BUTTON_PIN) == LOW) {
       lastSeenPressed = now;
       if (gestures.longHold && now >= requiredDurationMs) {
-        return true;
+        return {WakeVerdict::LongHold, stamp(now), stamp(now - gateStart)};
       }
     } else if (now - lastSeenPressed >= BOUNCE_TOLERANCE_MS) {
       // Released before the long-hold threshold. A double-click gesture gets one more
       // chance: a second press within the window after this release.
+      const uint16_t heldMs = stamp(lastSeenPressed - gateStart);
       if (!gestures.doubleClick) {
-        return false;
+        return {WakeVerdict::ReleasedEarly, stamp(now), heldMs};
       }
       const unsigned long releaseTime = now;
       while (millis() - releaseTime < DOUBLE_WINDOW_MS) {
         if (digitalRead(InputManager::POWER_BUTTON_PIN) == LOW) {
-          return true;
+          return {WakeVerdict::DoubleClick, stamp(millis()), heldMs};
         }
         delay(POLL_INTERVAL_MS);
       }
-      return false;
+      return {WakeVerdict::NoSecondPress, stamp(millis()), heldMs};
     }
     delay(POLL_INTERVAL_MS);
   }

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -305,6 +305,48 @@ void HalGPIO::waitForStablePowerRelease() {
   LOG_DBG("GPIO", "Power button stable-released after %lu ms", millis() - waitStart);
 }
 
+bool HalGPIO::isHeldNow(uint8_t buttonIndex, uint8_t confirmSamples) {
+  constexpr unsigned long SAMPLE_GAP_MS = 10;
+  // Raw values from the deciding sample, logged below. A negative verdict on the ADC
+  // ladder has two very different causes — the button genuinely is not held, or its
+  // divider reads outside the band the firmware expects — and only the raw value tells
+  // them apart. Worth a line: the boot-time callers run before any UI exists to report a
+  // misdetected combo, so the log is the sole evidence.
+  int raw1 = -1;
+  int raw2 = -1;
+  int classified1 = -1;
+  int classified2 = -1;
+  bool held = true;
+
+  for (uint8_t i = 0; i < confirmSamples; i++) {
+    if (i > 0) delay(SAMPLE_GAP_MS);
+    if (buttonIndex == BTN_POWER) {
+      if (digitalRead(InputManager::POWER_BUTTON_PIN) != LOW) {
+        held = false;
+        break;
+      }
+      continue;
+    }
+    InputManager::ButtonAdcSample group1{};
+    InputManager::ButtonAdcSample group2{};
+    inputMgr.readButtonAdc(group1, group2);
+    raw1 = group1.raw;
+    raw2 = group2.raw;
+    classified1 = group1.button;
+    classified2 = group2.button;
+    if (group1.button != buttonIndex && group2.button != buttonIndex) {
+      held = false;
+      break;
+    }
+  }
+
+  if (buttonIndex != BTN_POWER) {
+    LOG_DBG("GPIO", "isHeldNow(btn=%u) -> %d (adc1 raw=%d btn=%d, adc2 raw=%d btn=%d)", buttonIndex, held ? 1 : 0, raw1,
+            classified1, raw2, classified2);
+  }
+  return held;
+}
+
 const char* HalGPIO::wakeVerdictName(WakeVerdict verdict) {
   switch (verdict) {
     case WakeVerdict::NotPressed:

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -153,6 +153,16 @@ class HalGPIO {
   // the 5 ms debounce being fooled by mechanical switch bounce during release.
   void waitForStablePowerRelease();
 
+  // "Is this button held right now?", answered from fresh hardware samples rather than
+  // the cache isPressed() reads. The six front buttons are resistor dividers on two ADC
+  // pins, so a sample is a plain analogRead plus a band lookup — no debounce state to
+  // warm up, which is what makes this usable during boot before update() has run enough
+  // times to populate the cache. Power is a digital pin and is read directly.
+  //
+  // Every sample must agree, so a transient cannot produce a false positive; a genuinely
+  // held button is stable and passes. Blocks for confirmSamples * 10 ms.
+  bool isHeldNow(uint8_t buttonIndex, uint8_t confirmSamples = 4);
+
   // Which power-button press pattern(s) are accepted as an intentional wake. Mirrors
   // whichever press type(s) the user configured to put the device to sleep — several
   // can be set at once (e.g. both short AND long press power off), in which case any

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -163,11 +163,40 @@ class HalGPIO {
     bool longHold = true;       // sustained hold of requiredDurationMs (the safe default)
   };
 
+  // What the boot-time wake gate actually observed on the power pin. Reported so a
+  // "the button did nothing" report can be told apart from a slow boot: the rejecting
+  // verdicts each name a different user error (let go too soon, second click missed).
+  enum class WakeVerdict : uint8_t {
+    NotPressed,     // pin already HIGH when the gate first sampled it
+    ShortPress,     // accepted: short-press-to-sleep is configured, any press wakes
+    LongHold,       // accepted: held past requiredDurationMs
+    DoubleClick,    // accepted: released early, second press inside the window
+    ReleasedEarly,  // rejected: released before the threshold, double-click not configured
+    NoSecondPress,  // rejected: released early, double-click armed, second press never came
+  };
+
+  struct WakeCheck {
+    WakeVerdict verdict = WakeVerdict::NotPressed;
+    uint16_t decidedAtMs = 0;  // millis() when the verdict was reached
+    // How long the gate itself saw the first press, NOT the user's real hold: the press
+    // began before the app did, so the bootloader and everything up to the gate is not
+    // counted. Use decidedAtMs for "when the device committed to waking".
+    uint16_t heldMs = 0;
+
+    bool accepted() const {
+      return verdict == WakeVerdict::ShortPress || verdict == WakeVerdict::LongHold ||
+             verdict == WakeVerdict::DoubleClick;
+    }
+  };
+
+  // Human-readable name of a verdict, for logging. Points at a string literal.
+  static const char* wakeVerdictName(WakeVerdict verdict);
+
   // Verify the raw power button was pressed in one of the patterns enabled by `gestures`,
   // mirroring the press type(s) configured to put the device to sleep. requiredDurationMs
   // is only used by the longHold gesture.
   // Call as early as possible so cold-boot initialization cannot hide a short press.
-  bool verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDurationMs);
+  WakeCheck verifyPowerButtonWakeup(WakeGestures gestures, uint16_t requiredDurationMs);
 
   // Check if USB is connected
   bool isUsbConnected() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,6 +342,96 @@ static void logStartupMemory(const char* stage) {
           static_cast<unsigned long>(freeInternal), static_cast<unsigned long>(largestInternal));
 }
 
+// --- Boot phase trace ---------------------------------------------------------------
+// millis() stamp per boot phase, summarized at the end of setup() and again whenever the
+// serial link comes up. The wake gesture is only a ~400 ms gate (getPowerButtonDuration),
+// but the splash lands seconds later because the settle waits, the SD mount, the config
+// loads, the panel bring-up and the first (non-differential) waveform all sit between the
+// two. Without per-phase stamps that gap is invisible in the log — every phase before
+// Serial.begin() has no output at all — and "the power button feels unresponsive" reports
+// cannot be attributed to a phase.
+//
+// The stamps stay live in .bss for the whole session precisely so they can be re-emitted:
+// a wake from deep sleep re-enumerates USB, so a host monitor reconnecting mid-boot misses
+// the first lines, and the RTC ring buffer (16 entries) has usually rolled past them by
+// the time anyone looks.
+//
+// Cost is 2 bytes per phase of .bss plus one log line; no heap, no allocation. Stamps are
+// clamped to 16 bits (a boot that reaches 65 s is pathological and reads as 65535).
+enum class BootPhase : uint8_t {
+  SetupEntry,      // first statement of setup()
+  NvsSettings,     // startup settings read from NVS (precedes the wake gate)
+  WakeGate,        // power-button wake gesture decided
+  HwInit,          // system / SPI bus / GPIO / power / tilt brought up
+  SerialUp,        // USB-CDC opened (only when USB is connected; earlier phases log nothing)
+  RecoverySettle,  // 500 ms UP+POWER recovery-combo sample window
+  SdMount,         // Storage.begin()
+  ConfigLoad,      // settings, app state, i18n, KOReader, OPDS, weather, theme
+  DisplayFonts,    // panel init + framebuffer alloc + font registration + SD font scan
+  FirstPaint,      // splash / quick-resume frame handed to the panel (logo now visible)
+  StoreLoad,       // clock, recent books, bookmarks, reading stats
+  ActivityRoute,   // target activity entered (home / reader / recovery)
+  PowerRelease,    // wake press released (stable), input sampler about to start
+  Count,
+};
+
+static uint16_t bootPhaseMs[static_cast<uint8_t>(BootPhase::Count)] = {};
+// Which phases were reached — a stamp of 0 is a legal millis() value, so "reached" cannot
+// be inferred from the value. 13 phases fit a uint16_t mask with room to spare.
+static uint16_t bootPhaseReached = 0;
+// What the wake gate decided this boot. Kept for the whole session so it can be re-emitted
+// alongside the phase trace; 4 bytes.
+static HalGPIO::WakeCheck bootWakeCheck;
+static_assert(static_cast<uint8_t>(BootPhase::Count) <= 16, "bootPhaseReached mask is 16 bits wide");
+
+static void markBootPhase(BootPhase phase) {
+  const unsigned long ms = millis();
+  bootPhaseMs[static_cast<uint8_t>(phase)] = static_cast<uint16_t>(ms > UINT16_MAX ? UINT16_MAX : ms);
+  bootPhaseReached |= static_cast<uint16_t>(1u << static_cast<uint8_t>(phase));
+}
+
+// Short labels so the whole trace fits one 256-byte ring-buffer entry (Logging.cpp).
+static constexpr const char* BOOT_PHASE_NAMES[] = {"entry", "nvs",  "gate",  "hw",    "ser",   "recov", "sd",
+                                                   "cfg",   "disp", "paint", "store", "route", "rel"};
+static_assert(sizeof(BOOT_PHASE_NAMES) / sizeof(BOOT_PHASE_NAMES[0]) == static_cast<size_t>(BootPhase::Count),
+              "BOOT_PHASE_NAMES must stay in sync with BootPhase");
+
+// One "name+costMs" token per reached phase, then the two absolute numbers worth
+// quoting. Deltas rather than absolutes because the cost of a phase is the actionable
+// figure and absolutes are just their running sum — and because the whole line has to
+// fit one 256-byte ring-buffer entry including logPrintf's timestamp/level prefix
+// (Logging.cpp, MAX_ENTRY_LEN). Unreached phases are skipped (e.g. `ser` on battery,
+// `recov` on a non-button boot), so a short trace is itself a signal about which path
+// the boot took.
+static void logBootTrace() {
+  char line[160];
+  size_t used = 0;
+  uint16_t previous = 0;
+  for (uint8_t i = 0; i < static_cast<uint8_t>(BootPhase::Count); i++) {
+    if ((bootPhaseReached & (1u << i)) == 0) continue;
+    const int written = snprintf(line + used, sizeof(line) - used, "%s%s+%u", used ? " " : "", BOOT_PHASE_NAMES[i],
+                                 static_cast<unsigned>(bootPhaseMs[i] - previous));
+    if (written < 0 || static_cast<size_t>(written) >= sizeof(line) - used) break;
+    used += static_cast<size_t>(written);
+    previous = bootPhaseMs[i];
+  }
+  // millis() excludes the ROM/2nd-stage bootloader (~200-300 ms), so time-to-logo as the
+  // user experiences it is that much longer than `logo` reports.
+  // Worst case (five-digit stamps throughout) still fits MAX_ENTRY_LEN: 29 prefix + 15
+  // here + 160 line + 38 tail = 242 of 256. Keep that budget in mind when editing either.
+  LOG_INF("BOOT", "phase cost ms: %s | logo=%u setup=%u (+bootloader)", line,
+          bootPhaseMs[static_cast<uint8_t>(BootPhase::FirstPaint)], previous);
+}
+
+// The whole boot story in two lines: what the power button was judged to be, and where the
+// time went. Re-emitted on every serial (re)connect — see the note above the phase table.
+static void logBootSummary() {
+  LOG_INF("BOOT", "Wake gate: %s (decided at %u ms, gate saw the press for %u ms, required %u ms)",
+          HalGPIO::wakeVerdictName(bootWakeCheck.verdict), bootWakeCheck.decidedAtMs, bootWakeCheck.heldMs,
+          CrossPointSettings::getPowerButtonDuration());
+  logBootTrace();
+}
+
 // Enter deep sleep mode. fromTimeout=true marks an auto-sleep (gates "Quick Resume on Timeout").
 void enterDeepSleep(bool fromTimeout = false) {
   LOG_DBG("MAIN", "enterDeepSleep called at millis=%lu, powerBtn isPressed=%d, rawPin=%d", millis(),
@@ -533,11 +623,13 @@ static HalGPIO::WakeGestures wakeGestureFromSettings() {
 }
 
 void setup() {
+  markBootPhase(BootPhase::SetupEntry);
   // Load just the settings we need before any other init, so the wake gesture mirrors
   // whichever press type(s) the user configured to put the device to sleep.
   SETTINGS.loadStartupFromNvs();
-  const bool powerButtonWakeVerified =
-      gpio.verifyPowerButtonWakeup(wakeGestureFromSettings(), CrossPointSettings::getPowerButtonDuration());
+  markBootPhase(BootPhase::NvsSettings);
+  bootWakeCheck = gpio.verifyPowerButtonWakeup(wakeGestureFromSettings(), CrossPointSettings::getPowerButtonDuration());
+  markBootPhase(BootPhase::WakeGate);
 
   // print_errors=true: the corrupt block's address and overwritten values go to the
   // boot console (USB-CDC on boot — the same channel the panic dumps reach), giving the
@@ -609,6 +701,7 @@ void setup() {
   powerManager.begin();
   halTiltSensor.begin();
   gpio_deep_sleep_hold_dis();  // Release deep sleep GPIO hold state from previous sleep cycle
+  markBootPhase(BootPhase::HwInit);
 
   const auto wakeupReason = gpio.getWakeupReason();
 
@@ -639,10 +732,17 @@ void setup() {
     while (!Serial && (millis() - start) < 500) {
       delay(10);
     }
+    markBootPhase(BootPhase::SerialUp);
   }
 #endif
 
   LOG_INF("MAIN", "Hardware detect: %s", gpio.deviceIsX3() ? "X3" : "X4");
+  // The gate ran before Serial was open, so this is the first chance to report it. INF
+  // level: a rejected wake leaves no other trace, and release builds must be able to
+  // answer "why did nothing happen when I pressed power".
+  LOG_INF("BOOT", "Wake gate: %s (decided at %u ms, gate saw the press for %u ms, required %u ms)",
+          HalGPIO::wakeVerdictName(bootWakeCheck.verdict), bootWakeCheck.decidedAtMs, bootWakeCheck.heldMs,
+          CrossPointSettings::getPowerButtonDuration());
   LOG_DBG("MAIN", "Wakeup reason: %d, millis=%lu, rawPowerPin=%d", static_cast<int>(wakeupReason), millis(),
           digitalRead(InputManager::POWER_BUTTON_PIN) == LOW);
 #ifdef ENABLE_BOOT_HEAP_DIAGNOSTICS
@@ -683,17 +783,12 @@ void setup() {
 #endif
   logStartupMemory("after_hw_init");
 
-  if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
-    LOG_DBG("MAIN", "Verifying power button press duration (required=%u ms)",
-            CrossPointSettings::getPowerButtonDuration());
-
-    if (!powerButtonWakeVerified) {
-      LOG_DBG("MAIN", "Power button released before wake threshold, returning to deep sleep");
-      halTiltSensor.deepSleep();
-      powerManager.startDeepSleep(gpio);
-      return;
-    }
-    LOG_DBG("MAIN", "Power button verification passed, millis=%lu", millis());
+  if (wakeupReason == HalGPIO::WakeupReason::PowerButton && !bootWakeCheck.accepted()) {
+    LOG_INF("BOOT", "Wake gate rejected the press (%s), returning to deep sleep",
+            HalGPIO::wakeVerdictName(bootWakeCheck.verdict));
+    halTiltSensor.deepSleep();
+    powerManager.startDeepSleep(gpio);
+    return;
   }
 
   // Recovery firmware mode: hold left side button (BTN_UP) together with the power button at
@@ -713,6 +808,7 @@ void setup() {
       recoveryFirmwareMode = true;
       LOG_INF("MAIN", "Recovery firmware mode (UP + POWER held at boot)");
     }
+    markBootPhase(BootPhase::RecoverySettle);
   }
 
   // SD Card Initialization
@@ -720,9 +816,13 @@ void setup() {
   if (!Storage.begin()) {
     LOG_ERR("MAIN", "SD card initialization failed");
     setupDisplayAndFonts();
+    markBootPhase(BootPhase::DisplayFonts);
     activityManager.goToFullScreenMessage("SD card error", EpdFontFamily::BOLD);
+    markBootPhase(BootPhase::FirstPaint);
+    logBootSummary();
     return;
   }
+  markBootPhase(BootPhase::SdMount);
   logStartupMemory("after_storage_begin");
 
   SETTINGS.loadFromFile();
@@ -745,6 +845,7 @@ void setup() {
   MappedInputManager::setStripReversedPredicate(
       [] { return renderer.getOrientation() == GfxRenderer::Orientation::LandscapeCounterClockwise; });
 
+  markBootPhase(BootPhase::ConfigLoad);
   // First serial output only here to avoid timing inconsistencies for power button press duration verification
   LOG_DBG("MAIN", "Starting CrossPoint version " CROSSPOINT_VERSION);
   logStartupMemory("before_display_fonts");
@@ -762,6 +863,7 @@ void setup() {
   // host is waiting through. Safe because that activity reboots on exit.
   const bool bootToSerialTransfer = (silentRebootTargetSnapshot == SILENT_REBOOT_TARGET_SERIAL_TRANSFER);
   setupDisplayAndFonts(resume != BootResume::Splash, bootToSerialTransfer);
+  markBootPhase(BootPhase::DisplayFonts);
   logStartupMemory("after_display_fonts");
 
   switch (resume) {
@@ -792,11 +894,17 @@ void setup() {
       activityManager.goToBoot();
       break;
   }
+  // The paints above are synchronous (BootActivity::onEnter -> displayBuffer), so this
+  // stamp is the moment the panel finished the waveform — i.e. when the user actually
+  // sees the logo. On a power-button boot it is also the first visible feedback of any
+  // kind, which is what makes the gap back to `gate` the number that matters.
+  markBootPhase(BootPhase::FirstPaint);
 
   HalClock::restore();
   RECENT_BOOKS.loadFromFile();
   GLOBAL_BOOKMARKS.load();
   READING_STATS.loadFromFile();
+  markBootPhase(BootPhase::StoreLoad);
 
   if (recoveryFirmwareMode) {
     // Skip normal home/reader routing: jump straight into the SD firmware picker.
@@ -839,6 +947,7 @@ void setup() {
     activityManager.goToReader(path);
   }
 
+  markBootPhase(BootPhase::ActivityRoute);
   logStartupMemory("after_activity_route");
 
   // Ensure we're not still holding the power button before leaving setup.
@@ -846,6 +955,10 @@ void setup() {
   // Skip on silent reboot: the firmware triggered the restart, so the button isn't held.
   if (!isSilentReboot) {
     gpio.waitForStablePowerRelease();
+    // Stamped after the wait, so `rel` minus `route` is how long the user kept holding
+    // past the point the device was ready — the other half of the "how long should I
+    // hold this?" question.
+    markBootPhase(BootPhase::PowerRelease);
   }
   // All boot-time power-button handling (which drives inputMgr.update() directly)
   // is done — hand button sampling to the background sampler so presses are caught
@@ -862,6 +975,7 @@ void setup() {
   // the wake-press a fraction late; without this guard the loop() power-hold check would
   // immediately fire enterDeepSleep().
   allowSleepAt = millis() + 2000;
+  logBootSummary();
   logStartupMemory("setup_complete");
 }
 
@@ -879,6 +993,31 @@ void loop() {
 
   renderer.setFadingFix(SETTINGS.fadingFix);
   renderer.setTextDarkness(SETTINGS.textDarkness);
+
+  // Re-emit the boot summary when the serial link comes up. A power-up from deep sleep
+  // re-enumerates USB, so a monitor attached across the wake misses everything setup()
+  // printed — including the trace itself, which is the one line worth having.
+  //
+  // Strictly bounded, because `Serial` is not a reliable connect signal: HWCDC flips
+  // itself to "disconnected" whenever its TX ring doesn't drain within the tx timeout
+  // (see the buffer-sizing comment in setup()), which on a busy boot flaps several times
+  // a second and once produced eight copies of this summary. The cap keeps a flapping
+  // link from spamming the log while still catching a monitor attached late; anything
+  // later than that is what `CMD:BOOTLOG` is for.
+  {
+    // Seeded true because setup() just emitted the summary: if the link was already up
+    // then, this must not fire again on the first tick. A battery boot clears it on that
+    // same tick (Serial is false), so a cable plugged in later still produces the edge.
+    static bool serialWasUp = true;
+    static uint8_t bootSummaryRepeats = 0;
+    constexpr uint8_t MAX_BOOT_SUMMARY_REPEATS = 2;
+    const bool serialIsUp = static_cast<bool>(Serial);
+    if (serialIsUp && !serialWasUp && bootSummaryRepeats < MAX_BOOT_SUMMARY_REPEATS) {
+      bootSummaryRepeats++;
+      logBootSummary();
+    }
+    serialWasUp = serialIsUp;
+  }
 
   if (Serial && millis() - lastMemPrint >= 10000) {
     // Keep runtime log lightweight: ESP.getMaxAllocHeap() walks heap metadata
@@ -929,6 +1068,10 @@ void loop() {
           // Framebuffers are released during the web server session — nothing to send.
           logSerial.printf("SCREENSHOT_ERROR:framebuffer released\n");
         }
+      } else if (cmd == "BOOTLOG") {
+        // On-demand replay of this session's boot summary, for when the monitor was
+        // attached too late to catch it and the automatic repeats are used up.
+        logBootSummary();
       }
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -796,15 +796,21 @@ void setup() {
   // flashing has been locked down (e.g. recent X3 firmware).
   bool recoveryFirmwareMode = false;
   if (wakeupReason == HalGPIO::WakeupReason::PowerButton) {
-    // Refresh the cached button state a few times — isPressed() needs ~half a second to settle
-    // after boot per the HalGPIO contract. Use a millis-based deadline so we always wait the full
-    // settle window even if the loop body takes longer than expected on slow boots.
-    const unsigned long settleStart = millis();
-    while (millis() - settleStart < 500) {
+    // This window sits between the wake gesture and the splash, so every millisecond here
+    // is dead time on a dark screen — it measured 501-508 ms across X3 and X4, roughly
+    // 15% of time-to-logo, spent to answer one yes/no question.
+    //
+    // The combo itself is read from fresh ADC samples (isHeldNow), which need no warm-up.
+    // The loop remains only to prime the cache that isPressed() reads, because the "hold
+    // Back at boot to skip resuming the reader" check further down consumes that cache and
+    // nothing calls update() in between. The 5 ms debounce means a handful of passes is
+    // enough; the 500 ms this replaces was not backed by any documented HalGPIO contract.
+    const unsigned long primeStart = millis();
+    while (millis() - primeStart < 60) {
       gpio.update();
       delay(10);
     }
-    if (gpio.isPressed(HalGPIO::BTN_UP)) {
+    if (gpio.isHeldNow(HalGPIO::BTN_UP)) {
       recoveryFirmwareMode = true;
       LOG_INF("MAIN", "Recovery firmware mode (UP + POWER held at boot)");
     }


### PR DESCRIPTION
Started as "the power button is documented as a ~half-second hold but the logo takes several seconds". The hold duration turned out to be accurate and irrelevant — it is a **wake gate**, and the splash is the last thing `setup()` does. Everything in between was invisible in the log, because every phase before `Serial.begin()` produces no output at all.

So: instrument first, then fix what the numbers actually pointed at.

## Results

| press → | X4 before | X4 after | X3 before | X3 after |
|---|---|---|---|---|
| logo | 3555 ms | **3112 ms** | 4232 ms | **3780 ms** |
| Home on screen | 4992 ms | **4464 ms** | 7634 ms | **4569 ms** |

*(long-hold, USB attached; subtract ~320-510 ms on battery, where the CDC wait disappears)*

The two devices are now within ~100 ms of each other on time-to-Home. The X3 used to be 2.6 s behind.

## Commits

**1. `feat(boot)` — instrumentation.** A 13-phase `BootPhase` trace emitted as one line of per-phase costs; `HalGPIO::WakeCheck`/`WakeVerdict` so the gate reports which gesture it judged the press to be, or why it rejected it; per-refresh panel timing in `HalDisplay`. No behaviour change.

The wake verdict is at INF deliberately: a rejected wake silently returns to deep sleep, so in release builds *"why did nothing happen when I pressed power"* previously had no answer anywhere. The summary is re-emitted when the serial link comes up (a wake from deep sleep re-enumerates USB and a monitor attached across it misses everything `setup()` printed), bounded to 2 repeats because `Serial` is not a reliable connect signal — HWCDC flips itself to disconnected when its TX ring does not drain in time, which on a busy boot flapped enough to produce eight copies. `CMD:BOOTLOG` replays it on demand.

**2. `perf(boot)` — recovery-combo window, 500 ms → 60 ms.** It sat between the wake gesture and the splash, so its full cost was dead time on a dark screen (~15% of time-to-logo) to answer one yes/no question. `HalGPIO::isHeldNow()` reads the ADC ladder directly — no debounce state to warm up — requiring 4 agreeing samples but short-circuiting on the first disagreement, so the common case is one sample.

The loop survives at 60 ms **only** to prime the cache that the "hold Back at boot to skip resuming the reader" check consumes; nothing calls `update()` in between, so deleting it outright would silently break that feature. That is the one non-obvious thing in this PR and the thing most worth a reviewer's eye.

**3. `build(sdk)` — submodule bump** for Free-Ink/freeink-sdk#31: the X3 driver reset `_initialFullSyncsRemaining` to 2, so the splash consumed sync #1 and the first Home paint still paid sync #2 — a FAST refresh costing 2989 ms where the X4 pays 527 ms for the same paint. Now 436 ms.

## Note on the submodule

`.gitmodules` **temporarily** points url+branch at the jpirnay fork, since upstream main does not carry that SHA yet and a `--recursive` clone would otherwise fail to fetch it. Both lines revert to `Free-Ink/main` once #31 merges; the file carries a comment saying exactly that. This PR should not be merged before that is resolved one way or the other.

## Validation

Device-tested on both X3 and X4, across long-hold and double-click wake gestures. X3 checked visually for ghosting after the full-sync change — splash and Home are clean.

Not yet verified: the X4 recovery-mode positive path (the `Recovery firmware mode` log timestamp should read ~640 ms, confirming detection happens while the combo is held), and Back-at-boot skipping reader resume. Both are behaviour that commit 2 touches.

Irreducible and unchanged: the splash waveform itself, 1730 ms on X4 (one pass) and 2303 ms on X3 (three).