### PR TITLE
feat: Adaptive tone mapping for inline EPUB images (AA only)

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -311,7 +311,7 @@ void Page::warmImageCaches(GfxRenderer& renderer, const int xOffset, const int y
   for (auto& element : elements) {
     if (element->getTag() == TAG_PageTable) {
       static_cast<const PageTableFragment&>(*element).warmCellImages(renderer, forceLoadLargeImages, monochromeOutput,
-                                                                    alsoWarmGrayscale);
+                                                                     alsoWarmGrayscale);
       continue;
     }
     if (element->getTag() != TAG_PageImage) continue;

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -143,29 +143,36 @@ bool PageTableFragment::hasImages() const {
   return false;
 }
 
-bool PageTableFragment::hasUncachedImages(const bool forceLoad, const bool monochromeOutput) const {
+bool PageTableFragment::hasUncachedImages(const bool forceLoad, const bool monochromeOutput,
+                                          const bool alsoWarmGrayscale) const {
   for (const auto& row : rows) {
     for (const auto& cell : row.cells) {
       if (!cell.image) continue;
       if (cell.image->wouldShowPlaceholder(forceLoad, monochromeOutput)) continue;
       const bool cached = monochromeOutput ? cell.image->hasPixelCache() : cell.image->hasGrayscaleCache();
       if (!cached) return true;
+      if (alsoWarmGrayscale && monochromeOutput && !cell.image->hasGrayscaleCache()) return true;
     }
   }
   return false;
 }
 
-void PageTableFragment::warmCellImages(GfxRenderer& renderer, const bool forceLoad, const bool monochromeOutput) const {
+void PageTableFragment::warmCellImages(GfxRenderer& renderer, const bool forceLoad, const bool monochromeOutput,
+                                       const bool alsoWarmGrayscale) const {
   for (const auto& row : rows) {
     for (const auto& cell : row.cells) {
       if (!cell.image) continue;
       if (cell.image->wouldShowPlaceholder(forceLoad, monochromeOutput)) continue;
       const bool cached = monochromeOutput ? cell.image->hasPixelCache() : cell.image->hasGrayscaleCache();
-      if (cached) continue;
       // The decode is the heap-hungry work; do it now (caller has freed the secondary buffer).
       // The cache is position-independent, so warm at the origin — the framebuffer write is
       // discarded by the caller's clearScreen().
-      cell.image->render(renderer, 0, 0, forceLoad, monochromeOutput);
+      if (!cached) {
+        cell.image->render(renderer, 0, 0, forceLoad, monochromeOutput);
+      }
+      if (alsoWarmGrayscale && monochromeOutput && !cell.image->hasGrayscaleCache()) {
+        cell.image->render(renderer, 0, 0, forceLoad, /*monochromeOutput=*/false);
+      }
     }
   }
 }
@@ -296,14 +303,15 @@ void Page::renderImagesFromGrayscaleCache(GfxRenderer& renderer, const int xOffs
 }
 
 void Page::warmImageCaches(GfxRenderer& renderer, const int xOffset, const int yOffset, const bool forceLoadLargeImages,
-                           const bool monochromeOutput) const {
+                           const bool monochromeOutput, const bool alsoWarmGrayscale) const {
   // Only do the costly decode pass when there's at least one image that would
   // actually require a PNG/JPG decoder allocation. Cached and placeholder paths
   // do not need the contiguous heap headroom, so skipping the iteration entirely
   // saves the no-op overhead on text-only pages (the common case).
   for (auto& element : elements) {
     if (element->getTag() == TAG_PageTable) {
-      static_cast<const PageTableFragment&>(*element).warmCellImages(renderer, forceLoadLargeImages, monochromeOutput);
+      static_cast<const PageTableFragment&>(*element).warmCellImages(renderer, forceLoadLargeImages, monochromeOutput,
+                                                                    alsoWarmGrayscale);
       continue;
     }
     if (element->getTag() != TAG_PageImage) continue;
@@ -311,9 +319,17 @@ void Page::warmImageCaches(GfxRenderer& renderer, const int xOffset, const int y
     if (ib.wouldShowPlaceholder(forceLoadLargeImages, monochromeOutput)) continue;
     // Check whether the appropriate cache already exists
     const bool alreadyCached = monochromeOutput ? ib.hasPixelCache() : ib.hasGrayscaleCache();
-    if (alreadyCached) continue;
-    static_cast<PageImage&>(*element).renderWithForceLoad(renderer, xOffset, yOffset, forceLoadLargeImages,
-                                                          monochromeOutput);
+    if (!alreadyCached) {
+      static_cast<PageImage&>(*element).renderWithForceLoad(renderer, xOffset, yOffset, forceLoadLargeImages,
+                                                            monochromeOutput);
+    }
+    // Second decode for the other variant when AA needs the grayscale planes on top of
+    // the BW frame. Skipped when monochromeOutput is already false — that pass wrote the
+    // grayscale cache itself.
+    if (alsoWarmGrayscale && monochromeOutput && !ib.hasGrayscaleCache()) {
+      static_cast<PageImage&>(*element).renderWithForceLoad(renderer, xOffset, yOffset, forceLoadLargeImages,
+                                                            /*monochromeOutput=*/false);
+    }
   }
 }
 

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -188,8 +188,7 @@ class Page {
   // Used to decide whether to release the secondary frame buffer before warm.
   // alsoWarmGrayscale mirrors warmImageCaches(): a missing .bayer.pxc is decode work too,
   // so it must count here or the secondary buffer stays allocated through that decode.
-  bool hasUncachedImages(bool forceLoadLargeImages, bool monochromeOutput,
-                         bool alsoWarmGrayscale = false) const {
+  bool hasUncachedImages(bool forceLoadLargeImages, bool monochromeOutput, bool alsoWarmGrayscale = false) const {
     return std::any_of(elements.begin(), elements.end(), [&](const std::shared_ptr<PageElement>& el) {
       if (el->getTag() == TAG_PageTable)
         return static_cast<const PageTableFragment&>(*el).hasUncachedImages(forceLoadLargeImages, monochromeOutput,

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -117,11 +117,12 @@ class PageTableFragment final : public PageElement {
 
   // In-cell graphics participate in the Page-level image passes below.
   bool hasImages() const;
-  bool hasUncachedImages(bool forceLoad, bool monochromeOutput) const;
+  bool hasUncachedImages(bool forceLoad, bool monochromeOutput, bool alsoWarmGrayscale = false) const;
   // Decode any missing cell-image pixel caches. Position is irrelevant to the cache
   // (it is position-independent); images are warmed at the origin and the framebuffer
   // garbage is discarded by the caller's clearScreen(), mirroring the Page warm pass.
-  void warmCellImages(GfxRenderer& renderer, bool forceLoad, bool monochromeOutput) const;
+  void warmCellImages(GfxRenderer& renderer, bool forceLoad, bool monochromeOutput,
+                      bool alsoWarmGrayscale = false) const;
 };
 
 class Page {
@@ -164,8 +165,11 @@ class Page {
   // Writes pixels to the framebuffer as a side effect (decoder requirement); callers
   // must clearScreen() afterward if the framebuffer needs to be clean.
   // monochromeOutput selects which cache variant to warm (BW or grayscale).
+  // alsoWarmGrayscale additionally warms the 4-level Bayer cache that the AA grayscale
+  // planes replay on top of the BW frame. Both variants are needed with AA on: the BW
+  // plane draws 1-bit Atkinson, the gray planes lift levels 1/2 back to real greys.
   void warmImageCaches(GfxRenderer& renderer, int xOffset, int yOffset, bool forceLoadLargeImages,
-                       bool monochromeOutput = true) const;
+                       bool monochromeOutput = true, bool alsoWarmGrayscale = false) const;
   bool hasPlaceholderImages(bool forceLoadLargeImages, bool monochromeOutput) const;
   bool allImagesArePlaceholders(bool forceLoadLargeImages, bool monochromeOutput) const;
   bool serialize(FsFile& file) const;
@@ -182,14 +186,19 @@ class Page {
   // Returns true if any image on this page would require a decoder allocation —
   // i.e. is not a placeholder AND does not already have a pixel cache on disk.
   // Used to decide whether to release the secondary frame buffer before warm.
-  bool hasUncachedImages(bool forceLoadLargeImages, bool monochromeOutput) const {
+  // alsoWarmGrayscale mirrors warmImageCaches(): a missing .bayer.pxc is decode work too,
+  // so it must count here or the secondary buffer stays allocated through that decode.
+  bool hasUncachedImages(bool forceLoadLargeImages, bool monochromeOutput,
+                         bool alsoWarmGrayscale = false) const {
     return std::any_of(elements.begin(), elements.end(), [&](const std::shared_ptr<PageElement>& el) {
       if (el->getTag() == TAG_PageTable)
-        return static_cast<const PageTableFragment&>(*el).hasUncachedImages(forceLoadLargeImages, monochromeOutput);
+        return static_cast<const PageTableFragment&>(*el).hasUncachedImages(forceLoadLargeImages, monochromeOutput,
+                                                                            alsoWarmGrayscale);
       if (el->getTag() != TAG_PageImage) return false;
       const auto& ib = static_cast<const PageImage&>(*el).getImageBlock();
       if (ib.wouldShowPlaceholder(forceLoadLargeImages, monochromeOutput)) return false;
-      return !(monochromeOutput ? ib.hasPixelCache() : ib.hasGrayscaleCache());
+      if (!(monochromeOutput ? ib.hasPixelCache() : ib.hasGrayscaleCache())) return true;
+      return alsoWarmGrayscale && monochromeOutput && !ib.hasGrayscaleCache();
     });
   }
 

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -1435,7 +1435,7 @@ std::unique_ptr<Page> Section::loadPageFromActiveBuild(const uint16_t pageIndex)
 }
 
 void Section::warmAllImageCaches(const int xOffset, const int yOffset, const bool forceLoad,
-                                 const bool monochromeOutput) {
+                                 const bool monochromeOutput, const bool alsoWarmGrayscale) {
   if (pageCount == 0) return;
   const int savedPage = currentPage;
   int warmed = 0;
@@ -1443,7 +1443,7 @@ void Section::warmAllImageCaches(const int xOffset, const int yOffset, const boo
     currentPage = p;
     auto page = loadPageFromSectionFile();
     if (!page || !page->hasImages()) continue;
-    page->warmImageCaches(renderer, xOffset, yOffset, forceLoad, monochromeOutput);
+    page->warmImageCaches(renderer, xOffset, yOffset, forceLoad, monochromeOutput, alsoWarmGrayscale);
     ++warmed;
     // Each image decode can take hundreds of ms; reset the WDT between pages
     // to avoid an interrupt watchdog timeout on image-heavy chapters.

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -200,7 +200,10 @@ class Section {
   // that are already cached or would show as a placeholder. The decode writes
   // pixels into the framebuffer as a side effect; call renderer.clearScreen()
   // afterward. forceLoad mirrors the effectiveForceLoad rule used at render time.
-  void warmAllImageCaches(int xOffset, int yOffset, bool forceLoad, bool monochromeOutput = true);
+  // alsoWarmGrayscale additionally decodes the 4-level Bayer variant the AA grayscale
+  // planes replay; see Page::warmImageCaches.
+  void warmAllImageCaches(int xOffset, int yOffset, bool forceLoad, bool monochromeOutput = true,
+                          bool alsoWarmGrayscale = false);
   bool isTruncatedCache() const { return truncatedCache; }
   bool isEmbeddedStyleFallback() const { return embeddedStyleFallback; }
   // True when the last build's CSS resolution hit low-heap skips (styles silently

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -51,20 +51,57 @@ bool ImageBlock::ensureExtracted() const {
 
 bool ImageBlock::imageExists() const { return Storage.exists(imagePath.c_str()); }
 
+namespace image_tone {
+namespace {
+uint8_t g_filterId = 0;
+}
+void setFilterId(const uint8_t filterId) { g_filterId = filterId; }
+uint8_t getFilterId() { return g_filterId; }
+}  // namespace image_tone
+
 namespace {
 
-// BW-plane cache: 1-bit Atkinson, only values 0/3, for AA-off rendering.
-std::string getBwCachePath(const std::string& imagePath) {
+std::string withSuffix(const std::string& imagePath, const std::string& suffix) {
   size_t dot = imagePath.rfind('.');
-  if (dot != std::string::npos) return imagePath.substr(0, dot) + ".1bit.pxc";
-  return imagePath + ".1bit.pxc";
+  if (dot != std::string::npos) return imagePath.substr(0, dot) + suffix;
+  return imagePath + suffix;
 }
 
+// BW-plane cache: 1-bit Atkinson, only values 0/3, for AA-off rendering.
+// Deliberately NOT keyed by the tone filter: tone mapping is applied only to the
+// grayscale variant (see ImageBlock::render), so these pixels are identical whatever
+// the filter is set to. Keying them too would fork every BW cache on SD for nothing.
+std::string getBwCachePath(const std::string& imagePath) { return withSuffix(imagePath, ".1bit.pxc"); }
+
 // Grayscale cache: 4-level Bayer (0–3), replayed in GRAYSCALE_LSB/MSB passes when AA is on.
+// Tone mapping IS baked into these pixels, so the filter id keys the name: switching the
+// setting must not replay pixels levelled for the old filter, and keying by name means
+// both variants survive a switch back (no invalidation hook needed). Filter 0 keeps the
+// historical unsuffixed name so existing caches stay valid.
 std::string getGrayscaleCachePath(const std::string& imagePath) {
-  size_t dot = imagePath.rfind('.');
-  if (dot != std::string::npos) return imagePath.substr(0, dot) + ".bayer.pxc";
-  return imagePath + ".bayer.pxc";
+  const uint8_t filterId = image_tone::getFilterId();
+  const std::string toneSuffix = filterId == 0 ? std::string() : ".f" + std::to_string(filterId);
+  return withSuffix(imagePath, toneSuffix + ".bayer.pxc");
+}
+
+// Derive adaptive tone points for one image. Both analyzers return inactive points on
+// any failure (low heap, unsupported coding mode, read error), which makes the tone
+// curve an identity — a failed analysis degrades to the untoned image, never to no image.
+// GIF has no analyzer and stays untoned.
+adaptive_tone::Points analyzeImageTone(const std::string& imagePath) {
+  std::string ext;
+  const size_t dot = imagePath.rfind('.');
+  if (dot != std::string::npos) {
+    ext = imagePath.substr(dot);
+    for (auto& c : ext) c = tolower(c);
+  }
+  if (JpegToFramebufferConverter::supportsFormat(ext)) {
+    return JpegToFramebufferConverter::analyzeAdaptiveTone(imagePath);
+  }
+  if (PngToFramebufferConverter::supportsFormat(ext)) {
+    return PngToFramebufferConverter::analyzeAdaptiveTone(imagePath);
+  }
+  return {};
 }
 
 // srcYOffset: first source row to render (0 = top of image).
@@ -130,12 +167,13 @@ bool renderFromCache(GfxRenderer& renderer, const std::string& cachePath, int x,
     }
   }
 
-  // Read several rows per SD access. A full-page image is re-rendered on every
-  // grayscale strip pass (~14x per page), and a one-row-per-read loop here means
-  // hundreds of tiny reads through the storage mutex + SdFat each time — the
-  // dominant cost of displaying an image page. Batching rows into a ~4KB buffer
+  // Read several rows per SD access. A full-page image is replayed from cache up to
+  // 3x per page with AA on (BW plane + both grayscale planes), and a one-row-per-read
+  // loop here means hundreds of tiny reads through the storage mutex + SdFat each time —
+  // the dominant cost of displaying an image page. Batching rows into a ~4KB buffer
   // cuts that down dramatically without holding the whole image.
-  // (Ported from upstream commit d9bcef7a, crosspoint-reader#2230.)
+  // (Ported from upstream commit d9bcef7a, crosspoint-reader#2230, when the multi-strip
+  // grayscale passes made this ~14x; the strips are gone but the batching still pays.)
   int rowsPerRead = 4096 / bytesPerRow;
   if (rowsPerRead < 1) rowsPerRead = 1;
   if (rowsPerRead > rowsToRender) rowsPerRead = rowsToRender;
@@ -176,8 +214,9 @@ bool renderFromCache(GfxRenderer& renderer, const std::string& cachePath, int x,
 
     const int destY = y + row;
     pw.beginRow(destY);
-    // On a grayscale strip pass only a narrow column window of the image is in
-    // the active band; skip the rest instead of unpacking+clipping every pixel.
+    // Column window for the active write target. The strip-based grayscale passes are
+    // gone (isStripActive() is hardcoded false), so this is the full image width today
+    // and the range doubles as a bounds guard.
     int colStart, colEnd;
     pw.bandColRange(x, cachedWidth, colStart, colEnd);
     for (int col = colStart; col < colEnd; col++) {
@@ -322,6 +361,15 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y, const b
   config.performanceMode = false;
   config.useExactDimensions = true;
   config.cachePath = cachePath;
+
+  // Adaptive tone applies only to the 4-level grayscale variant. On the BW plane the
+  // output is just 0/3, so a level stretch mostly shifts where the Atkinson threshold
+  // falls rather than adding information — and it would desync the BW frame from the
+  // grey planes layered on top of it. Only reached on a cache miss, so the analysis
+  // decode is paid once per image and amortized by the .pxc.
+  if (!monochromeOutput && image_tone::getFilterId() != 0) {
+    config.adaptiveTone = analyzeImageTone(imagePath);
+  }
 
   ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(imagePath);
   if (!decoder) {

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <HalStorage.h>
+#include <stdint.h>
 
 #include <memory>
 #include <string>
@@ -10,6 +11,19 @@
 // as a placeholder until the user explicitly requests it.
 // 800x600 covers most full-page illustrations that take >1s to dither on ESP32.
 static constexpr int32_t LARGE_IMAGE_PIXEL_THRESHOLD = 800 * 600;
+
+// Tone mapping for inline images. Set once from src/ (which owns the settings) before a
+// render pass; lib/Epub must not read settings itself. Applies to every ImageBlock: the
+// filter is a global display preference, not per-image state, and threading it through
+// every cache-query and warm signature would touch a dozen call sites to carry a constant.
+//
+// filterId keys the pixel caches, because tone mapping is baked into the cached pixels —
+// see the cache-path helpers in ImageBlock.cpp. 0 means "no filter" and keeps the
+// historical unsuffixed cache names.
+namespace image_tone {
+void setFilterId(uint8_t filterId);
+uint8_t getFilterId();
+}  // namespace image_tone
 
 class ImageBlock final : public Block {
  public:

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -1,5 +1,6 @@
 #include "JpegToFramebufferConverter.h"
 
+#include <AdaptiveTone.h>
 #include <BitmapHelpers.h>
 #include <CooperativeAbort.h>
 #include <FsHelpers.h>
@@ -74,6 +75,12 @@ struct JpegContext {
   PixelCache cache;
   bool caching{false};
 
+  // Adaptive-tone analysis pre-pass only (see analyzeAdaptiveTone): when histogram is
+  // non-null the decode writes no pixels and just tallies luminance. Never set on a
+  // real render.
+  uint32_t* histogram{nullptr};
+  uint64_t histogramSamples{0};
+
   // See PngContext for the rationale: monochromeOutput requests a 1-bit Atkinson dither
   // emitting only 0/3 so the BW DirectPixelWriter (`pixelValue < 3` rule) maps cleanly.
   int oneBitDitherRow{-1};
@@ -139,6 +146,11 @@ void prepareDitherRow(JpegContext& ctx, int dstY) {
 }
 
 uint8_t ditherGray(JpegContext& ctx, uint8_t gray, int localX, int outX, int outY) {
+  // Level-correct before dithering, so the ditherer sees the stretched range.
+  // Identity when the caller supplied no points. Applied here rather than at the
+  // sample sites because both the banded and non-banded emit paths funnel through
+  // this function — see flushDitherBand and emitGrayBlock's sinkPixel.
+  if (ctx.config) gray = adaptive_tone::apply(ctx.config->adaptiveTone, gray);
   if (ctx.atkinson1BitDitherer) {
     return ctx.atkinson1BitDitherer->processPixel(gray, localX) ? 3 : 0;
   }
@@ -168,6 +180,8 @@ uint8_t ditherGray(JpegContext& ctx, uint8_t gray, int localX, int outX, int out
 }
 #else
 uint8_t ditherGray(JpegContext& ctx, uint8_t gray, int localX, int outX, int outY) {
+  // See the extension-enabled variant above: one tone-mapping seam for both emit paths.
+  if (ctx.config) gray = adaptive_tone::apply(ctx.config->adaptiveTone, gray);
   if (ctx.atkinson1BitDitherer) {
     return ctx.atkinson1BitDitherer->processPixel(gray, localX) ? 3 : 0;
   }
@@ -712,6 +726,21 @@ int tjpgOutput(JDEC* jd, void* bitmap, JRECT* rect) {
   return emitGrayBlock(*ctx, static_cast<const uint8_t*>(bitmap), rect->left, rect->top, validW, blockH, validW);
 }
 
+// TJpgDec output callback for the adaptive-tone pre-pass: tally luminance, write nothing.
+// Feeds the WDT like the real decode does — even at 1/8 scale a large image is many blocks.
+int tjpgHistogramOutput(JDEC* jd, void* bitmap, JRECT* rect) {
+  JpegContext* ctx = static_cast<TJpgSession*>(jd->device)->ctx;
+  if (!ctx || !ctx->histogram) return 0;
+  const int validW = rect->right - rect->left + 1;
+  const int blockH = rect->bottom - rect->top + 1;
+  const auto* px = static_cast<const uint8_t*>(bitmap);
+  const size_t count = static_cast<size_t>(validW) * static_cast<size_t>(blockH);
+  for (size_t i = 0; i < count; i++) ctx->histogram[px[i]]++;
+  ctx->histogramSamples += count;
+  esp_task_wdt_reset();
+  return 1;
+}
+
 bool progressiveOutput(void* user, uint16_t y, const uint8_t* grayscale, uint16_t width) {
   auto* ctx = static_cast<JpegContext*>(user);
   if (!ctx || width != ctx->dstWidth || y >= ctx->dstHeight) return false;
@@ -856,6 +885,62 @@ bool JpegToFramebufferConverter::getDimensionsStatic(const std::string& imagePat
   }
   LOG_DBG("JPG", "Image dimensions: %dx%d", out.width, out.height);
   return true;
+}
+
+adaptive_tone::Points JpegToFramebufferConverter::analyzeAdaptiveTone(const std::string& imagePath) {
+  adaptive_tone::Points points;  // inactive by default — identity tone curve
+
+  // Only baseline JPEGs go through TJpgDec. The progressive path reconstructs a DC-only
+  // preview whose sample distribution is not the real image, so analysing it would derive
+  // the wrong points; leave those untoned.
+  JpegMode mode = JpegMode::Baseline;
+  if (!getModeFromHeader(imagePath, mode) || mode != JpegMode::Baseline) {
+    return points;
+  }
+
+  const size_t freeHeap = ESP.getFreeHeap();
+  if (freeHeap < MIN_FREE_HEAP_FOR_JPEG) {
+    LOG_DBG("JPG", "Skipping adaptive tone analysis, low heap (%u free)", static_cast<unsigned>(freeHeap));
+    return points;
+  }
+
+  FsFile file;
+  if (!Storage.openFileForRead("JPG", imagePath, file)) {
+    return points;
+  }
+
+  auto pool = makeUniqueNoThrow<uint8_t[]>(TJPG_WORK_POOL_SIZE);
+  auto histogram = makeUniqueNoThrow<uint32_t[]>(256);
+  if (!pool || !histogram) {
+    file.close();
+    return points;
+  }
+  for (int i = 0; i < 256; i++) histogram[i] = 0;
+
+  // The histogram only needs the tonal distribution, not resolution: decode at TJpgDec's
+  // coarsest DCT scale (1/8) so this pre-pass costs ~1/64 of the samples of a real decode.
+  // This is the shortcut PNG cannot take, which is why its analysis is a full extra decode.
+  JpegContext histCtx;
+  histCtx.histogram = histogram.get();
+  TJpgSession session{&file, &histCtx};
+  JDEC jdec{};
+  if (jd_prepare(&jdec, tjpgInput, pool.get(), TJPG_WORK_POOL_SIZE, &session) != JDR_OK) {
+    file.close();
+    return points;
+  }
+  const JRESULT jr = jd_decomp(&jdec, tjpgHistogramOutput, 3 /* 1/8 scale */);
+  file.close();
+  if (jr != JDR_OK) {
+    LOG_DBG("JPG", "Adaptive tone analysis decode failed (jr=%d): %s", jr, imagePath.c_str());
+    return points;
+  }
+
+  if (histCtx.histogramSamples == 0) return points;
+  points = adaptive_tone::derivePoints(histogram.get(), histCtx.histogramSamples);
+  LOG_DBG("JPG", "Adaptive tone: active=%d black=%u white=%u (%llu samples): %s", points.active ? 1 : 0,
+          points.blackPoint, points.whitePoint, static_cast<unsigned long long>(histCtx.histogramSamples),
+          imagePath.c_str());
+  return points;
 }
 
 bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath, GfxRenderer& renderer,

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.h
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.h
@@ -30,6 +30,14 @@ class JpegToFramebufferConverter final : public ImageToFramebufferDecoder {
   static bool getDimensionsFromZipEntryStreaming(const std::string& epubPath, const std::string& entryPath,
                                                  ImageDimensions& out, JpegMode* outMode = nullptr);
 
+  // Derive adaptive tone points by histogramming the image. Unlike the PNG equivalent this
+  // is cheap: the pre-pass runs at TJpgDec's 1/8 DCT scale, so it decodes ~1/64 of the
+  // samples of a full render. Returns inactive points on any failure (unsupported mode, low
+  // heap, read error), which makes the tone curve an identity — never a hard failure.
+  // Call once and reuse across render passes; the result must be shared so every pass
+  // quantizes against the same black/white points.
+  static adaptive_tone::Points analyzeAdaptiveTone(const std::string& imagePath);
+
   bool decodeToFramebuffer(const std::string& imagePath, GfxRenderer& renderer, const RenderConfig& config) override;
 
   bool getDimensions(const std::string& imagePath, ImageDimensions& dims) const override {

--- a/lib/GfxRenderer/AdaptiveTone.h
+++ b/lib/GfxRenderer/AdaptiveTone.h
@@ -41,6 +41,29 @@ inline constexpr int HIGHLIGHT_FLOOR = 242;
 // Sample every Nth row where the source allows skipping (see the note above).
 inline constexpr int ROW_STEP = 4;
 
+// --- Line-art rejection ------------------------------------------------------
+// The MIN_RANGE guard above is a percentile spread, so it does NOT catch line art:
+// a pure black-on-white drawing puts the 1st percentile at 0 and the 99th at 255,
+// a spread of 255, and sails through. But such an image has no tones to stretch --
+// every pixel is already ink or paper -- so the correction only moves the dither
+// threshold around and can thicken or break up strokes.
+//
+// The distinguishing property is not how many levels are occupied but WHERE the mass
+// sits: line art puts nearly every pixel at the two extremes and leaves the middle
+// empty. Measuring that directly is robust to two things a distinct-level count gets
+// wrong -- JPEG ringing around hard edges (which smears ink and paper across dozens of
+// near-black/near-white bins, so bilevel art can touch 50+ levels), and smooth tonal
+// artwork like pencil shading (where a real ramp spreads so thinly that no single
+// level looks individually significant).
+//
+// Bins within this distance of 0/255 count as ink/paper rather than tone.
+inline constexpr int EXTREME_MARGIN = 24;
+// Minimum share of pixels that must fall between those end zones for the image to be
+// treated as tonal. Measured against synthetic distributions: bilevel and screentone
+// art land at 0-42 permille, while diagrams with flat fills, engravings, pencil
+// shading and photographs all sit at 173 permille or above.
+inline constexpr uint32_t MIN_MIDTONE_PERMILLE = 60;
+
 // Black/white points derived from a luminance histogram. `active` is false when the
 // analysis declined -- too narrow a range, or the caller never ran it -- in which
 // case apply() is the identity and the caller's existing renderer is untouched.
@@ -57,6 +80,15 @@ struct Points {
 inline Points derivePoints(const uint32_t* histogram, uint64_t sampleCount) {
   Points points;
   if (!histogram || sampleCount == 0) return points;
+
+  // Line-art / bilevel rejection -- see the constants above. Runs before the
+  // percentile search because that search cannot tell an ink-and-paper drawing
+  // (0 and 255, spread 255) from a photograph using the full range.
+  uint64_t midtoneCount = 0;
+  for (int i = EXTREME_MARGIN; i <= 255 - EXTREME_MARGIN; i++) {
+    midtoneCount += histogram[i];
+  }
+  if ((midtoneCount * 1000u) / sampleCount < MIN_MIDTONE_PERMILLE) return points;
 
   const uint64_t lowTarget = (sampleCount * LOW_PERCENTILE_PERMILLE + 999u) / 1000u;
   const uint64_t highTarget = (sampleCount * HIGH_PERCENTILE_PERMILLE + 999u) / 1000u;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2812,7 +2812,11 @@ EpubReaderActivity::BuildOutcome EpubReaderActivity::compileSectionCache(const R
   if (createOk && released) {
     const bool indexForceLoad = forceLoadLargeImages || !SETTINGS.largeImagePlaceholder;
     const uint32_t warmStart = millis();
-    section->warmAllImageCaches(0, 0, indexForceLoad, /*monochromeOutput=*/true);
+    // Warm the AA grayscale variant here too: this is the released-buffer path, the point of
+    // maximum contiguous heap. Skipping it would push that decode into renderContents' own warm
+    // pass on the first image page, where headroom is worse.
+    section->warmAllImageCaches(0, 0, indexForceLoad, /*monochromeOutput=*/true,
+                                /*alsoWarmGrayscale=*/getEffectiveTextAntiAliasing());
     LOG_INF("ERS", "warmAllImageCaches done in %ums (free=%lu)", millis() - warmStart, esp_get_free_heap_size());
     renderer.clearScreen();
     checkHeapIntegrity("after_warmAllImageCaches");
@@ -3530,8 +3534,16 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   }
   lastRenderStats.textAntiAliasing = aaEnabledForThisRender;
 
-  // Always use 1-bit Atkinson dither for images in the epub reader.
+  // The BW plane always uses 1-bit Atkinson dither. 4-level Bayer values would collapse
+  // to black here (DirectPixelWriter draws BW for any value < 3), which is what made the
+  // earlier "always Bayer" attempt look wrong.
   const bool imageMonochrome = true;
+  // With AA on, the grayscale planes replay a 4-level Bayer cache on top of that BW frame
+  // to lift levels 1 and 2 back to real greys. That replay needs its own .bayer.pxc, so
+  // warm both variants. If the grayscale pass is preempted or aborted (decided later, at
+  // aaPreempted below), the 1-bit BW frame is what stays on the panel — the same output
+  // as with AA off, never a crushed-to-black image.
+  const bool warmGrayscaleImageCache = aaEnabledForThisRender;
 
   // Warm any missing image pixel caches BEFORE font prewarm and BW backup chunks
   // reduce heap contig below the ~49 KB the PNG decoder needs. The decode
@@ -3554,13 +3566,14 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   // bail on RenderLock::peek(), and this whole pass runs under the lock the render task took
   // before calling renderContents()) — this flag is a second, explicit guard against that
   // invariant silently breaking if a future change adds a yield point in here.
-  imageProcessingActive_ = page->hasUncachedImages(warmForceLoad, imageMonochrome);
+  imageProcessingActive_ = page->hasUncachedImages(warmForceLoad, imageMonochrome, warmGrayscaleImageCache);
   if (imageProcessingActive_ && renderer.hasSecondaryBuffer()) {
     renderer.releaseSecondaryBuffer();
     releasedSecondaryForWarm = true;
     LOG_DBG("ERS", "Released secondary buffer for image warm pass");
   }
-  page->warmImageCaches(renderer, orientedMarginLeft, contentTop, warmForceLoad, imageMonochrome);
+  page->warmImageCaches(renderer, orientedMarginLeft, contentTop, warmForceLoad, imageMonochrome,
+                        warmGrayscaleImageCache);
   // Image decode (JPEG/PNG) is the deepest, most heap-hungry work in a render pass
   // and the prime suspect for the lazy multi_heap poisoning assert. Check here, right
   // after the warm/decode pass, so corruption is attributed to the decode rather than

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -19,6 +19,7 @@
 
 #include <Epub/FootnotePreviews.h>
 #include <Epub/Page.h>
+#include <Epub/blocks/ImageBlock.h>
 #include <Epub/blocks/TextBlock.h>
 #include <FontCacheManager.h>
 #include <FontDecompressor.h>
@@ -333,6 +334,19 @@ void EpubReaderActivity::onEnter() {
   // syncRedRamFromFrameBuffer(). If the previous activity set a HALF_REFRESH override via
   // enforceExitFullRefresh(), consumeRefreshOverride() will honour it on the first display call.
   pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
+
+  // Publish the image tone filter for lib/Epub, which must not read settings itself.
+  // Set here rather than per-render so every path that derives a pixel-cache name agrees
+  // (renderContents, the section-index warm pass, the pre-reboot warm). Reuses the sleep
+  // screen's filter setting rather than adding a second one: it is the same tone curve,
+  // and a separate inline-image toggle is display surface the reader does not need.
+  //
+  // Only ADAPTIVE_TONE carries over. The other values are sleep-screen compositing modes
+  // (Contrast picks the BW plane, Inverted flips the whole screen) with no meaning for an
+  // image sitting inside a page of text.
+  const bool adaptiveToneImages =
+      SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::ADAPTIVE_TONE;
+  image_tone::setFilterId(adaptiveToneImages ? CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::ADAPTIVE_TONE : 0);
 
   // Drop any input events that arrived from the activity that launched us (e.g. a wake-up power
   // button hold) before they reach the page-turn handling — see ReaderUtils::InputDrainGuard.


### PR DESCRIPTION
Extends the sleep screen's adaptive tone curve to images inside books, and fixes the grayscale image path it depends on.

## Background

The reader's AA grayscale planes have always called `renderImagesFromGrayscaleCache`, but nothing ever wrote the `.bayer.pxc` it replays — every reader call site passes `monochromeOutput=true`, so only the 1-bit Atkinson cache existed and the replay silently no-opped on a missing file. Inline images therefore rendered 1-bit regardless of the AA setting.

That was the result of an earlier attempt (`061d9209`, reverted by `1176db59` with *"4-level Bayer collapses too many grey levels to black"*). The revert was right about the symptom but the cause was elsewhere: the same commit had deleted the gray-plane replay, so Bayer values were written and then only drawn in the BW pass, where `DirectPixelWriter` draws black for any value `< 3` — crushing levels 0, 1 and 2. This PR restores the missing half rather than repeating the attempt.

## Commits

**1. Render inline images in grayscale when AA is on** — warms both cache variants. The BW plane keeps its 1-bit Atkinson dither; the grayscale planes layer on top and lift levels 1 and 2 back to real greys.

**2. Adaptive tone mapping for inline images** — grayscale variant only, both PNG and JPEG.

**3. Skip adaptive tone for line art** — see below.

## Design notes

**Only the grayscale variant is toned.** On the BW plane the output is just 0/3, so a level stretch mostly shifts where the Atkinson threshold falls rather than adding information, and it would desync the BW frame from the grey planes drawn over it.

**No fallback code was needed for preemption.** `aaPreempted` is computed *after* the BW render, and every preempt/abort path leaves the BW frame on the panel because only `displayGrayBuffer()` runs the gray waveform. A preempted page therefore looks exactly like AA-off — the 1-bit cache is the natural resting state, not a special case.

**JPEG's tone line sits at the head of `ditherGray`** (both extension variants). That is the one seam both the banded and non-banded emit paths funnel through; applying it at the sample sites would miss the banded path.

**JPEG analysis is ~64x cheaper than PNG's.** A histogram needs the tonal distribution, not resolution, so it decodes at TJpgDec's 1/8 DCT scale reusing the same 12 KB pool. PNG can neither rewind nor subsample and still pays a full extra decode. Both run only on a cache miss, so the `.pxc` amortizes either way, and both return inactive points on any failure — a failed analysis degrades to the untoned image, never to no image.

**Only the grayscale cache is keyed by filter id** (`.f<id>.bayer.pxc`), since only those pixels have tone baked in. Keying the BW cache too would fork every `.1bit.pxc` on SD into an identical copy under a new name.

**No new setting.** Reuses `sleepScreenCoverFilter` — same tone curve, already user-visible. Only `ADAPTIVE_TONE` carries over; the other values are sleep-screen compositing modes with no meaning for an image inside a page of text. The id is published to `lib/Epub` from `onEnter` rather than read there, since `lib/Epub` must not touch settings.

## Line-art rejection

`MIN_RANGE` is a percentile spread, so it never caught bilevel images: black-on-white line art puts the 1st percentile at 0 and the 99th at 255 and passes straight through — but has no tones to stretch.

Rejecting by **midtone mass** (share of pixels between the ink and paper end zones) measures the property that actually distinguishes line art. A distinct-level count was tried first and is wrong twice: JPEG ringing smears ink and paper across 50+ bins, and smooth pencil shading spreads a real ramp so thinly that no individual level looks significant.

Checked against synthetic distributions — line art and screentone land at 0–42‰, every tonal case (diagrams, engravings, pencil shading, photographs at three exposures) at 173‰ or above. The 60‰ threshold falls in empty space. Degenerate inputs (blank page, solid grey) skip safely.

This lives in the shared `derivePoints`, so it applies to the sleep screen too. Intentional — a bilevel sleep image gains nothing either — but note a cover that is essentially line art will now skip a correction it previously received.

## Costs

- A second decode per image and a second `.pxc` on SD, for books read with AA on.
- Two extra cache replays per image page (1 → 3). On X4 one overlaps the BW waveform; on X3 both are additive on the input-blocking loop task.

## Testing

- Builds clean on `default` and `gh_release`.
- Line-art classifier verified against the real header across 11 synthetic distributions.
- Cover rendering reported as visibly improved on device.

## Not covered

- **Inline figures are unvalidated on device.** The classifier is verified against synthetic histograms, which shows it separates cleanly on plausible shapes — not that real EPUB figures land where modeled. A figure-heavy book is the real test.
- The pre-reboot heap-recovery warm still warms 1-bit only; it runs with both framebuffers freed on the way to a restart, which is no place for a second decode.
- GIF has no analyzer and stays untoned.
