### PR TITLE
fix(serialization): bound decoded length of obfuscated credentials

### DIFF
--- a/lib/Serialization/ObfuscationUtils.cpp
+++ b/lib/Serialization/ObfuscationUtils.cpp
@@ -6,6 +6,7 @@
 #include <wolfssl/wolfcrypt/coding.h>
 
 #include <cstring>
+#include <limits>
 
 namespace obfuscation {
 
@@ -46,12 +47,30 @@ String obfuscateToBase64(const std::string& plaintext) {
 }
 
 std::string deobfuscateFromBase64(const char* encoded, bool* ok) {
+  return deobfuscateFromBase64(encoded, std::numeric_limits<size_t>::max(), ok, nullptr);
+}
+
+std::string deobfuscateFromBase64(const char* encoded, const size_t maxDecodedLength, bool* ok, bool* tooLong) {
+  if (tooLong) *tooLong = false;
   if (encoded == nullptr || encoded[0] == '\0') {
     if (ok) *ok = false;
     return "";
   }
   if (ok) *ok = true;
   const size_t encodedLen = strlen(encoded);
+  // Reject oversized input before allocating: a corrupt wifi.json with a multi-KB
+  // blob would otherwise cost ~3/4 of it in contiguous heap. Test the *minimum*
+  // the encoding could decode to (4 encoded chars -> 3 bytes, minus up to 2 bytes
+  // of padding), so a value that would legitimately have fit is never rejected.
+  if (maxDecodedLength != std::numeric_limits<size_t>::max()) {
+    size_t minDecodedLen = (encodedLen / 4) * 3;
+    if (minDecodedLen >= 2) minDecodedLen -= 2;
+    if (minDecodedLen > maxDecodedLength) {
+      if (ok) *ok = false;
+      if (tooLong) *tooLong = true;
+      return "";
+    }
+  }
   // Base64 decodes to at most 3/4 of the input length; +3 for rounding slack.
   word32 decodedLen = static_cast<word32>((encodedLen / 4) * 3 + 3);
   std::string result(decodedLen, '\0');
@@ -63,6 +82,12 @@ std::string deobfuscateFromBase64(const char* encoded, bool* ok) {
     return "";
   }
   result.resize(decodedLen);
+  // The pre-allocation check is on the minimum, so re-check the true length here.
+  if (result.size() > maxDecodedLength) {
+    if (ok) *ok = false;
+    if (tooLong) *tooLong = true;
+    return "";
+  }
   xorTransform(result);
   return result;
 }

--- a/lib/Serialization/ObfuscationUtils.h
+++ b/lib/Serialization/ObfuscationUtils.h
@@ -29,6 +29,12 @@ String obfuscateToBase64(const std::string& plaintext);
 // Returns empty string on invalid base64 input; sets *ok to false if decode fails.
 std::string deobfuscateFromBase64(const char* encoded, bool* ok = nullptr);
 
+// Bounded variant. Rejects input whose decoded form would exceed maxDecodedLength
+// *before* allocating the result buffer, so a corrupt or hand-edited JSON blob
+// cannot make us reserve kilobytes of contiguous heap. Reports that case through
+// tooLong (which also sets *ok to false).
+std::string deobfuscateFromBase64(const char* encoded, size_t maxDecodedLength, bool* ok, bool* tooLong = nullptr);
+
 // Self-test: verifies round-trip obfuscation with hardware key. Logs PASS/FAIL.
 void selfTest();
 

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -18,6 +18,14 @@
 #include "SettingsList.h"
 #include "WifiCredentialStore.h"
 
+namespace {
+// Upper bound on any stored credential we will decode from JSON. A WPA passphrase
+// tops out at 63 characters (or a 64-hex-char PSK); server passwords get the same
+// generous cap. Anything longer is corrupt or hand-edited, and decoding it would
+// cost contiguous heap we can't spare.
+constexpr size_t MAX_PASSWORD_LENGTH = 64;
+}  // namespace
+
 // Convert legacy settings.
 void applyLegacyStatusBarSettings(CrossPointSettings& settings) {
   switch (static_cast<CrossPointSettings::STATUS_BAR_MODE>(settings.statusBar)) {
@@ -311,7 +319,15 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       std::string val;
       if (info.obfuscated) {
         bool ok = false;
-        val = obfuscation::deobfuscateFromBase64(doc[std::string(info.key) + "_obf"] | "", &ok);
+        bool tooLong = false;
+        // The value is about to be truncated into a stringMaxLen buffer anyway, so
+        // anything longer is already garbage — reject it before it costs us heap.
+        val = obfuscation::deobfuscateFromBase64(doc[std::string(info.key) + "_obf"] | "",
+                                                 info.stringMaxLen ? info.stringMaxLen - 1 : 0, &ok, &tooLong);
+        if (tooLong) {
+          LOG_ERR("CPS", "Oversized obfuscated value for key '%s'", info.key);
+          if (needsResave) *needsResave = true;
+        }
         if (!ok || val.empty()) {
           val = doc[info.key] | fieldDefault;
           if (val != fieldDefault && needsResave) *needsResave = true;
@@ -408,10 +424,21 @@ bool JsonSettingsIO::loadKOReader(KOReaderCredentialStore& store, const char* js
 
   store.username = doc["username"] | std::string("");
   bool ok = false;
-  store.password = obfuscation::deobfuscateFromBase64(doc["password_obf"] | "", &ok);
+  bool tooLong = false;
+  store.password = obfuscation::deobfuscateFromBase64(doc["password_obf"] | "", MAX_PASSWORD_LENGTH, &ok, &tooLong);
+  if (tooLong) {
+    LOG_ERR("KRS", "Discarding oversized password for user: %s", store.username.c_str());
+    if (needsResave) *needsResave = true;
+  }
   if (!ok || store.password.empty()) {
     store.password = doc["password"] | std::string("");
-    if (!store.password.empty() && needsResave) *needsResave = true;
+    if (store.password.size() > MAX_PASSWORD_LENGTH) {
+      LOG_ERR("KRS", "Discarding oversized legacy password for user: %s", store.username.c_str());
+      store.password.clear();
+      if (needsResave) *needsResave = true;
+    } else if (!store.password.empty() && needsResave) {
+      *needsResave = true;
+    }
   }
   store.serverUrl = doc["serverUrl"] | std::string("");
   uint8_t method = doc["matchMethod"] | (uint8_t)0;
@@ -509,10 +536,21 @@ bool JsonSettingsIO::loadWifi(WifiCredentialStore& store, const char* json, bool
     WifiCredential cred;
     cred.ssid = obj["ssid"] | std::string("");
     bool ok = false;
-    cred.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &ok);
+    bool tooLong = false;
+    cred.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", MAX_PASSWORD_LENGTH, &ok, &tooLong);
+    if (tooLong) {
+      LOG_ERR("WCS", "Discarding oversized password for %s", cred.ssid.c_str());
+      if (needsResave) *needsResave = true;
+    }
     if (!ok || cred.password.empty()) {
       cred.password = obj["password"] | std::string("");
-      if (!cred.password.empty() && needsResave) *needsResave = true;
+      if (cred.password.size() > MAX_PASSWORD_LENGTH) {
+        LOG_ERR("WCS", "Discarding oversized legacy password for %s", cred.ssid.c_str());
+        cred.password.clear();
+        if (needsResave) *needsResave = true;
+      } else if (!cred.password.empty() && needsResave) {
+        *needsResave = true;
+      }
     }
     const std::string bssidHex = obj["bssid"] | std::string("");
     const int channel = obj["channel"] | 0;
@@ -691,10 +729,21 @@ bool JsonSettingsIO::loadOpds(OpdsServerStore& store, const char* json, bool* ne
     // Try the obfuscated key first; fall back to plaintext "password" for
     // files written before obfuscation was added (or hand-edited JSON).
     bool ok = false;
-    server.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &ok);
+    bool tooLong = false;
+    server.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", MAX_PASSWORD_LENGTH, &ok, &tooLong);
+    if (tooLong) {
+      LOG_ERR("OPS", "Discarding oversized password for server: %s", server.name.c_str());
+      if (needsResave) *needsResave = true;
+    }
     if (!ok || server.password.empty()) {
       server.password = obj["password"] | std::string("");
-      if (!server.password.empty() && needsResave) *needsResave = true;
+      if (server.password.size() > MAX_PASSWORD_LENGTH) {
+        LOG_ERR("OPS", "Discarding oversized legacy password for server: %s", server.name.c_str());
+        server.password.clear();
+        if (needsResave) *needsResave = true;
+      } else if (!server.password.empty() && needsResave) {
+        *needsResave = true;
+      }
     }
     store.servers.push_back(std::move(server));
   }


### PR DESCRIPTION
# Summary

`deobfuscateFromBase64` sized its result buffer straight from the encoded length:

```cpp
word32 decodedLen = static_cast<word32>((encodedLen / 4) * 3 + 3);
std::string result(decodedLen, '\0');
```

A corrupt or hand-edited JSON blob therefore made us allocate ~3/4 of it in contiguous heap before anything was validated. On the C3 contiguous heap is the scarce resource, and all four call sites were exposed: settings strings, KOReader, Wi-Fi, and OPDS.

## Changes

- **`ObfuscationUtils.{h,cpp}`** — new bounded overload taking `maxDecodedLength` + `tooLong`. The rejection happens *before* the allocation, which is the whole point. The existing signature delegates to it with a `size_t` max, so every current caller is behaviourally unchanged.
- **`JsonSettingsIO.cpp`** — all four call sites capped. Settings strings use `info.stringMaxLen - 1` (they are truncated into that buffer anyway); the three password paths use 64 (a WPA passphrase tops out at 63 characters, or a 64-hex-char PSK). Oversized values log and set `needsResave`, so the bad entry gets rewritten on next save.

Two details worth a reviewer's eye:

- The pre-allocation test uses the **minimum** the encoding could decode to (4 chars -> 3 bytes, minus up to 2 padding bytes), so a value that would legitimately have fit is never rejected by the `+3` slack. The true length is then re-checked after decoding.
- The **legacy plaintext fallback** paths are bounded too. Those read an unbounded `doc[password]` straight into a `std::string` — the same exposure by a different route.

## Provenance

Adapted from crosspoint-reader PR [#2834](https://github.com/crosspoint-reader/crosspoint-reader/pull/2834) by @itsthisjustin, credited via `Co-authored-by`.

Only the bounded-decode part of that PR applies here. Deliberately **not** ported:

- The **mutex** and **magic-static `getHwKey()`** fixes address a UI-vs-web-server race that does not exist in this tree — `handleClient()` is called from the activity loop (`CrossPointWebServerActivity.cpp`, `CalibreConnectActivity.cpp`), on the same task as everything touching `WIFI_STORE`. No concurrent access, so the mutex would be RAM and code cost for zero benefit.
- The **`getCredentials()` -> `getCredentialAt()`/`getCredentialSummaries()` refactor** exists upstream only because returning `const&` into a mutex-protected vector is unsound. No mutex, no hazard. Our web server already never emits passwords, only `hasPassword`.
- The **CRC32 + `password_len`** machinery treats a corruption symptom whose cause the upstream PR never establishes — plausibly the race itself, which we do not have. Worth revisiting only if we actually observe corrupted credentials on our hardware.

Upstream is also structurally different here (`PersistableStore<T>` CRTP + mbedtls, vs our free functions in `JsonSettingsIO` + wolfSSL), so this is a reimplementation rather than a cherry-pick.