### PR TITLE
perf(wake): let the page consume the X3's mandatory post-wake full sync

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -62,6 +62,7 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "util/ScreenshotUtil.h"
+#include "util/WakeTrace.h"
 
 // Defined further down (near the other font helpers); declared here because
 // buildRenderParams() above it needs the ladder.
@@ -318,6 +319,7 @@ int getImageOnlyPageYOffset(const Page& page, const int viewportHeight) {
 void EpubReaderActivity::onEnter() {
   Activity::onEnter();
   logReaderMemSnapshot("onEnter_begin");
+  WakeTrace::mark(WakeTrace::Phase::ActivityEnter);
   // Bisect anchor: corruption already present HERE means the writer ran before the
   // reader (Home sidecar JPEG conversion / thumb generation are prime suspects — see
   // the long-standing "heap may be corrupt after image decode failures" note below).
@@ -406,6 +408,9 @@ void EpubReaderActivity::onEnter() {
     }
   }
   logReaderMemSnapshot("onEnter_after_progress_load");
+  // Covers setupCacheDir + the image manifest + progress.bin + the sync/bookmark overlays —
+  // i.e. everything needed to know WHICH page to show, before anything is read to show it.
+  WakeTrace::mark(WakeTrace::Phase::ProgressLoaded);
 
   // Load bookmarks for this book
   bookmarkStore.load(epub->getCachePath());
@@ -445,6 +450,9 @@ void EpubReaderActivity::onEnter() {
   // accumulate going forward.
   globalReadingSessionTracker().begin(KOReaderDocumentId::calculateFromFilename(epub->getPath()), epub->getTitle(),
                                       epub->getAuthor());
+  // Bookmarks + recent-books overrides + the stats session. These are the loads a wake
+  // shortcut would most plausibly skip or cache in RTC, so they get their own bucket.
+  WakeTrace::mark(WakeTrace::Phase::StoresLoaded);
 
   // Trigger first update
   logReaderMemSnapshot("onEnter_before_request_update");
@@ -2921,6 +2929,10 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
   const bool cacheHit = !resumeBackgroundBuild && section->loadSectionFile(probeParams);
   const bool cssFallbackRebuild = cacheHit && section->isEmbeddedStyleFallback();
   const bool needBuild = resumeBackgroundBuild || !cacheHit || cssFallbackRebuild;
+  // The decisive fact for wake-latency work: a probe that hits means the section cost is a
+  // LUT read, a miss means a full rebuild sits between the wake and the page. Recorded as
+  // "was a build needed", not the raw probe result, so a CSS-fallback rebuild counts as a miss.
+  WakeTrace::setSectionCacheHit(!needBuild);
 
   // One grep-able line per section entry tying the cache decision to the effective
   // preview inputs — discriminates "stale variant loaded" from "effective value not
@@ -3373,6 +3385,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   // Classify the pass, then consume the pre-render flags.
   const RenderPass pass = classifyRenderPass();
+  // First render() to get this far after a book open. Re-marking on later renders is harmless:
+  // the summary is emitted at the first visible page and ignores everything after it.
+  WakeTrace::mark(WakeTrace::Phase::RenderStart);
   pendingPreRender = false;
   usePreRenderedBuffer = false;
   // Any other pass redraws the write framebuffer and flushes/swaps, destroying pre-rendered
@@ -3406,6 +3421,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       if (!buildSection(layout)) {
         return;
       }
+      WakeTrace::mark(WakeTrace::Phase::SectionReady);
       // Flush any image dimensions this build just resolved (foreground path).
       epub->persistImageManifest();
       renderNormalPass(lock, layout);
@@ -3807,6 +3823,13 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   // on X3, conditioning passes, flag updates). SPI ownership transfers back
   // to this task only after completeDisplay() returns.
   renderer.completeDisplay();
+  // Close the wake trace only now. triggerDisplay() returns once the content is COMMITTED, not
+  // once the pixels have settled — on X3 the first post-wake refresh is a mandatory full sync
+  // whose three waveform passes run after it returns. Stamping at the trigger understated the
+  // measured wake by ~2.1 s (trace said 858 ms while the page landed at ~2.4 s), which is
+  // exactly the number this trace exists to get right.
+  WakeTrace::mark(WakeTrace::Phase::PageVisible);
+  WakeTrace::logSummary();
 }
 
 void EpubReaderActivity::displayBuildPage(RenderLock& lock, const Page& page, const RenderLayout& layout) {
@@ -3842,6 +3865,12 @@ void EpubReaderActivity::displayBuildPage(RenderLock& lock, const Page& page, co
   // uses for Background-A.
   lock.unlock();
   renderer.completeDisplay();
+  // On a cache miss this mid-build page is what the user actually sees first, well before the
+  // build completes and renderNormalPass() runs — so the trace has to close here or a miss
+  // would report a wake latency that includes the whole rest of the build. After
+  // completeDisplay() for the same reason as renderContents(): the pixels are settled here.
+  WakeTrace::mark(WakeTrace::Phase::PageVisible);
+  WakeTrace::logSummary();
 }
 
 void EpubReaderActivity::renderPageContentOnly(const Page& page, const int orientedMarginTop,
@@ -3917,6 +3946,12 @@ void EpubReaderActivity::displayPreRenderedPage(const Page& page, const int orie
   } else {
     ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
   }
+  // A pre-rendered page can be the first one a book open puts on screen (Background-A having
+  // won the race), so this path closes the trace too. Correct to stamp here without a
+  // completeDisplay(): unlike renderContents()'s trigger/complete split, displayBuffer() is
+  // the blocking variant and has already waited out the waveform by this line.
+  WakeTrace::mark(WakeTrace::Phase::PageVisible);
+  WakeTrace::logSummary();
   // Capture before the AA replay below overwrites the renderer's last-mode (see renderContents).
   lastPageRefreshMode_ = renderer.getLastRefreshMode();
   lastPageDisplayModeByte_ = renderer.getLastDisplayModeByte();

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -26,6 +26,7 @@
 #include "activities/util/FullScreenMessageActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+#include "util/WakeTrace.h"
 
 #ifndef DEBUG_MEMORY_CONSUMPTION
 #define DEBUG_MEMORY_CONSUMPTION 0
@@ -680,6 +681,9 @@ void ReaderActivity::onGoToMdReader(std::unique_ptr<Txt> txt) {
 void ReaderActivity::onEnter() {
   Activity::onEnter();
   logReaderLaunchMemSnapshot("onEnter_begin");
+  // Start the wake-to-page trace. Whether this open is a deep-sleep resume was latched by
+  // setup() (WakeTrace::armResume) rather than read from APP_STATE here — see armResume().
+  WakeTrace::begin();
 
   if (initialBookPath.empty()) {
     goToLibrary();  // Start from root when entering via Browse
@@ -786,6 +790,9 @@ void ReaderActivity::onEnter() {
       onGoBack();
       return;
     }
+    // Stamped after every load path above (warm cache, first-open index build, and the
+    // drop-and-reload retry) so `book` is the true cost of getting a usable Epub.
+    WakeTrace::mark(WakeTrace::Phase::BookLoaded);
     onGoToEpubReader(std::move(epub));
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@
 #include "images/LoadingIcon.h"
 #include "util/ButtonNavigator.h"
 #include "util/ScreenshotUtil.h"
+#include "util/WakeTrace.h"
 
 #ifdef ENABLE_BOOT_HEAP_DIAGNOSTICS
 #include <BootHeapProbe.h>
@@ -182,6 +183,11 @@ enum class BootResume : uint8_t {
   Splash,       // cold boot, flash, panic, or plain reboot
   Silent,       // heap-defrag ESP.restart() (RTC flag; lost on power loss)
   QuickResume,  // wake from a quick-resume deep sleep (SD flag; survives power loss)
+  // Wake from a plain deep sleep that is heading straight back into the reader. Distinct from
+  // QuickResume because it paints NOTHING at boot: the X3's one mandatory post-begin() full
+  // sync (~2.3 s) is reserved for the page itself rather than spent on an interstitial. There
+  // is no saved frame on this path — enterDeepSleep() only persists one for Quick Resume.
+  ReaderResume,
 };
 
 // Latched true once enterDeepSleep() commits to sleeping, before it tears down
@@ -280,11 +286,19 @@ void disarmSerialTransferReboot() {
   }
 }
 
-// ---- Quick Resume framebuffer persistence ----
+// ---- Retained-frame persistence across deep sleep ----
 //
-// Quick Resume keeps the last reader page on screen during deep sleep (just overlaid with a moon
-// icon) and skips the boot screen on wake by restoring the saved framebuffer + a loading icon.
-// The buffer is persisted to SD only when the user actually enabled the feature.
+// Deep sleep loses the framebuffer (and the SDK's previous-frame copy) with the power domain, so
+// anything the wake path wants to composite onto must be persisted to SD first.
+//
+// Only Quick Resume saves one. It keeps the last reader page on screen during deep sleep (just
+// overlaid with a moon icon) and restores that frame on wake, so reading resumes with no visible
+// boot at all — the user is looking at their own page for the whole load.
+//
+// A plain reader resume deliberately saves NOTHING, because painting a restored frame would
+// consume the X3's one mandatory post-wake full sync on an interstitial and push the page behind
+// a second refresh (see enterDeepSleep). The presence of this file is therefore also what setup()
+// uses to tell the two resume flows apart.
 constexpr char SLEEP_FRAME_FILE[] = "/.crosspoint/sleep_frame.bin";
 
 static void saveSleepFrameBuffer() {
@@ -465,7 +479,26 @@ void enterDeepSleep(bool fromTimeout = false) {
       SETTINGS.sleepScreen == CrossPointSettings::SLEEP_SCREEN_MODE::QUICK_RESUME ||
       (fromTimeout &&
        SETTINGS.quickResumeSleepScreen == CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT);
-  APP_STATE.showBootScreen = !isQuickResumeSleep;
+  // Sleeping from a book with a book still open means the next boot's destination is already
+  // known: setup() will route straight back into the reader. Paint NOTHING before that page.
+  //
+  // The reason is specific to the panel, not to taste. After begin() the X3 driver arms exactly
+  // one mandatory full sync (Uc8253X3Driver: _initialFullSyncsRemaining = 1) — the controller's
+  // DTM1 baseline was wiped to white by the power-down, so the first refresh must drive every
+  // pixel whatever mode it asks for. Measured on X3: ~2.3 s. Whichever frame paints first
+  // consumes it, and everything after it is a cheap differential.
+  //
+  // So an intermediate frame is not "a cheap extra refresh" — it spends the single expensive
+  // sync on a throwaway image and forces the page to pay a second refresh on top. Both the boot
+  // splash and a loading-icon-over-sleep-screen do exactly that (measured: wake 4.8 s, of which
+  // 2.4 s was the intermediate paint). Skipping straight to the page lets the page itself
+  // consume the mandatory sync, removing a whole refresh from the wake.
+  //
+  // The trade-off, deliberately taken: for the ~700 ms the book takes to open there is no
+  // on-screen acknowledgement of the wake press. The panel is not blank — it still physically
+  // holds the sleep screen — so this reads as "not woken yet" rather than as a fault.
+  const bool resumeIntoReader = APP_STATE.lastSleepFromReader && !APP_STATE.openEpubPath.empty();
+  APP_STATE.showBootScreen = !(isQuickResumeSleep || resumeIntoReader);
 
   APP_STATE.saveToFile();
   // Tear down WiFi so the modem power domain isn't held alive across deep sleep.
@@ -480,7 +513,11 @@ void enterDeepSleep(bool fromTimeout = false) {
   deepSleepInProgress = true;
   activityManager.goToSleep(fromTimeout);
 
-  // Persist the moon-icon-overlaid framebuffer after goToSleep() has painted it.
+  // Persist the moon-icon-overlaid framebuffer after goToSleep() has painted it. Quick Resume
+  // only: it restores this frame and paints a loading icon over it, which is worth the mandatory
+  // full sync because the restored frame IS the reader page — the user is looking at their book
+  // for the whole load, not at an interstitial. A plain reader resume saves nothing and paints
+  // nothing, so the page gets that sync instead (see showBootScreen above).
   if (isQuickResumeSleep) {
     saveSleepFrameBuffer();
   }
@@ -860,9 +897,16 @@ void setup() {
   // skips the panel-clearing pass and the X3 initial-full-sync arming (see
   // HalDisplay::begin), so the first paint is FAST_REFRESH (~500ms) over the
   // retained frame and input dispatches against a visible UI.
-  const BootResume resume = isSilentReboot              ? BootResume::Silent
-                            : !APP_STATE.showBootScreen ? BootResume::QuickResume
-                                                        : BootResume::Splash;
+  //
+  // Both suppressed-splash flows set showBootScreen=false, so the saved frame is what tells
+  // them apart: enterDeepSleep() persists one only for Quick Resume. Present means "restore it
+  // and paint the loading icon"; absent means a plain reader resume, which paints nothing at
+  // boot so the page gets the X3's one mandatory full sync (see BootResume::ReaderResume).
+  const bool haveSleepFrame = !APP_STATE.showBootScreen && Storage.exists(SLEEP_FRAME_FILE);
+  const BootResume resume = isSilentReboot             ? BootResume::Silent
+                            : APP_STATE.showBootScreen ? BootResume::Splash
+                            : haveSleepFrame           ? BootResume::QuickResume
+                                                       : BootResume::ReaderResume;
 
   // Booting straight into the USB serial-transfer activity? Skip SD-font
   // discovery (only built-in UI fonts are used there) to shorten the reboot the
@@ -888,13 +932,22 @@ void setup() {
       APP_STATE.showBootScreen = true;
       APP_STATE.saveToFile();
       if (loadSleepFrameBuffer()) {
-        // Frame restored: swap the sleep moon for the loading icon.
+        // Frame restored: swap the sleep moon for the loading icon. Worth the mandatory full
+        // sync here because the restored frame IS the reader page — the user reads their book
+        // while it loads rather than watching an interstitial.
         const auto pageHeight = renderer.getScreenHeight();
         renderer.drawImage(LoadingIcon, 0, pageHeight - LOADINGICON_HEIGHT, LOADINGICON_WIDTH, LOADINGICON_HEIGHT);
         renderer.displayBuffer(HalDisplay::HALF_REFRESH);
       } else {
         activityManager.goToBoot();  // frame file missing, fall back to the splash
       }
+      break;
+    case BootResume::ReaderResume:
+      // Deliberately paints nothing: the panel keeps physically showing the sleep screen until
+      // the reader's own first render lands, so the X3's single mandatory full sync is spent on
+      // the page instead of an interstitial. Still re-arms the splash for the next plain boot.
+      APP_STATE.showBootScreen = true;
+      APP_STATE.saveToFile();
       break;
     case BootResume::Splash:
       activityManager.goToBoot();
@@ -950,6 +1003,10 @@ void setup() {
     APP_STATE.openEpubPath = "";
     APP_STATE.readerActivityLoadCount++;
     APP_STATE.saveToFile();
+    // This is the wake-straight-back-into-the-book branch: tell the wake trace that the open
+    // it is about to see is a resume, so its summary line separates resume cost from the cost
+    // of an ordinary library open.
+    WakeTrace::armResume();
     activityManager.goToReader(path);
   }
 

--- a/src/util/WakeTrace.cpp
+++ b/src/util/WakeTrace.cpp
@@ -1,0 +1,109 @@
+#include "WakeTrace.h"
+
+#include <Arduino.h>
+#include <Logging.h>
+#include <stdio.h>
+
+namespace WakeTrace {
+namespace {
+
+uint16_t phaseMs[static_cast<uint8_t>(Phase::Count)] = {};
+// A stamp of 0 is a legal millis() value, so "was this phase reached" cannot be inferred
+// from the stamp itself — same reasoning as bootPhaseReached in main.cpp.
+uint16_t phaseReached = 0;
+bool traceFromWake = false;
+bool resumeArmed = false;
+bool sectionCacheHit = false;
+bool sectionCacheHitKnown = false;
+bool summaryEmitted = true;  // seeded true so a stray logSummary() before begin() is a no-op
+
+// Short labels so the whole trace fits one 256-byte ring-buffer entry (Logging.cpp).
+constexpr const char* PHASE_NAMES[] = {"rdr", "book", "act", "prog", "store", "rend", "sect", "page"};
+static_assert(sizeof(PHASE_NAMES) / sizeof(PHASE_NAMES[0]) == static_cast<size_t>(Phase::Count),
+              "PHASE_NAMES must stay in sync with Phase");
+
+}  // namespace
+
+void armResume() { resumeArmed = true; }
+
+void begin() {
+  for (uint8_t i = 0; i < static_cast<uint8_t>(Phase::Count); i++) {
+    phaseMs[i] = 0;
+  }
+  phaseReached = 0;
+  // Consume the one-shot: only the first book open after a wake is the resume. Any later open
+  // in the same session (user backed out to the library and picked another book) is a plain open.
+  traceFromWake = resumeArmed;
+  resumeArmed = false;
+  sectionCacheHit = false;
+  sectionCacheHitKnown = false;
+  summaryEmitted = false;
+  mark(Phase::ReaderEnter);
+}
+
+void mark(Phase phase) {
+  const uint8_t index = static_cast<uint8_t>(phase);
+  const uint16_t bit = static_cast<uint16_t>(1u << index);
+  // First write wins. Every phase here is a once-per-open milestone, but several of the call
+  // sites run repeatedly within one open (render() is re-entered for the pre-render pass, the
+  // section-building pass, and periodic status-bar updates). Letting a later call overwrite the
+  // stamp would silently retime the phase to whenever the LAST such render happened and make
+  // every preceding delta meaningless. begin() clears the mask, so the next open re-stamps.
+  if (phaseReached & bit) {
+    return;
+  }
+  const unsigned long ms = millis();
+  phaseMs[index] = static_cast<uint16_t>(ms > UINT16_MAX ? UINT16_MAX : ms);
+  phaseReached |= bit;
+}
+
+void setSectionCacheHit(bool hit) {
+  sectionCacheHit = hit;
+  sectionCacheHitKnown = true;
+}
+
+void logSummary() {
+  if (summaryEmitted) {
+    return;
+  }
+  summaryEmitted = true;
+
+  // Deltas rather than absolutes: the cost of a phase is the actionable figure, and the
+  // absolutes are just their running sum. The first delta is measured against the reader
+  // entry, so `rdr` itself prints as an absolute — it is the handoff point from the boot
+  // trace, and lining the two up is the whole reason this trace exists.
+  char line[160];
+  size_t used = 0;
+  uint16_t previous = 0;
+  for (uint8_t i = 0; i < static_cast<uint8_t>(Phase::Count); i++) {
+    if ((phaseReached & (1u << i)) == 0) continue;
+    const int written = snprintf(line + used, sizeof(line) - used, "%s%s+%u", used ? " " : "", PHASE_NAMES[i],
+                                 static_cast<unsigned>(phaseMs[i] - previous));
+    if (written < 0 || static_cast<size_t>(written) >= sizeof(line) - used) break;
+    used += static_cast<size_t>(written);
+    previous = phaseMs[i];
+  }
+
+  const uint8_t readerIndex = static_cast<uint8_t>(Phase::ReaderEnter);
+  const uint8_t pageIndex = static_cast<uint8_t>(Phase::PageVisible);
+  const bool hasPage = (phaseReached & (1u << pageIndex)) != 0;
+  // open = reader entry to first visible page (the cost this trace exists to attribute).
+  // page = absolute millis() at first paint, so it can be read against the boot trace's
+  // `logo=`/`setup=` numbers without adding anything up by hand.
+  const unsigned open = hasPage ? static_cast<unsigned>(phaseMs[pageIndex] - phaseMs[readerIndex]) : 0;
+
+  // `section=` distinguishes the three outcomes that need different fixes:
+  //   cached    the section LUT was reusable — wake cost is elsewhere (boot path, stores, render)
+  //   rebuilt   a full section build sat between the wake and the page
+  //   building  the build was still running when the first page was drawn from its partial LUT,
+  //             i.e. Background-C already hides the rebuild and `open` understates the real cost
+  const char* sectionState = "n/a";
+  if (sectionCacheHitKnown) {
+    const bool sectionFinished = (phaseReached & (1u << static_cast<uint8_t>(Phase::SectionReady))) != 0;
+    sectionState = sectionCacheHit ? "cached" : (sectionFinished ? "rebuilt" : "building");
+  }
+  LOG_INF("WAKE", "%s phase cost ms: %s | open=%u page=%u section=%s", traceFromWake ? "resume" : "open", line, open,
+          hasPage ? phaseMs[pageIndex] : 0, sectionState);
+}
+
+}  // namespace WakeTrace

--- a/src/util/WakeTrace.h
+++ b/src/util/WakeTrace.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <stdint.h>
+
+// --- Wake-to-page trace -------------------------------------------------------------
+// Answers one question: when the device wakes from deep sleep straight back into a book,
+// where does the time between the wake gesture and the page appearing actually go?
+//
+// The existing boot trace (main.cpp, BootPhase) stops at `route` — the moment the reader
+// activity is entered. On a reader wake that is precisely where the expensive part begins:
+// Epub::load() reads book.bin, EpubReaderActivity::onEnter() reads progress.bin/bookmarks/
+// recent-books, and the first render() either hits the section cache or rebuilds it. All of
+// that is invisible in the boot trace, which is why "is wake latency dominated by the boot
+// path or by the book open?" could not be answered without guessing.
+//
+// This trace continues past `route` with the same design as logBootTrace(): a fixed array
+// of millis() stamps, a reached-mask (0 is a legal stamp), and one summary line emitted when
+// the first page is on the panel. Stamps are absolute millis() so they share a time origin
+// with the boot trace and the two lines can be read as one timeline.
+//
+// Cost: 2 bytes per phase of .bss plus one log line per reader open. No heap, no allocation.
+// Always compiled in — unlike DEBUG_MEMORY_CONSUMPTION this is a handful of stores on a path
+// that runs once per book open, and the whole point is to have the number available from a
+// field device (`CMD:BOOTLOG`-style) rather than only from an instrumented build.
+namespace WakeTrace {
+
+enum class Phase : uint8_t {
+  ReaderEnter,     // ReaderActivity::onEnter — book path known, format dispatch about to run
+  BookLoaded,      // Epub/Txt/Xtc load() returned (book.bin read, or first-open index built)
+  ActivityEnter,   // EpubReaderActivity::onEnter begins (the Epub is now owned by the reader)
+  ProgressLoaded,  // progress.bin read + pending sync/bookmark overlays applied
+  StoresLoaded,    // bookmarks, recent-books overrides, reading-stats session
+  RenderStart,     // first render() reached the pass dispatcher
+  SectionReady,    // section cache loaded (hit) or rebuilt (miss) — see setSectionCacheHit()
+  // First page SETTLED on the panel — after the waveform, not merely after the content was
+  // handed to the driver. The distinction is not academic on X3: the first refresh after a wake
+  // is a mandatory full sync whose waveform passes run after triggerDisplay() returns, so
+  // stamping at the trigger understated a measured wake by ~2.1 s. The trace is emitted here.
+  PageVisible,
+  Count,
+};
+
+// Stamp a phase with the current millis(). Re-stamping a phase overwrites it; the reader is
+// re-entered on orientation changes and setting edits, so `begin()` resets the whole trace
+// rather than letting a second open interleave with the first.
+void mark(Phase phase);
+
+// Arm the "this open is a deep-sleep resume" flag. Called from setup() on the one branch that
+// routes a wake straight back into the book. It is a ONE-SHOT consumed by the next begin():
+// APP_STATE.lastSleepFromReader cannot serve this purpose because nothing clears it during a
+// session, so a library open later in the same session would still read as a resume.
+void armResume();
+
+// Clear all stamps and start a fresh trace. Called from ReaderActivity::onEnter, which is the
+// single funnel for every book open (library, recent books, and the wake resume alike).
+void begin();
+
+// Records how the section was obtained, which is the single most important bit for deciding
+// whether a wake shortcut is worth building: a cache hit means the time is elsewhere, a miss
+// means the section rebuild dominates and no amount of boot-path trimming will help.
+void setSectionCacheHit(bool hit);
+
+// Emit the summary line. Called once, when the first page is on the panel. Safe to call
+// again (subsequent calls are ignored until the next begin()) so the several render paths
+// that can produce the first visible page need no coordination between them.
+void logSummary();
+
+}  // namespace WakeTrace


### PR DESCRIPTION
## Problem

Waking from a book straight back into the reader painted an interstitial first (the boot splash), then the page. On X3 that costs a whole extra full refresh.

After `begin()` the UC8253 driver arms exactly one mandatory full sync (`Uc8253X3Driver.cpp`, `_initialFullSyncsRemaining = 1`). The controller's DTM1 baseline is wiped to white by the power-down, so the first refresh has to drive every pixel whatever mode it asks for — measured **~2.3 s on X3**. Whichever frame paints first consumes it; everything after is a cheap differential.

The splash was spending that sync on a logo and pushing the page behind a second refresh. The driver source already calls this out:

> *"On a consumer that boots into a splash that is measurable: the splash consumed sync #1 and the first real screen still paid sync #2, so a FAST refresh that costs 435 ms once warm cost 2989 ms."*

## Change

On a reader resume the destination is already known at sleep time, so paint nothing at boot and let the page itself take the mandatory sync. New `BootResume::ReaderResume` state, distinct from `QuickResume`.

**Quick Resume is unchanged.** It still restores the saved page frame and overlays the loading icon — that earns the sync, because the restored frame *is* the book, so the user reads their own page while it loads rather than watching an interstitial. The two flows are told apart by whether a sleep frame was persisted (only Quick Resume saves one).

## Measured (X3, warm cache, USB-attached)

| | before | after |
|---|---|---|
| boot phase `paint` | 2420 ms | **25 ms** |
| `logo` | 3888 ms | **1502 ms** |
| `setup` | 4477 ms | **2087 ms** |
| page settled on panel | ~5246 ms | **~4742 ms** |

Wall-clock saving is **~500 ms**, not the ~2.4 s the boot phases suggest — the sync was *relocated* onto the page, not removed. What's actually saved is the duplicated second refresh. It's also one fewer full-panel refresh per wake, which is battery as well as latency.

`ser+502` in these traces is the USB-CDC wait and won't exist on battery.

## Trade-off

For the ~850 ms the book takes to open there is no on-screen acknowledgement of the wake press. The panel is **not blank** — it still physically holds the sleep screen — so this reads as "not woken yet" rather than as a fault.

If the book fails to resume (Back held, load-count guard, empty path), routing falls through to `goHome()`, which paints normally, so the panel can't get stranded showing the sleep screen. Verified by reading the routing, not on hardware.

## Also: a WAKE trace

The existing BOOT trace stops at `route` — exactly where the expensive part of a reader wake begins. This adds a `WAKE` line covering reader-entry → first page settled:

```
[WAKE] resume phase cost ms: rdr+1746 book+131 act+222 prog+27 store+135 rend+1 sect+48 page+294 | open=858 page=2604 section=cached
```

Attributes latency across book load, progress/store reads, section probe and render, and records whether the section was `cached`, `rebuilt`, or still `building`. Same design as `logBootTrace()`: fixed array, reached-mask, one log line, ~16 bytes of .bss, no heap.

Two details worth knowing:

- **`PageVisible` is stamped after `completeDisplay()`, not `triggerDisplay()`.** The trigger returns once content is *committed*; on X3 the waveform passes run after it. Stamping at the trigger understated a measured wake by ~2.1 s.
- **Resume vs. open is latched in `setup()`**, not read from `APP_STATE.lastSleepFromReader` in the reader — nothing clears that flag during a session, so a library open later in the same session would have been mislabelled as a resume.

This trace is what disproved my first plan for this work (caching stores/overrides in RTC, skipping SD-font discovery): those total ~330 ms of a 4.8 s wake, while one refresh was 2.4 s. Worth keeping for the next round.

## Testing

- Builds clean (`pio run -e default`).
- Flashed on X3; traces above are from that device. Page renders correctly with no ghosting — the mandatory sync drives every pixel from the white DTM1 baseline.
- **Not tested on X4.** X4 uses host-managed RED RAM and has a real FAST path, so its wake profile may differ entirely; the change is safe there (it only suppresses a paint) but the benefit is unmeasured.
- Quick Resume path exercised unchanged.

## Not included

The `freeink-sdk` submodule pointer is modified in my working tree (M5 Paper Mono support) but pre-dates this work and is deliberately left out of this branch.
