### PR TITLE
fix(footnotes): never record "no footnotes" as an answer the book cannot undo

### DIFF
--- a/lib/Epub/Epub/FootnotePreviews.cpp
+++ b/lib/Epub/Epub/FootnotePreviews.cpp
@@ -339,6 +339,7 @@ bool gather(Epub& epub, const std::function<void(int)>& progressFn) {
   ZipFile zip(epub.getPath());
 
   // Pass A: collect footnote-shaped link targets from every spine document.
+  int spinesScanned = 0;
   std::vector<Target> targets;
   targets.reserve(64);  // typical books have dozens of notes; grows to MAX_ENTRIES worst case
   for (int i = 0; i < spineCount; ++i) {
@@ -350,8 +351,20 @@ bool gather(Epub& epub, const std::function<void(int)>& progressFn) {
     if (!streamSpineEntry(zip, epub.getSpineItem(i).href, chunk.get(), scanner)) {
       LOG_ERR("FNP", "Failed to stream spine %d for link scan", i);
       // Unreadable entry: skip it; other chapters' notes still gather.
+    } else {
+      ++spinesScanned;
     }
     if (progressFn) progressFn((i + 1) * 60 / spineCount);
+  }
+
+  // Every spine failed to open — almost certainly transient heap exhaustion (the ZIP reader
+  // could not even get its 4 KB EOCD buffer), not a book without notes. Writing a cache here
+  // would record "0 previews" as a permanent, authoritative answer: cacheExists() would report
+  // ready on every later open, so the book's footnotes would stay dead until someone deleted
+  // the cache directory. Fail instead, so the caller can retry when there is memory again.
+  if (spineCount > 0 && spinesScanned == 0) {
+    LOG_ERR("FNP", "No spine could be read (0/%d); not writing a cache", spineCount);
+    return false;
   }
 
   // Pass B: capture the note text at each wanted anchor, one stream per target spine,

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -162,6 +162,16 @@ constexpr uint32_t PRE_RENDER_MIN_FREE_HEAP_BYTES = 44 * 1024;
 // the CSS resolver needs above the LEAN floor it drops to in arena mode. These floors cover that
 // remainder with reserve, and are reachable from the ~57 KB reading steady state — which the
 // heap-backed floors above are not, on either device.
+// Free heap the deferred footnote gather needs before it will start. It opens the ZIP once per
+// spine and each open takes a 4 KB contiguous EOCD buffer plus a 1 KB stream chunk; starting it
+// without room does not merely fail, it produces a cache that records "no footnotes" for the book
+// permanently (see gatherFootnotesIfBuildNeedsThem). Sized well above that so it declines and
+// retries rather than limping.
+#ifndef FOOTNOTE_GATHER_MIN_FREE_HEAP_BYTES
+#define FOOTNOTE_GATHER_MIN_FREE_HEAP_BYTES (48 * 1024)
+#endif
+constexpr uint32_t FOOTNOTE_GATHER_MIN_FREE_HEAP_BYTES_V = FOOTNOTE_GATHER_MIN_FREE_HEAP_BYTES;
+
 #ifndef BG_BUILD_BORROW_MIN_FREE_HEAP_BYTES
 #define BG_BUILD_BORROW_MIN_FREE_HEAP_BYTES (40 * 1024)
 #endif
@@ -2502,6 +2512,25 @@ bool EpubReaderActivity::gatherFootnotesIfBuildNeedsThem(const Section* target) 
   // one 583991-byte spine) would otherwise lay out the entire novel, render, and only then
   // discover it must do all of it again. Polled between build slices, so the work discarded is
   // whatever came before the first footnote link — typically a page or two.
+  // The gather is heap-hungry in its own right: it opens the ZIP and streams every spine, and
+  // each open needs a 4 KB contiguous EOCD buffer. Mid-build with the framebuffer lent out is
+  // the thinnest the heap ever gets, i.e. the worst possible moment to start it.
+  //
+  // Device-observed on alice: the trigger fired while Background-B held the borrow, all 15
+  // spines failed with "Failed to allocate EOCD scan buffer (4096 bytes)", and the gather then
+  // wrote a cache recording ZERO previews. That file is authoritative — cacheExists() reports
+  // ready on every subsequent open — so the book's footnotes would have stayed dead until
+  // someone deleted the cache directory by hand.
+  //
+  // Deliberately does NOT set the attempted latch when it declines: this is "not now", not
+  // "never". The next build slice re-asks, by which time the borrow is usually back.
+  if (!renderer.hasSecondaryBuffer() || secondaryBorrowed_) {
+    return false;
+  }
+  if (esp_get_free_heap_size() < FOOTNOTE_GATHER_MIN_FREE_HEAP_BYTES_V) {
+    return false;
+  }
+
   footnotePreviewGatherAttempted_ = true;
   LOG_INF("ERS", "Build for spine %d hit a footnote before previews were gathered; gathering now", currentSpineIndex);
   if (!ensureFootnotePreviewCache()) {


### PR DESCRIPTION
A cache that records a **negative** result must prove it actually looked. This one didn't.

## The bug

The deferred footnote gather (PR #124) is triggered from inside a section build. A build holds the borrowed framebuffer, so that is the thinnest the heap ever gets — and the gather is itself heap-hungry: it opens the ZIP once per spine, and each open needs a 4 KB *contiguous* EOCD buffer.

Device-observed on X3, alice-illustrated:

```
[30980] Build for spine 0 hit a footnote before previews were gathered; gathering now
[31432] [ERR] [ZIP] Failed to allocate EOCD scan buffer (4096 bytes)     ← ×15, every spine
[31601] [INF] [FNP] Gathered 0 footnote previews (0 link targets, 0 note files) in 179ms
```

Not one spine could be opened — and `gather()` wrote a cache anyway.

That file is authoritative. `cacheExists()` reports ready on every subsequent open, so the book's footnotes were dead **permanently**, surviving reboots, until someone deleted the cache directory by hand. And it is indistinguishable from the truthful result for a book that simply has no notes, so nothing would ever have flagged it.

## Two fixes, because either alone leaves the hole open

1. **`gather()` counts the spines it actually read** and returns false without writing anything when that count is zero on a non-empty book. A total read failure is transient heap exhaustion, not a finding, and must never be persisted as one.
2. **The trigger declines** while the framebuffer is lent out or free heap is below `FOOTNOTE_GATHER_MIN_FREE_HEAP_BYTES`, and deliberately does **not** set the attempted latch when it declines — "not now", not "never".

## Known gap, deliberately not fixed here

Fix (2) makes the build-path trigger inert in practice: it is only polled from inside a build slice, and a build always holds the borrow, so the guard is never satisfied. Previews still gather via the render-time backstop, so **correctness holds**, but the giant-spine case that motivated the build-path trigger (Small Gods is one 583991-byte spine) is not currently served.

The fix is to poll `Section::sawFootnote()` — already latched for exactly this purpose — after a build completes and the buffer is returned. Left out to keep this change minimal and reviewable; it is recorded in the commit message so it does not get lost.

## Verification

Device, X3, alice-illustrated with a cleared cache:

- no `Failed to allocate EOCD scan buffer`, no `[FNP] Gathered` line, no cache written (`variant=0` throughout)
- `contig` holds **40948 → 36852 → 32756** across both spine builds; the poisoned run went 40948 → 25588 → **13300**, so that heap damage was downstream of the failed gather rather than independent
- `lowHeapSkips` 9 (was 213), `Min Free` 40032, pre-render working

418/418 host tests pass; device build clean.

## Note for anyone who ran the previous build

If a book was opened while that build was flashed, its `footnotes.bin` may be the poisoned empty one — deleting it (or the book's cache directory) clears it. New books are unaffected.
