### PR TITLE
feat(web): load web-UI plugins from the SD card

### DIFF
--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -1,0 +1,181 @@
+# SD-card web plugins
+
+A plugin is a folder on the SD card holding a `plugin.js`. The web server lists
+it, the Settings or File Manager page loads it, and the script renders into a
+card on that page. Adding or changing a plugin never needs a firmware build.
+
+> **Provenance.** This system is ported from
+> [crosspoint-reader#2734](https://github.com/crosspoint-reader/crosspoint-reader/pull/2734)
+> ("feat: Add browser-side plugin system with SD card support") by Justin
+> Mitchell ([@itsthisjustin](https://github.com/itsthisjustin)). The folder
+> layout, the `/api/plugins` and `/plugin` contract, the `registerPlugin`
+> handshake and the `mount` convention are his design, and are kept compatible
+> so a plugin written for either firmware works on both. This port deliberately
+> carries none of that branch's device-capability endpoints, on-device catalog
+> screens or content-protection work — see [Trust](#trust) for why.
+
+Plugins extend the **web interface**, not the reader. Nothing runs on the
+device: the firmware only enumerates the folders and serves their bytes, and the
+script executes in the browser of whoever opened the page. Cost on the device is
+one directory scan per page load and no resident RAM.
+
+## Layout
+
+```
+<root>/<name>/
+    plugin.js       the plugin (required - a folder without one is not listed)
+    manifest.json   optional: { "title": "...", "mount": "settings" | "files" }
+    ...assets       optional, served flat via api.pluginFile()
+```
+
+`<root>` is any of `/.crosspoint/plugins`, `/plugins`, or `/.plugins`. All three
+are scanned; on a name collision the earliest in that order wins. The two
+dot-free roots exist because a dot-prefixed folder is awkward to create in some
+desktop file managers.
+
+**Clear Cache does not remove plugins**, including from `/.crosspoint/plugins`.
+That action is an allowlist: it deletes only the `epub_`/`xtc_`/`txt_` per-book
+cache directories and leaves everything else in `/.crosspoint` alone. Note
+though that `/plugins` is a normal visible folder, so unlike the two dot-prefixed
+roots it can be deleted through the web file manager like any other.
+
+Folders are flat. The server rejects any `name` or `file` containing `/`, `\`,
+or `..`, so a plugin cannot ship subdirectories or read outside its own folder.
+
+## Writing one
+
+`plugin.js` calls `registerPlugin` at top level with a render function:
+
+```js
+CrossPoint.registerPlugin((container, api) => {
+  container.innerHTML = '<h2>' + api.title + '</h2><button id="go">Scan</button>';
+  container.querySelector('#go').onclick = async () => {
+    const files = await (await fetch('/api/files?path=/Books')).json();
+    // ...inspect, then POST to /move, /mkdir, /delete as needed
+  };
+});
+```
+
+The plugin is handed an empty `<div class="card">` and owns all of it, heading
+included — the firmware renders no chrome of its own, so a plugin that draws no
+heading shows an untitled card.
+
+`api` carries three things:
+
+| Field | Description |
+|---|---|
+| `name` | the folder name |
+| `title` | `manifest.json`'s title, falling back to `name` — use it if you want the heading to track the manifest rather than hardcoding it |
+| `pluginFile(filename)` | URL for another file in this plugin's folder |
+
+Everything else is the web server's own
+same-origin API — a plugin uses `fetch()` against the endpoints in
+[webserver-endpoints.md](webserver-endpoints.md) exactly as the pages do:
+`/api/files`, `/mkdir`, `/move`, `/rename`, `/delete`, `/upload`, `/download`.
+The File Manager page also has JSZip already loaded, so a plugin mounted there
+can open and rewrite an EPUB in the browser.
+
+That set is deliberate. There is **no** device endpoint for outbound HTTP,
+crypto, or arbitrary file writes: a plugin can reach the SD card through the
+same doors the web UI already opens, and it cannot make the reader talk to the
+internet. Anything needing a remote service must be done by the browser
+directly, subject to normal CORS rules.
+
+### Mount points
+
+| `mount` | Page | Suits |
+|---|---|---|
+| `settings` (default) | Settings | configuration, one-off maintenance actions |
+| `files` | File Manager | anything operating on the library; JSZip available |
+
+### Conventions
+
+**Declare nothing at top level.** Plugins are `<script>` tags in the shared page,
+so a top-level `function escapeHtml()` collides with the page and with every
+other plugin, last one wins. Keep all state and helpers inside the
+`registerPlugin` closure, as the bundled plugins do.
+
+**Request one thing at a time.** The device serves a single connection, so
+concurrent `fetch()` calls only queue - and a burst can stall a response long
+enough to trip the firmware watchdog. `await` in a loop.
+
+**Move a book's sidecars with it.** The firmware resolves a cover as `book.jpg`
+(or `.jpeg`/`.png`/`.bmp`) beside `book.epub` and prefers it over the embedded
+cover, so a plugin that relocates a book and leaves those behind silently breaks
+its cover. `book.opf` travels with it for the same reason - see below.
+
+### The `book.opf` metadata sidecar
+
+Calibre writes an OPF beside each exported book. Where `book.opf` sits next to
+`book.epub`, treat it as authoritative for that book's metadata: it is a few KB
+against a multi-megabyte download, so reading it instead of the book is the
+difference between a library organising instantly and one grinding through
+every file. `organize-by-author` prefers it and falls back to the book's own
+OPF, reporting which it used per book.
+
+Prefer `opf:file-as` over the element text when deriving a folder name - that is
+the sortable form, and what Calibre's own author folders use.
+
+This mirrors the existing cover-sidecar rule, and the same priority applies:
+sidecar wins over what is embedded in the book. Note the firmware itself does
+not read `book.opf` today; this is a convention between plugins for now.
+
+## Bundled plugins
+
+`plugins/` in this repository. Copy a folder onto the card to install it; they
+are never compiled, so they cost no flash.
+
+| Plugin | Mount | What it does |
+|---|---|---|
+| `hello-plugin` | settings | Minimal reference and smoke test - renders a card and lists `/` |
+| `find-duplicates` | files | Reports files sharing an exact size. Report only: never writes, and never downloads a book |
+| `organize-by-author` | files | Sorts loose EPUBs into `<Author>/` folders. Preview first, moves only on Apply, carries sidecars along |
+
+## Loading order and failures
+
+Plugins load **last** on a page, strictly one at a time. The device serves one
+HTTP connection at a time, so a plugin fetching in parallel with the page's own
+loaders can stall a response long enough to trip the firmware watchdog — which
+is also why a plugin should not fire concurrent requests of its own.
+
+A plugin that fails to load, or that never calls `registerPlugin`, renders an
+error in its own card and does not affect the rest of the page or the other
+plugins.
+
+## Trust
+
+A plugin is unsandboxed JavaScript running with the page's full authority: it
+can read, rewrite, and delete anything on the SD card the web UI can reach.
+Installing one is equivalent to running a script on your library — only use
+plugins you would trust with the card. This is inherent to the design, not a
+gap to be closed: the plugin is code you chose to copy onto your own card.
+
+Note also that the web server has no authentication of its own, so it should
+only be enabled on networks you trust — that is true with or without plugins.
+
+## Limits
+
+- `manifest.json` is read with a 4KB cap; a larger file is ignored (the plugin
+  still loads, falling back to its folder name and the `settings` mount).
+- An unparseable manifest is logged (`[WEB]`) and ignored the same way.
+- A plugin whose listing entry would exceed 384 bytes of JSON is skipped —
+  in practice this means keeping `title` short.
+- At most 64 directories are examined per root. The scan runs inside one
+  request and each candidate costs two SD stats, so an unbounded walk over a
+  folder holding hundreds of subdirectories could outlast the task watchdog.
+  Hitting the bound logs to serial (`[PLG]`) and ignores the remainder — which
+  is why a plugins root should be a dedicated folder, not a general-purpose one.
+- `/api/plugins` and `/plugin` return 503 with `Retry-After` when the heap is
+  too fragmented to serve them, like the other allocating endpoints.
+- The scan reports the folders it finds; there is no install or update
+  mechanism. Copy a folder onto the card and reload the page.
+
+## Debugging
+
+1. Copy the folder to `/.crosspoint/plugins/<name>/` on the card.
+2. Open Settings (or the File Manager) and check the card appears.
+3. `GET /api/plugins` shows exactly what the firmware discovered — if a plugin
+   is missing from that list, the folder has no `plugin.js` or a same-named
+   folder in an earlier root shadowed it.
+4. Script errors surface in the browser console, not on the device. Watch
+   serial (`[WEB]`) only for manifest and file-serving problems.

--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -261,6 +261,64 @@ Deleted successfully
 
 ---
 
+## Plugin Endpoints
+
+Discovery and file serving for SD-card web plugins. The firmware only enumerates
+plugin folders and serves their bytes — plugin code runs in the browser. See
+[sd-plugins.md](sd-plugins.md) for the folder layout and the JS contract.
+
+### GET `/api/plugins` - List Plugins
+
+Scans `/.crosspoint/plugins`, `/plugins`, and `/.plugins` and returns every
+folder holding a `plugin.js`.
+
+**Request:**
+```bash
+curl http://crosspoint.local/api/plugins
+```
+
+**Response (200 OK):**
+```json
+[{"name":"organize-by-author","title":"Organize by Author","mount":"files"}]
+```
+
+| Field   | Description                                                              |
+| ------- | ------------------------------------------------------------------------ |
+| `name`  | Folder name; the value to pass to `/plugin`                              |
+| `title` | From `manifest.json`, falling back to `name`                             |
+| `mount` | `settings` (default) or `files` — which page loads the plugin            |
+
+Always 200 with an array; an unreadable or absent plugins folder yields `[]`.
+
+### GET `/plugin` - Serve a Plugin File
+
+Serves one file from a plugin's folder.
+
+**Request:**
+```bash
+curl "http://crosspoint.local/plugin?name=organize-by-author&file=plugin.js"
+```
+
+**Query Parameters:**
+
+| Parameter | Required | Description                          |
+| --------- | -------- | ------------------------------------ |
+| `name`    | Yes      | Plugin folder name                   |
+| `file`    | Yes      | File within that folder (flat, no subdirectories) |
+
+Content-Type is derived from the extension (`.js`, `.css`, `.html`, `.json`,
+`.svg`), else `application/octet-stream`.
+
+**Error Responses:**
+
+| Status | Body                | Cause                                                   |
+| ------ | ------------------- | ------------------------------------------------------- |
+| 400    | `Bad plugin path`   | `name` or `file` empty or containing `/`, `\`, or `..`   |
+| 404    | `Plugin not found`  | No such folder in any plugins root                      |
+| 404    | `File not found`    | No such file in that folder, or it is a directory       |
+
+---
+
 ## WebSocket Endpoint
 
 ### Port 81 - Fast Binary Upload

--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -89,6 +89,22 @@ size_t HalStorage::readFileToBuffer(const char* path, char* buffer, size_t buffe
   HAL_STORAGE_WRAPPED_CALL(readFileToBuffer, path, buffer, bufferSize, maxBytes);
 }
 
+// Ported verbatim from crosspoint-reader PR #2734 by Justin Mitchell
+// (@itsthisjustin).
+//
+// Composed of already-locked HalStorage/HalFile operations, so it takes no
+// StorageLock of its own - doing so would deadlock on the non-recursive mutex.
+bool HalStorage::readFileToString(const char* moduleName, const std::string& path, size_t cap, std::string& out) {
+  out.clear();
+  HalFile file;
+  if (!openFileForRead(moduleName, path, file)) return false;
+  if (file.isDirectory()) return false;
+  const size_t size = file.fileSize();
+  if (size == 0 || size > cap) return false;
+  out.resize(size);
+  return file.read(out.data(), size) == static_cast<int>(size);
+}
+
 bool HalStorage::writeFile(const char* path, const String& content) {
   HAL_STORAGE_WRAPPED_CALL(writeFile, path, content);
 }

--- a/lib/hal/HalStorage.h
+++ b/lib/hal/HalStorage.h
@@ -25,6 +25,11 @@ class HalStorage {
   bool readFileToStream(const char* path, Print& out, size_t chunkSize = 256);
   // Read up to `bufferSize-1` bytes into `buffer`, null-terminating it. Returns bytes read.
   size_t readFileToBuffer(const char* path, char* buffer, size_t bufferSize, size_t maxBytes = 0);
+  // Read the whole file at `path` into `out`. Unlike readFile(), the size is
+  // checked against `cap` before anything is allocated, so an unexpectedly
+  // large file fails instead of claiming the heap. Fails on missing,
+  // directory, empty, above-`cap` and short-read files.
+  bool readFileToString(const char* moduleName, const std::string& path, size_t cap, std::string& out);
   // Write a string to `path` on the SD card. Overwrites existing file.
   // Returns true on success.
   bool writeFile(const char* path, const String& content);

--- a/plugins/find-duplicates/manifest.json
+++ b/plugins/find-duplicates/manifest.json
@@ -1,0 +1,4 @@
+{
+  "title": "Find Duplicates",
+  "mount": "files"
+}

--- a/plugins/find-duplicates/plugin.js
+++ b/plugins/find-duplicates/plugin.js
@@ -1,0 +1,139 @@
+// Find Duplicates - reports files that share an exact byte size.
+//
+// Grown from the "library tidy tools (dedupe, bulk rename, move-by-metadata)"
+// idea in crosspoint-reader#2734 by Justin Mitchell (@itsthisjustin). That
+// branch shipped no plugin sources, so the implementation here is our own.
+//
+// Report only: this plugin never writes, moves or deletes anything. It also
+// never downloads a book - it works purely from the /api/files listing, so
+// scanning a large library costs one small request per folder and no book
+// traffic at all.
+//
+// Everything lives inside the registerPlugin closure. Plugins share one page
+// and one global scope, so a top-level `function escapeHtml()` here would
+// collide with the host page and with other plugins.
+CrossPoint.registerPlugin((container, api) => {
+  // Descending into these would walk the book cache, which holds thousands of
+  // files and is not part of the user's library.
+  const SKIP_DOT_DIRS = true;
+  const MAX_FOLDERS = 200;
+  const MAX_FILES = 3000;
+
+  container.innerHTML =
+    '<h2>' + esc(api.title) + '</h2>' +
+    '<p>Lists files that share an exact size - usually the same book stored twice. ' +
+    'Reads only the folder listing, so it never downloads a book, and never changes anything.</p>' +
+    '<p><label>Start folder <input type="text" id="fd-root" value="/" style="width:16em"></label> ' +
+    '<label><input type="checkbox" id="fd-epub" checked> EPUBs only</label></p>' +
+    '<p><button id="fd-scan">Scan</button> <span id="fd-status"></span></p>' +
+    '<div id="fd-out"></div>';
+
+  const el = (id) => container.querySelector(id);
+  const status = (t) => { el('#fd-status').textContent = t; };
+
+  el('#fd-scan').onclick = async () => {
+    const root = el('#fd-root').value.trim() || '/';
+    const epubOnly = el('#fd-epub').checked;
+    el('#fd-scan').disabled = true;
+    el('#fd-out').textContent = '';
+    try {
+      const files = await walk(root, epubOnly);
+      render(groupBySize(files));
+    } catch (e) {
+      status('Failed: ' + ((e && e.message) || e));
+    } finally {
+      el('#fd-scan').disabled = false;
+    }
+  };
+
+  // Breadth-first, one request at a time. The device serves a single
+  // connection, so concurrent listing requests would only queue anyway.
+  async function walk(root, epubOnly) {
+    const queue = [normalize(root)];
+    const files = [];
+    let folders = 0;
+
+    while (queue.length && folders < MAX_FOLDERS && files.length < MAX_FILES) {
+      const dir = queue.shift();
+      folders++;
+      status('Scanning ' + dir + ' (' + folders + ' folders, ' + files.length + ' files)...');
+
+      let entries;
+      try {
+        const r = await fetch('/api/files?path=' + encodeURIComponent(dir));
+        if (!r.ok) throw new Error(r.status + ' on ' + dir);
+        entries = await r.json();
+      } catch (e) {
+        continue;  // unreadable folder should not abort the whole scan
+      }
+
+      for (const entry of entries) {
+        const name = entry.name || '';
+        if (!name || name === '.' || name === '..') continue;
+        const full = (dir === '/' ? '' : dir) + '/' + name;
+        if (entry.isDirectory) {
+          if (SKIP_DOT_DIRS && name.startsWith('.')) continue;
+          queue.push(full);
+        } else if (!epubOnly || entry.isEpub) {
+          files.push({ path: full, size: entry.size || 0 });
+        }
+      }
+    }
+
+    const capped = folders >= MAX_FOLDERS || files.length >= MAX_FILES;
+    status(files.length + ' files in ' + folders + ' folders' +
+      (capped ? ' (stopped at the scan limit - narrow the start folder)' : ''));
+    return files;
+  }
+
+  function groupBySize(files) {
+    const bySize = new Map();
+    for (const f of files) {
+      if (!f.size) continue;  // zero-length files are not interesting duplicates
+      if (!bySize.has(f.size)) bySize.set(f.size, []);
+      bySize.get(f.size).push(f);
+    }
+    return [...bySize.values()]
+      .filter((g) => g.length > 1)
+      .sort((a, b) => b[0].size - a[0].size);
+  }
+
+  function render(groups) {
+    const out = el('#fd-out');
+    if (!groups.length) {
+      out.innerHTML = '<p>No duplicates found.</p>';
+      return;
+    }
+    const wasted = groups.reduce((n, g) => n + g[0].size * (g.length - 1), 0);
+    let html = '<p><strong>' + groups.length + ' group(s)</strong>, about ' +
+      kb(wasted) + ' recoverable if you delete one copy from each.</p>' +
+      '<div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse">' +
+      '<tr><th align="left">Size</th><th align="left">Copies</th><th align="left">Paths</th></tr>';
+    for (const g of groups) {
+      html += '<tr style="border-top:1px solid rgba(128,128,128,.35)">' +
+        '<td valign="top">' + kb(g[0].size) + '</td>' +
+        '<td valign="top">' + g.length + '</td>' +
+        '<td>' + g.map((f) => esc(f.path)).join('<br>') + '</td></tr>';
+    }
+    out.innerHTML = html + '</table></div>' +
+      '<p><em>Same size is a strong hint, not proof. Check before deleting anything ' +
+      '- deletion is not done here, use the file list above.</em></p>';
+  }
+
+  function normalize(p) {
+    if (!p.startsWith('/')) p = '/' + p;
+    if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+    return p;
+  }
+
+  function kb(n) {
+    if (n >= 1048576) return (n / 1048576).toFixed(1) + ' MB';
+    if (n >= 1024) return (n / 1024).toFixed(1) + ' KB';
+    return n + ' B';
+  }
+
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+});

--- a/plugins/hello-plugin/manifest.json
+++ b/plugins/hello-plugin/manifest.json
@@ -1,0 +1,1 @@
+{ "title": "Hello Plugin", "mount": "settings" }

--- a/plugins/hello-plugin/plugin.js
+++ b/plugins/hello-plugin/plugin.js
@@ -1,0 +1,19 @@
+CrossPoint.registerPlugin((container, api) => {
+  container.innerHTML =
+    '<h2>' + api.title + '</h2>' +
+    '<p>Loaded from the SD card as <code>' + api.name + '</code>.</p>' +
+    '<button id="hp-count">Count files in /</button>' +
+    '<pre id="hp-out" style="white-space:pre-wrap"></pre>';
+  container.querySelector('#hp-count').onclick = async () => {
+    const out = container.querySelector('#hp-out');
+    out.textContent = 'Loading...';
+    try {
+      const r = await fetch('/api/files?path=/');
+      const files = await r.json();
+      out.textContent = files.length + ' entries in /\n' +
+        files.slice(0, 10).map(f => '  ' + (f.name || JSON.stringify(f))).join('\n');
+    } catch (e) {
+      out.textContent = 'Error: ' + e.message;
+    }
+  };
+});

--- a/plugins/organize-by-author/manifest.json
+++ b/plugins/organize-by-author/manifest.json
@@ -1,0 +1,4 @@
+{
+  "title": "Organize by Author",
+  "mount": "files"
+}

--- a/plugins/organize-by-author/plugin.js
+++ b/plugins/organize-by-author/plugin.js
@@ -1,0 +1,237 @@
+// Organize by Author - sorts loose EPUBs into one folder per author.
+//
+// The plugin concept and its name come from crosspoint-reader#2734 by Justin
+// Mitchell (@itsthisjustin), which describes an organize-by-author File Manager
+// plugin as the reference example of the same-origin endpoint pattern. That
+// branch's own plugin sources were never published, so this is an independent
+// implementation of the idea; the sidecar handling below is not from it.
+//
+// Scans a single folder (not recursive), works out each book's author, shows a
+// preview, and only moves anything when you press Apply.
+//
+// Author lookup prefers a Calibre-style sidecar: for "book.epub" a "book.opf"
+// beside it is read instead of the book. That is a few KB rather than a
+// multi-megabyte download over the device's single connection, so a library
+// exported from Calibre organises almost instantly. Without a sidecar the EPUB
+// itself is fetched and its OPF read with JSZip, which is correct but slow -
+// the preview says which of the two happened for every book.
+//
+// Moving a book also moves its sidecars. The firmware resolves a cover as
+// "book.jpg" beside "book.epub" and prefers it over the embedded cover, so
+// leaving those behind would silently break the cover on the home screen.
+//
+// Everything is inside this closure: plugins share the page's global scope.
+CrossPoint.registerPlugin((container, api) => {
+  // Matches ReaderActivity::sidecarCoverPath() plus the metadata sidecar.
+  const SIDECAR_EXTS = ['.opf', '.jpg', '.jpeg', '.png', '.bmp'];
+  const DC_NS = 'http://purl.org/dc/elements/1.1/';
+
+  container.innerHTML =
+    '<h2>' + esc(api.title) + '</h2>' +
+    '<p>Sorts loose EPUBs in one folder into <code>&lt;Author&gt;/</code> subfolders. ' +
+    'Reads a Calibre <code>book.opf</code> sidecar when there is one, otherwise downloads ' +
+    'the book to read its metadata. Nothing moves until you press Apply.</p>' +
+    '<p><label>Folder <input type="text" id="oba-dir" value="/" style="width:16em"></label> ' +
+    '<label><input type="checkbox" id="oba-sortname" checked> Prefer sort name (Lastname, First)</label></p>' +
+    '<p><button id="oba-scan">Scan</button> ' +
+    '<button id="oba-apply" disabled>Apply</button> <span id="oba-status"></span></p>' +
+    '<div id="oba-out"></div>';
+
+  const el = (id) => container.querySelector(id);
+  const status = (t) => { el('#oba-status').textContent = t; };
+  let plan = [];
+
+  el('#oba-scan').onclick = async () => {
+    setBusy(true);
+    el('#oba-out').textContent = '';
+    plan = [];
+    try {
+      plan = await scan(normalize(el('#oba-dir').value.trim() || '/'), el('#oba-sortname').checked);
+      renderPlan();
+    } catch (e) {
+      status('Scan failed: ' + msg(e));
+    } finally {
+      setBusy(false);
+      el('#oba-apply').disabled = !plan.some((p) => p.willMove);
+    }
+  };
+
+  el('#oba-apply').onclick = async () => {
+    const todo = plan.filter((p) => p.willMove);
+    if (!todo.length || !confirm('Move ' + todo.length + ' book(s) into author folders?')) return;
+    setBusy(true);
+    el('#oba-apply').disabled = true;
+    let done = 0, failed = 0;
+    for (const item of todo) {
+      status('Moving ' + (done + failed + 1) + ' of ' + todo.length + '...');
+      try {
+        await apply(item);
+        item.note = 'moved';
+        done++;
+      } catch (e) {
+        item.note = 'FAILED: ' + msg(e);
+        failed++;
+      }
+      renderPlan();
+    }
+    status('Moved ' + done + (failed ? ', ' + failed + ' failed' : '') + '. Reload to see the new layout.');
+    setBusy(false);
+  };
+
+  async function scan(dir, useSortName) {
+    status('Listing ' + dir + '...');
+    const entries = await getJson('/api/files?path=' + encodeURIComponent(dir));
+
+    // Index non-directory names so a sidecar can be spotted without a request.
+    const present = new Set(entries.filter((e) => !e.isDirectory).map((e) => e.name));
+    const books = entries.filter((e) => !e.isDirectory && e.isEpub);
+    if (!books.length) {
+      status('No EPUBs directly in ' + dir + '.');
+      return [];
+    }
+
+    const out = [];
+    for (let i = 0; i < books.length; i++) {
+      const b = books[i];
+      const base = stripExt(b.name);
+      const sidecar = present.has(base + '.opf') ? base + '.opf' : null;
+      status('Reading ' + (i + 1) + ' of ' + books.length + ' - ' + b.name +
+        (sidecar ? ' (sidecar)' : ' (downloading book)') + '...');
+
+      let author = '', how = '';
+      try {
+        if (sidecar) {
+          author = authorFromOpf(await getText(dl(join(dir, sidecar))), useSortName);
+          how = 'book.opf';
+        } else {
+          author = authorFromOpf(await opfFromEpub(join(dir, b.name)), useSortName);
+          how = 'in book';
+        }
+      } catch (e) {
+        how = 'unreadable: ' + msg(e);
+      }
+
+      const folder = sanitize(author);
+      out.push({
+        name: b.name, base, dir, author, how, folder,
+        companions: SIDECAR_EXTS.map((x) => base + x).filter((n) => present.has(n)),
+        // Already filed correctly, or no usable author - either way, leave alone.
+        willMove: !!folder && lastSegment(dir) !== folder
+      });
+    }
+    status(out.filter((p) => p.willMove).length + ' of ' + out.length + ' book(s) would move.');
+    return out;
+  }
+
+  async function apply(item) {
+    const target = join(item.dir, item.folder);
+    // 400 "Folder already exists" is the success case on a re-run.
+    const created = await post('/mkdir', { name: item.folder, path: item.dir });
+    if (!created.ok && !/exists/i.test(created.text)) throw new Error(created.text || created.status);
+
+    // Book first: if a companion move fails the book is still filed, and the
+    // reverse would orphan the cover next to an absent book.
+    const moveBook = await post('/move', { path: join(item.dir, item.name), dest: target });
+    if (!moveBook.ok) throw new Error(moveBook.text || moveBook.status);
+    for (const c of item.companions) {
+      await post('/move', { path: join(item.dir, c), dest: target });  // best effort
+    }
+  }
+
+  // --- EPUB fallback: container.xml -> OPF, via JSZip (File Manager page) ----
+  async function opfFromEpub(path) {
+    if (typeof JSZip === 'undefined') throw new Error('JSZip unavailable on this page');
+    const r = await fetch(dl(path));
+    if (!r.ok) throw new Error('download ' + r.status);
+    const zip = await JSZip.loadAsync(await r.blob());
+    const containerFile = zip.file('META-INF/container.xml');
+    if (!containerFile) throw new Error('no container.xml');
+    const rootfile = xml(await containerFile.async('string')).getElementsByTagName('rootfile')[0];
+    const opfPath = rootfile && rootfile.getAttribute('full-path');
+    if (!opfPath) throw new Error('no rootfile');
+    const opfFile = zip.file(opfPath);
+    if (!opfFile) throw new Error('missing ' + opfPath);
+    return opfFile.async('string');
+  }
+
+  function authorFromOpf(text, useSortName) {
+    const doc = xml(text);
+    let nodes = doc.getElementsByTagNameNS(DC_NS, 'creator');
+    if (!nodes.length) nodes = doc.getElementsByTagName('dc:creator');
+    if (!nodes.length) nodes = doc.getElementsByTagName('creator');
+    if (!nodes.length) return '';
+    const n = nodes[0];
+    // Calibre writes the sortable form in opf:file-as, which is what its own
+    // on-disk author folders use - so prefer it when organising into folders.
+    const fileAs = n.getAttribute('opf:file-as') || n.getAttribute('file-as');
+    return ((useSortName && fileAs) || n.textContent || '').trim();
+  }
+
+  function xml(text) {
+    const doc = new DOMParser().parseFromString(text, 'application/xml');
+    if (doc.getElementsByTagName('parsererror').length) throw new Error('malformed XML');
+    return doc;
+  }
+
+  // --- helpers --------------------------------------------------------------
+  function renderPlan() {
+    if (!plan.length) { el('#oba-out').innerHTML = '<p>Nothing to do.</p>'; return; }
+    let html = '<div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse">' +
+      '<tr><th align="left">Book</th><th align="left">Author</th>' +
+      '<th align="left">Source</th><th align="left">Moves to</th></tr>';
+    for (const p of plan) {
+      html += '<tr style="border-top:1px solid rgba(128,128,128,.35)">' +
+        '<td>' + esc(p.name) + (p.companions.length > 1 ?
+          ' <em>+' + (p.companions.length - 1) + ' sidecar</em>' : '') + '</td>' +
+        '<td>' + (esc(p.author) || '<em>unknown</em>') + '</td>' +
+        '<td>' + esc(p.how) + '</td>' +
+        '<td>' + (p.note ? esc(p.note) : p.willMove ? esc(p.folder) + '/' : '<em>no change</em>') +
+        '</td></tr>';
+    }
+    el('#oba-out').innerHTML = html + '</table></div>';
+  }
+
+  function setBusy(b) { el('#oba-scan').disabled = b; }
+  function dl(p) { return '/download?path=' + encodeURIComponent(p); }
+  function join(dir, name) { return (dir === '/' ? '' : dir) + '/' + name; }
+  function lastSegment(p) { return p.slice(p.lastIndexOf('/') + 1); }
+  function stripExt(n) { const d = n.lastIndexOf('.'); return d > 0 ? n.slice(0, d) : n; }
+  function msg(e) { return (e && e.message) || String(e); }
+
+  function normalize(p) {
+    if (!p.startsWith('/')) p = '/' + p;
+    if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+    return p;
+  }
+
+  // Drops the characters /mkdir rejects, plus leading dots (which the firmware
+  // treats as hidden) and trailing dots/spaces (invalid on FAT).
+  function sanitize(a) {
+    return String(a || '').replace(/["*:<>?\/\\|]/g, ' ')
+      .replace(/\s+/g, ' ').replace(/^[.\s]+|[.\s]+$/g, '').slice(0, 64);
+  }
+
+  async function getJson(url) {
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(url + ' -> ' + r.status);
+    return r.json();
+  }
+
+  async function getText(url) {
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(url + ' -> ' + r.status);
+    return r.text();
+  }
+
+  async function post(path, fields) {
+    const fd = new FormData();
+    for (const k of Object.keys(fields)) fd.append(k, fields[k]);
+    const r = await fetch(path, { method: 'POST', body: fd });
+    return { ok: r.ok, status: r.status, text: await r.text().catch(() => '') };
+  }
+
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+});

--- a/scripts/build_html.py
+++ b/scripts/build_html.py
@@ -10,8 +10,49 @@ SRC_DIR = "src"
 
 PLACEHOLDERS = {}
 
+# <!--#include file="shared/Foo.js.inc" --> directives, resolved relative to the
+# including file's directory. Included fragments use the .inc suffix so the
+# asset walk below skips them — they are only ever inlined, never compiled to a
+# header of their own.
+INCLUDE_RE = re.compile(r'<!--\s*#include\s+file="([^"]+)"\s*-->')
+MAX_INCLUDE_DEPTH = 8
+
 def warn(msg: str) -> None:
     print(f"WARNING [build_html.py]: {msg}", file=sys.stderr)
+
+
+def resolve_includes(html: str, base_dir: str, included: list) -> str:
+    """Inline #include directives, appending each resolved path to `included`.
+
+    Must run BEFORE minify_html, which strips every HTML comment. Repeats so an
+    included fragment may itself include others; the caller stats `included` so
+    editing a fragment invalidates the generated header of every page using it.
+
+    Ported from crosspoint-reader PR #2734 by Justin Mitchell (@itsthisjustin) -
+    the directive syntax, the substitution loop and its depth bound are his.
+    Added here: recording resolved paths, because this fork's asset pipeline
+    caches on mtime and would otherwise leave a page stale when only the
+    fragment changed; and failing the build loudly on a missing include.
+    """
+
+    def repl(match):
+        inc_path = os.path.normpath(os.path.join(base_dir, match.group(1)))
+        included.append(inc_path)
+        try:
+            with open(inc_path, "r", encoding="utf-8") as f:
+                return f.read()
+        except OSError as e:
+            raise SystemExit(
+                f'ERROR [build_html.py]: cannot resolve #include "{match.group(1)}"'
+                f" from {base_dir}: {e}"
+            )
+
+    for _ in range(MAX_INCLUDE_DEPTH):
+        html, count = INCLUDE_RE.subn(repl, html)
+        if count == 0:
+            return html
+    warn(f"#include nesting exceeded {MAX_INCLUDE_DEPTH} levels (circular include?)")
+    return html
 
 
 def get_base_version(project_dir: str) -> (str, str):
@@ -262,7 +303,11 @@ for root, _, files in os.walk(SRC_DIR):
                 content = f.read()
 
             # Replace build-time placeholders only in HTML files
+            included = []
             if file.endswith(".html"):
+                # Resolve includes first, so a fragment gets placeholder
+                # substitution and comment stripping like any inline script.
+                content = resolve_includes(content, root, included)
                 content = replace_placeholders(content, PLACEHOLDERS)
                 processed = minify_html(content)
             else:
@@ -278,11 +323,13 @@ for root, _, files in os.walk(SRC_DIR):
             base_name = sanitize_identifier(f"{os.path.splitext(file)[0]}{suffix}")
             header_path = os.path.join(root, f"{base_name}.generated.h")
 
-            if (
-                os.path.exists(header_path)
-                and os.path.getmtime(header_path) >= os.path.getmtime(file_path)
-                and os.path.getmtime(header_path) >= ini_time
-            ):
+            # Editing an included fragment must invalidate the header too, so
+            # the freshness bar is the newest of the page, its includes and the ini.
+            newest_src = max(
+                [os.path.getmtime(file_path), ini_time]
+                + [os.path.getmtime(p) for p in included if os.path.exists(p)]
+            )
+            if os.path.exists(header_path) and os.path.getmtime(header_path) >= newest_src:
                 print(f"Unchanged: {header_path}")
                 continue
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -37,6 +37,7 @@
 #include "html/WelcomePageHtml.generated.h"
 #include "html/js/jszip_minJs.generated.h"
 #include "network/HttpDownloader.h"
+#include "util/PluginLocations.h"
 
 // Log free heap + max contiguous block at a named point.
 #define LOG_WEB_MEM(tag)                                                                             \
@@ -178,6 +179,27 @@ bool isProtectedItemName(const String& name) {
   }
   return false;
 }
+
+// True when `s` is usable as a single path component: no separator and no
+// parent reference, so it cannot escape the folder it is joined to. Rejecting
+// "/" outright also means plugin folders are flat - no subdirectories.
+bool isSafePathComponent(const String& s) {
+  return !s.isEmpty() && s.indexOf('/') < 0 && s.indexOf('\\') < 0 && s.indexOf("..") < 0;
+}
+
+const char* pluginContentType(const String& file) {
+  if (file.endsWith(".js")) return "application/javascript";
+  if (file.endsWith(".css")) return "text/css";
+  if (file.endsWith(".html")) return "text/html";
+  if (file.endsWith(".json")) return "application/json";
+  if (file.endsWith(".svg")) return "image/svg+xml";
+  return "application/octet-stream";
+}
+
+// A manifest carries a title and a mount point. The cap keeps a stray large
+// file in a plugin folder from being read into the heap; 4KB is far more than
+// the handful of fields the format defines.
+constexpr size_t PLUGIN_MANIFEST_MAX_BYTES = 4096;
 }  // namespace
 
 // File listing page template - now using generated headers:
@@ -278,6 +300,10 @@ void CrossPointWebServer::begin() {
   server->on("/api/opds/delete", HTTP_POST, [this] { handleDeleteOpdsServer(); });
 
   // Wi-Fi credential endpoints
+  // Web-UI plugins (SD card)
+  server->on("/api/plugins", HTTP_GET, [this] { handlePluginList(); });
+  server->on("/plugin", HTTP_GET, [this] { handlePluginFile(); });
+
   server->on("/api/wifi", HTTP_GET, [this] { handleGetWifiNetworks(); });
   server->on("/api/wifi", HTTP_POST, [this] { handlePostWifiNetwork(); });
   server->on("/api/wifi/delete", HTTP_POST, [this] { handleDeleteWifiNetwork(); });
@@ -2625,6 +2651,100 @@ void CrossPointWebServer::handleDeleteOpdsServer() {
   }
   LOG_DBG("WEB", "Deleted OPDS server at index %d", idx);
   server->send(200, "text/plain", "OK");
+}
+
+// GET /api/plugins -> [{"name","title","mount"}, ...]
+// Only folders carrying a plugin.js are listed, since the page's whole job is
+// to load that file; manifest.json just supplies the label and mount point.
+// Streamed rather than assembled: a JsonDocument holding every entry plus a
+// manifest string each would be the largest allocation on this path.
+void CrossPointWebServer::handlePluginList() const {
+  if (rejectIfLowMemory(server.get())) return;
+
+  server->setContentLength(CONTENT_LENGTH_UNKNOWN);
+  server->send(200, "application/json", "");
+  ChunkedJsonArray out(server.get());
+
+  char output[384];
+  JsonDocument doc;
+  size_t listed = 0;
+
+  for (const auto& e : PluginLocations::scanPlugins()) {
+    if (!e.hasPluginJs) continue;
+
+    doc.clear();
+    doc["name"] = e.name;
+    doc["title"] = e.name;      // manifest overrides below
+    doc["mount"] = "settings";  // default page
+
+    std::string manifest;
+    if (e.hasManifest &&
+        Storage.readFileToString("WEB", e.dir + "/manifest.json", PLUGIN_MANIFEST_MAX_BYTES, manifest)) {
+      JsonDocument m;
+      if (deserializeJson(m, manifest) == DeserializationError::Ok) {
+        if (m["title"].is<const char*>()) doc["title"] = m["title"];
+        if (m["mount"].is<const char*>()) doc["mount"] = m["mount"];
+      } else {
+        LOG_DBG("WEB", "Plugin %s: unparseable manifest.json", e.name.c_str());
+      }
+    }
+
+    const size_t written = serializeJson(doc, output, sizeof(output));
+    if (written >= sizeof(output)) {
+      LOG_DBG("WEB", "Plugin %s: entry too long, skipped", e.name.c_str());
+      continue;
+    }
+    out.addEntry(output, written);
+    listed++;
+  }
+
+  out.finish();
+  // Logged even when empty: "no plugins" and "the page never asked" look
+  // identical from the outside otherwise.
+  LOG_DBG("WEB", "Served plugin list (%u plugins)", static_cast<unsigned>(listed));
+}
+
+// GET /plugin?name=<plugin>&file=<file> -> that file from the plugin's folder.
+// Both components are validated as single path segments, so a request cannot
+// reach outside the folder findPluginDir resolved.
+void CrossPointWebServer::handlePluginFile() const {
+  // Streaming claims a 4KB chunk buffer, same as /download.
+  if (rejectIfLowMemory(server.get())) return;
+
+  const String name = server->arg("name");
+  const String file = server->arg("file");
+  if (!isSafePathComponent(name) || !isSafePathComponent(file)) {
+    server->send(400, "text/plain", "Bad plugin path");
+    return;
+  }
+
+  const std::string pluginDir = PluginLocations::findPluginDir(name.c_str());
+  if (pluginDir.empty()) {
+    LOG_DBG("WEB", "Plugin not found in any root: %s", name.c_str());
+    server->send(404, "text/plain", "Plugin not found");
+    return;
+  }
+
+  const std::string path = pluginDir + "/" + file.c_str();
+  FsFile f = Storage.open(path.c_str());
+  if (!f || !f.isOpen() || f.isDirectory()) {
+    if (f) f.close();
+    LOG_DBG("WEB", "Plugin file not found: %s", path.c_str());
+    server->send(404, "text/plain", "File not found");
+    return;
+  }
+  LOG_DBG("WEB", "Serving plugin file: %s (%u bytes)", path.c_str(), static_cast<unsigned>(f.size()));
+
+  server->setContentLength(f.size());
+  server->send(200, pluginContentType(file), "");
+
+  NetworkClient client = server->client();
+  const bool ok = HttpFileStreamer::streamFileToClient(f, client);
+  client.clear();
+  f.close();
+  if (!ok) {
+    LOG_DBG("WEB", "Plugin file streaming interrupted: %s/%s", name.c_str(), file.c_str());
+  }
 }
 
 // WebSocket callback trampoline

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -157,4 +157,19 @@ class CrossPointWebServer {
   void handleStatsPage() const;
   void handleStatsApi() const;
   void handleStatsExport() const;
+
+  // Web-UI plugins: JS on the SD card that the Settings and File Manager pages
+  // discover and load, so the web interface can be extended without a firmware
+  // build. The firmware only lists the folders and serves their files - plugin
+  // code runs in the browser, never on the device, and reaches the card through
+  // the same endpoints the pages themselves use.
+  //
+  // Both endpoints are ported from crosspoint-reader PR #2734 ("feat: Add
+  // browser-side plugin system with SD card support", Justin Mitchell /
+  // @itsthisjustin). His /api/plugins and /plugin contract is preserved so
+  // plugins written for either firmware work on both; the implementations
+  // differ (streamed listing, low-memory guard, tighter manifest cap). None of
+  // that branch's device-capability endpoints are ported.
+  void handlePluginList() const;  // GET /api/plugins -> discovered plugins
+  void handlePluginFile() const;  // GET /plugin?name&file -> one file from its folder
 };

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -185,6 +185,11 @@
       cursor: not-allowed;
     }
 
+    .plugin-error {
+      color: #c0392b;
+      margin: 0;
+    }
+
     /* Drag & drop overlay */
     .drop-overlay {
       display: none;
@@ -1894,6 +1899,8 @@
       </div>
     </div>
   </div>
+
+  <div id="plugin-container"></div>
 
   <div class="card">
     <p style="text-align: center; color: #95a5a6; margin: 0;">
@@ -6069,7 +6076,13 @@
 
       moveNext(0);
     }
-    hydrate();
+
+<!--#include file="shared/PluginHost.js.inc" -->
+
+    // Plugins load after the listing, not beside it: the device serves one
+    // connection at a time. finally() so a hydrate failure still surfaces the
+    // way it does today, and a broken listing does not disable plugins.
+    hydrate().finally(() => loadPlugins('files'));
   </script>
 </body>
 

--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -215,6 +215,10 @@
       color: #721c24;
       border: 1px solid #f5c6cb;
     }
+    .plugin-error {
+      color: #c0392b;
+      margin: 0;
+    }
     .loader-container {
       display: flex;
       justify-content: center;
@@ -331,6 +335,7 @@
   
   <div id="wifi-container"></div>
   <div id="opds-container"></div>
+  <div id="plugin-container"></div>
 
   <div class="card">
     <p style="text-align: center; color: #95a5a6; margin: 0;">
@@ -839,13 +844,17 @@
     }
   }
   
+<!--#include file="shared/PluginHost.js.inc" -->
+
   // Sequential, not concurrent: the device's web server handles one client
   // connection at a time, and three simultaneous fetches on page load can
   // stall long enough inside a single response to trip the firmware watchdog.
+  // Plugins load last, so a slow or broken one cannot delay the real settings.
   (async () => {
     await loadSettings();
     await loadWifiNetworks();
     await loadOpdsServers();
+    await loadPlugins('settings');
   })();
 </script>
 </body>

--- a/src/network/html/shared/PluginHost.js.inc
+++ b/src/network/html/shared/PluginHost.js.inc
@@ -1,0 +1,83 @@
+// --- browser-side plugin host (shared by Settings + File Manager) -----------
+// Ported from crosspoint-reader PR #2734 ("feat: Add browser-side plugin system
+// with SD card support", Justin Mitchell / @itsthisjustin). The discovery flow,
+// the registerPlugin handshake and the mount convention are his design; this
+// version drops the device-capability API (relay/crypto/fetch/plugin-fs) and
+// the plugin job queue, keeping only the loader.
+//
+// Discovers plugins from the SD card via /api/plugins, loads each plugin.js,
+// and hands it a container element to render into. A plugin is just JS on the
+// card, so adding one needs no firmware build.
+//
+// Plugins run in the page with full same-origin authority: they call the web
+// server's existing endpoints (/api/files, /mkdir, /move, /delete, /upload,
+// /download) directly with fetch(). The firmware deliberately exposes no
+// outbound-request or crypto endpoint - a plugin can reach the SD card, not
+// the internet.
+window.CrossPoint = window.CrossPoint || {
+  _pending: null,
+  // Called by a plugin at top level; loadPlugins() picks the function up after
+  // that script finishes loading. Safe because plugins load strictly one at a
+  // time (see loadPlugins), so _pending never belongs to two plugins at once.
+  registerPlugin(fn) { this._pending = fn; }
+};
+
+// `mount` selects which page's plugins to load, matching the manifest's "mount"
+// field ("settings" or "files"); plugins omitting it default to "settings".
+//
+// Strictly sequential: the device serves one connection at a time, and parallel
+// requests on page load can stall a response long enough to trip the firmware
+// watchdog. Await this alongside the page's other loaders, never beside them.
+async function loadPlugins(mount) {
+  const host = document.getElementById('plugin-container');
+  if (!host) return;
+
+  let list;
+  try {
+    list = await (await fetch('/api/plugins')).json();
+  } catch (e) {
+    return;  // no card, no plugins folder, or a device busy elsewhere
+  }
+
+  for (const p of list) {
+    if ((p.mount || 'settings') !== mount) continue;
+
+    const container = document.createElement('div');
+    container.className = 'card';
+    container.id = 'plugin-' + p.name;
+    host.appendChild(container);
+
+    CrossPoint._pending = null;
+    try {
+      await new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = '/plugin?name=' + encodeURIComponent(p.name) + '&file=plugin.js';
+        s.onload = resolve;
+        s.onerror = () => reject(new Error('load ' + p.name));
+        document.body.appendChild(s);
+      });
+      if (typeof CrossPoint._pending !== 'function') {
+        throw new Error(p.name + ' did not call registerPlugin()');
+      }
+      CrossPoint._pending(container, {
+        name: p.name,
+        // manifest.json's title, falling back to the folder name. The host
+        // renders no chrome - the plugin owns its whole card - so this is here
+        // for a plugin that wants its heading to track the manifest instead of
+        // hardcoding it.
+        title: p.title || p.name,
+        // URL of another file in this plugin's folder, for a plugin that ships
+        // its own assets. Flat: the server serves no subdirectories.
+        pluginFile: (f) => '/plugin?name=' + encodeURIComponent(p.name) +
+          '&file=' + encodeURIComponent(f)
+      });
+    } catch (e) {
+      const title = document.createElement('h2');
+      title.textContent = p.title || p.name;
+      const msg = document.createElement('p');
+      msg.className = 'plugin-error';
+      msg.textContent = 'Failed to load plugin: ' + ((e && e.message) || e);
+      container.replaceChildren(title, msg);
+    }
+  }
+}

--- a/src/util/PluginLocations.cpp
+++ b/src/util/PluginLocations.cpp
@@ -1,0 +1,55 @@
+#include "PluginLocations.h"
+
+#include <HalStorage.h>
+#include <Logging.h>
+
+#include <algorithm>
+
+namespace PluginLocations {
+
+std::vector<Entry> scanPlugins() {
+  std::vector<Entry> plugins;
+  plugins.reserve(8);
+  std::vector<std::string> seen;
+  seen.reserve(8);
+
+  for (size_t r = 0; r < kRootCount; r++) {
+    HalFile root = Storage.open(kRoots[r]);
+    if (!root || !root.isDirectory()) continue;
+
+    size_t examined = 0;
+    for (HalFile entry = root.openNextFile(); entry; entry = root.openNextFile()) {
+      if (!entry.isDirectory()) continue;
+      if (++examined > kMaxDirsPerRoot) {
+        LOG_ERR("PLG", "%s holds more than %u directories; ignoring the rest", kRoots[r],
+                static_cast<unsigned>(kMaxDirsPerRoot));
+        break;
+      }
+      char name[128];
+      if (entry.getName(name, sizeof(name)) == 0 || name[0] == '.') continue;
+      if (std::find(seen.begin(), seen.end(), name) != seen.end()) continue;
+      // Claimed even when it carries no marker: findPluginDir resolves this name
+      // to this root, so a same-named folder in a later root must not be
+      // reported in its place.
+      seen.emplace_back(name);
+
+      Entry e;
+      e.name = name;
+      e.dir = std::string(kRoots[r]) + "/" + name;
+      e.hasPluginJs = Storage.exists((e.dir + "/plugin.js").c_str());
+      e.hasManifest = Storage.exists((e.dir + "/manifest.json").c_str());
+      if (e.hasPluginJs || e.hasManifest) plugins.push_back(std::move(e));
+    }
+  }
+  return plugins;
+}
+
+std::string findPluginDir(const char* name) {
+  for (size_t i = 0; i < kRootCount; i++) {
+    std::string dir = std::string(kRoots[i]) + "/" + name;
+    if (Storage.exists(dir.c_str())) return dir;
+  }
+  return {};
+}
+
+}  // namespace PluginLocations

--- a/src/util/PluginLocations.h
+++ b/src/util/PluginLocations.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <string>
+#include <vector>
+
+// Ported from crosspoint-reader PR #2734 ("feat: Add browser-side plugin system
+// with SD card support", Justin Mitchell / @itsthisjustin), whose design this
+// follows closely: the three SD roots, earliest-root-wins collision handling,
+// and the marker-file classification are all his. Reduced here to the browser
+// plugin surface only - none of that branch's device-capability endpoints,
+// on-device catalog or content-protection work is carried over - and bounded
+// with a per-root directory cap.
+//
+// Where web-UI plugins live on the SD card. A plugin is just a folder holding a
+// plugin.js (and optionally a manifest.json); the web server discovers it and
+// the browser loads it, so adding one needs no firmware build.
+//
+// /.crosspoint/plugins is the canonical home. /plugins and /.plugins are also
+// scanned because a dot-prefixed folder is awkward to create on some desktop
+// file managers, and copying a folder onto the card should be all it takes.
+namespace PluginLocations {
+inline constexpr const char* kRoots[] = {"/.crosspoint/plugins", "/plugins", "/.plugins"};
+inline constexpr size_t kRootCount = sizeof(kRoots) / sizeof(kRoots[0]);
+
+// Directories examined per root before the scan gives up. Each candidate costs
+// two SD stats to classify, and the scan runs inside a single request, so an
+// unbounded loop over a folder that happens to hold hundreds of subdirectories
+// could outlast the task watchdog. Far above any real plugin count.
+inline constexpr size_t kMaxDirsPerRoot = 64;
+
+// One plugin folder, classified by the marker files it carries.
+struct Entry {
+  std::string name;          // folder name
+  std::string dir;           // "<root>/<name>"
+  bool hasPluginJs = false;  // browser-side plugin (plugin.js)
+  bool hasManifest = false;  // optional card metadata (manifest.json)
+};
+
+// Scans every root. The earliest root holding a folder name claims it - matching
+// findPluginDir, which serves that folder's files - and folders carrying no
+// marker file are omitted. Callers filter by the markers they need.
+std::vector<Entry> scanPlugins();
+
+// Directory of the named plugin ("<root>/<name>"), or "" when absent. The caller
+// must have validated `name` as a single path component.
+std::string findPluginDir(const char* name);
+}  // namespace PluginLocations


### PR DESCRIPTION
Loads web-UI plugins from the SD card: a folder holding a `plugin.js` under `/.crosspoint/plugins` (or `/plugins`, `/.plugins`) is discovered by the web server and rendered as a card on the Settings or File Manager page. Adding or changing a plugin needs no firmware build.

## Credit

This is a port of [crosspoint-reader#2734](https://github.com/crosspoint-reader/crosspoint-reader/pull/2734) ("feat: Add browser-side plugin system with SD card support") by **Justin Mitchell ([@itsthisjustin](https://github.com/itsthisjustin))**, sole author of all 46 commits on that branch.

The design is his: the SD folder layout and earliest-root-wins collision rule, the `/api/plugins` and `/plugin` contract, the `registerPlugin` handshake, and the `mount` convention. That contract is kept compatible on purpose, so a plugin written for either firmware works on both. What differs is the implementation and the scope — see below.

The three firmware commits carry a `Co-authored-by` trailer, because they are substantially his code: `readFileToString` is his implementation verbatim, and `resolve_includes` shares his directive syntax, substitution loop and depth bound. The plugins commit carries attribution but **no** co-author trailer — those are independent implementations of ideas his docs describe, and claiming co-authorship there would overstate his involvement.

Our fork shares no history with upstream, so this is a hand-port rather than a cherry-pick, and it is reduced to a deliberately minimal subset. The `sd-plugins` repository that branch's docs refer to for plugin sources was never published, so the two bundled plugins are independent implementations of ideas described there.

## What is deliberately not included

Upstream's branch bundles four separable concerns. This takes one of them.

| Concern | Included |
|---|---|
| Browser plugin loader | ✅ |
| Device endpoints (`/api/relay`, `/api/crypto`, `/api/fetch`, `/api/plugin-fs`) | ❌ |
| On-device catalog (`device.json`, 3 new activities, ~2100 lines) | ❌ |
| Adobe DRM / ContentProtection | ❌ |

**Nothing runs on the device.** The firmware enumerates folders and serves bytes; the script executes in the browser of whoever opened the page and reaches the card through the endpoints the pages already use (`/api/files`, `/mkdir`, `/move`, `/delete`, `/upload`, `/download`) plus the JSZip the File Manager already loads. **The reader gains no ability to talk to the internet.**

Skipping the relay is a security decision, not just scope. Upstream commit `5987594b` *removed* the `allowedHosts` manifest gate that restricted relay targets, and our web server has no authentication — porting it as-is would put an open HTTP proxy on the LAN. If we ever want it, restore the allowlist from `5987594b^` rather than porting current head.

The `device.json` surface was skipped as the largest scope grab, and much of it duplicates what we already ship: Kavita/Komga/Calibre-Web/COPS all expose OPDS which our OPDS browser handles, a font store duplicates `FontDownloadActivity`, a dictionary store duplicates dictionary lookup.

## Cost

- **Flash +999 bytes** (measured: both pages built from master vs this branch through the same pipeline). Relevant because the firmware is at **96.7%** of the OTA partition. The C++ side is not separately isolated.
- **RAM unchanged**, 17.2%. Nothing is resident — the scan runs per request.
- Plugins themselves live on the SD card and cost **zero** flash, which is the main architectural argument at this fill level.

## Local adaptations over upstream

- Listing streams through our `ChunkedJsonArray` rather than assembling one `JsonDocument` holding every entry and its manifest.
- Both endpoints take the `rejectIfLowMemory` guard our other allocating handlers use.
- File serving reuses `HttpFileStreamer` (heap chunk buffer) instead of upstream's 4KB stack frame, which would breach our 256-byte stack rule. Upstream's `streamFileToClient` was dropped as redundant.
- Manifests read with a 4KB cap, not upstream's 64KB.
- Folder scan bounded to 64 directories per root: it runs inside one request at two SD stats per candidate.
- Plugins load **last and strictly sequentially** on both pages. Load-bearing for correctness, not just the watchdog: the `_pending` registration handshake is a single global, and the device serves one connection at a time.
- `build_html.py` has an mtime staleness cache upstream's lacks, so include paths are stat'd too — otherwise editing the shared fragment leaves both pages silently stale.

## Security

Path components (`name`, `file`) are each validated as a single segment — rejecting `/`, `\` and `..` after the server's URL decoding — so a request cannot escape the resolved plugin folder, and plugin folders stay flat.

A plugin is unsandboxed JS with the page's full authority over the SD card. `docs/sd-plugins.md` states that plainly rather than implying a sandbox. Installing a plugin is equivalent to running a script on your library.

Clear Cache does not remove plugins: that action is an allowlist over `epub_`/`xtc_`/`txt_` prefixes and leaves everything else in `/.crosspoint` alone.

## Bundled plugins

`plugins/` — SD-card files, never compiled, zero flash.

| Plugin | Mount | What it does |
|---|---|---|
| `hello-plugin` | settings | Minimal reference and smoke test |
| `find-duplicates` | files | Reports files sharing an exact size. Report only; never writes, never downloads a book |
| `organize-by-author` | files | Sorts loose EPUBs into `<Author>/` folders; preview first, moves only on Apply |

`organize-by-author` prefers a Calibre-style `book.opf` sidecar over opening the book — a few KB rather than a multi-megabyte download over the device's single connection — falling back to the book's own OPF via JSZip and reporting which source it used per book.

Moving a book also moves its sidecars. `ReaderActivity::sidecarCoverPath()` resolves `book.jpg` beside `book.epub` and prefers it over the embedded cover, so relocating a book without its companions would silently break the home-screen cover.

Note the firmware does not read `book.opf` itself — that is currently a convention between plugins. Making the device prefer a sidecar OPF for title/author would mirror `sidecarCoverPath` cleanly, but is separate work with flash cost.

## Testing

- Verified on **X3 hardware**: discovery, file serving, the `registerPlugin` handshake, mount filtering in both directions, `api.title`, and a plugin driving a same-origin endpoint. Both `find-duplicates` and `organize-by-author` exercised on device.
- Both pages' minified inline JS parses under `node --check` *after* minification — the real gate, since our minifier runs a hand-rolled JS comment stripper over script blocks.
- Confirmed no reference to `/api/relay`, `/api/crypto`, `/api/fetch`, `/api/plugin-fs` or the job queue survives into the shipped pages.
- Include resolution covered for nesting, a missing file (fails the build) and a cycle (warns).

## Commits

1. `build(html)` — `#include` directive in the asset pipeline
2. `feat(hal)` — `HalStorage::readFileToString` with a size cap
3. `feat(web)` — the plugin loader
4. `feat(plugins)` — the bundled plugin set

Commits 1–3 are co-authored with @itsthisjustin; commit 4 credits him without claiming co-authorship.
