### PR TITLE
fix(web): upload dropped folders, and minify inline JS with terser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
           version: "latest"
           enable-cache: false
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      # terser minifies the inline JS in the embedded web pages (see
+      # scripts/build_html.py). Without it the build still succeeds, but the
+      # generated pages are ~17% larger - so CI installs it to match a release.
+      - name: Install web asset tooling
+        run: npm ci
+
       - name: Install PlatformIO Core
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
@@ -80,6 +91,17 @@ jobs:
           version: "latest"
           enable-cache: false
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      # terser minifies the inline JS in the embedded web pages (see
+      # scripts/build_html.py). Without it the build still succeeds, but the
+      # generated pages are ~17% larger - so CI installs it to match a release.
+      - name: Install web asset tooling
+        run: npm ci
+
       - name: Install PlatformIO Core
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
@@ -93,7 +115,18 @@ jobs:
       - name: Build CrossPoint
         run: |
           set -euo pipefail
-          pio run | tee pio.log
+          pio run 2>&1 | tee pio.log
+
+      # A missing terser is only a warning in build_html.py, so that the build
+      # still works for contributors without node. In CI it must be an error:
+      # silently shipping ~10KB of un-mangled JS is exactly the regression this
+      # tooling exists to prevent.
+      - name: Verify web assets were minified
+        run: |
+          if grep -q "terser not found" pio.log; then
+            echo "::error::terser did not run - embedded web pages are ~17% larger than a release build"
+            exit 1
+          fi
 
       - name: Extract firmware stats
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,17 @@ jobs:
           version: "latest"
           enable-cache: false
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      # terser minifies the inline JS in the embedded web pages (see
+      # scripts/build_html.py). Without it the build still succeeds, but the
+      # generated pages are ~17% larger - so CI installs it to match a release.
+      - name: Install web asset tooling
+        run: npm ci
+
       - name: Install PlatformIO Core
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -27,6 +27,17 @@ jobs:
           version: "latest"
           enable-cache: false
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      # terser minifies the inline JS in the embedded web pages (see
+      # scripts/build_html.py). Without it the build still succeeds, but the
+      # generated pages are ~17% larger - so CI installs it to match a release.
+      - name: Install web asset tooling
+        run: npm ci
+
       - name: Install PlatformIO Core
         run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ lib/EpdFont/scripts/output/
 # (worktrees, scheduled-task locks, settings.local, scout CLEANUP.md) out.
 .claude/*
 !.claude/skills/
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,131 @@
+{
+  "name": "witchhunt-reader-web-assets",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "witchhunt-reader-web-assets",
+      "hasInstallScript": true,
+      "devDependencies": {
+        "terser": "5.50.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "witchhunt-reader-web-assets",
+  "private": true,
+  "description": "Build-time tooling for the firmware's embedded web pages. Not shipped, not required to run the firmware - scripts/build_html.py falls back to whitespace-only minification when this is not installed.",
+  "scripts": {
+    "postinstall": "node -e \"console.log('terser available - build_html.py will minify inline JS')\""
+  },
+  "devDependencies": {
+    "terser": "5.50.0"
+  }
+}

--- a/scripts/build_html.py
+++ b/scripts/build_html.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -200,7 +201,66 @@ def strip_js_comments(js: str) -> str:
     return "".join(result)
 
 
-def minify_html(html: str) -> str:
+_TERSER = "unresolved"  # cached: None once we know it is unavailable
+
+
+def find_terser(project_dir: str):
+    """Locate terser, or None. Resolved once per build.
+
+    Invoked through `node <entry>` rather than the .bin shim so the same code
+    path works on Windows and POSIX.
+    """
+    global _TERSER
+    if _TERSER != "unresolved":
+        return _TERSER
+
+    entry = os.path.join(project_dir, "node_modules", "terser", "bin", "terser")
+    if os.path.isfile(entry) and shutil.which("node"):
+        _TERSER = ["node", entry]
+    else:
+        _TERSER = None
+        warn(
+            "terser not found - inline JS keeps its original identifiers, so the "
+            "generated pages are roughly 17% larger than a release build. "
+            "Run `npm install` in the project root to match CI."
+        )
+    return _TERSER
+
+
+def minify_js(js: str, project_dir: str) -> str:
+    """Compress and mangle one inline <script> body.
+
+    Mangles local names only: `toplevel` is deliberately NOT set, because the
+    pages call top-level functions from inline HTML attributes
+    (onclick="validateFile()") which terser cannot see and would rename into
+    oblivion. Same reason unused top-level functions must not be dropped.
+
+    Falls back to the caller's whitespace/comment stripping if terser is absent
+    or rejects the input - a bigger page is always preferable to a broken one.
+    """
+    terser = find_terser(project_dir)
+    if not terser or not js.strip():
+        return strip_js_comments(js)
+
+    try:
+        result = subprocess.run(
+            terser + ["--compress", "--mangle"],
+            input=js,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError as e:
+        warn(f"could not run terser ({e}); falling back to comment stripping")
+        return strip_js_comments(js)
+
+    if result.returncode != 0 or not result.stdout.strip():
+        warn(f"terser failed, falling back to comment stripping: {(result.stderr or '').strip()[:200]}")
+        return strip_js_comments(js)
+    return result.stdout
+
+
+def minify_html(html: str, project_dir: str = "") -> str:
     # Tags where whitespace should be preserved
     preserve_tags = ["pre", "code", "textarea"]
     script_style_tags = ["script", "style"]
@@ -229,7 +289,7 @@ def minify_html(html: str) -> str:
         content = full[open_end:close_start]
         closing = full[close_start:]
         if tag == "script":
-            content = strip_js_comments(content)
+            content = minify_js(content, project_dir)
         elif tag == "style":
             # Remove CSS comments
             content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
@@ -295,6 +355,10 @@ PLACEHOLDERS["%%CROSSPOINT%%"] = name_string
 PLACEHOLDERS["%%VERSION%%"] = version_string
 ini_path = os.path.join(project_dir, "platformio.ini")
 ini_time = os.path.getmtime(ini_path) if os.path.exists(ini_path) else 0
+# Resolved once, before the walk, so the warning prints at most one time and
+# so its mtime can take part in the staleness check below.
+_terser_cmd = find_terser(project_dir)
+terser_time = os.path.getmtime(_terser_cmd[1]) if _terser_cmd else 0
 for root, _, files in os.walk(SRC_DIR):
     for file in files:
         if file.endswith(".html") or file.endswith(".js"):
@@ -309,7 +373,7 @@ for root, _, files in os.walk(SRC_DIR):
                 # substitution and comment stripping like any inline script.
                 content = resolve_includes(content, root, included)
                 content = replace_placeholders(content, PLACEHOLDERS)
-                processed = minify_html(content)
+                processed = minify_html(content, project_dir)
             else:
                 processed = content
 
@@ -324,9 +388,12 @@ for root, _, files in os.walk(SRC_DIR):
             header_path = os.path.join(root, f"{base_name}.generated.h")
 
             # Editing an included fragment must invalidate the header too, so
-            # the freshness bar is the newest of the page, its includes and the ini.
+            # the freshness bar is the newest of the page, its includes and the
+            # ini. Terser's own mtime joins them: installing it after a build
+            # changes the output, and without this the cached headers would stay
+            # at their larger un-mangled size.
             newest_src = max(
-                [os.path.getmtime(file_path), ini_time]
+                [os.path.getmtime(file_path), ini_time, terser_time]
                 + [os.path.getmtime(p) for p in included if os.path.exists(p)]
             )
             if os.path.exists(header_path) and os.path.getmtime(header_path) >= newest_src:

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1915,7 +1915,7 @@
       <h3>📤 Upload file</h3>
       <div class="upload-form">
         <p class="file-info">Select a file to upload to <strong id="uploadPathDisplay"></strong></p>
-        <input type="file" id="fileInput" onchange="validateFile()" multiple>
+        <input type="file" id="fileInput" onchange="pendingFolderUpload = null; validateFile()" multiple>
         <div class="picker-columns" id="pickerColumns">
           <div class="convert-options" id="convertOptions" style="display:none;">
             <div class="convert-row">
@@ -2470,6 +2470,8 @@
 
     // Modal functions
     function openUploadModal() {
+      // Clear any staged folder drop; prepareFolderDrop re-arms it after this.
+      pendingFolderUpload = null;
       // Reset converter variables to defaults
       ENABLE_GRAYSCALE = true;
       JPEG_QUALITY = 85;
@@ -3374,17 +3376,137 @@
         dragDepth = 0;
         overlay.classList.remove('active');
         if (!canAcceptDrop()) return;
+
+        // webkitGetAsEntry has to be read synchronously: the DataTransfer is
+        // neutered as soon as this handler returns, so the entries must be
+        // grabbed before any await. dataTransfer.files alone cannot represent a
+        // folder - it reports one zero-length File named after it, which would
+        // upload as a 0-byte junk file.
+        const entries = [];
+        const items = e.dataTransfer.items;
+        if (items && typeof DataTransferItem !== 'undefined' && DataTransferItem.prototype.webkitGetAsEntry) {
+          for (let i = 0; i < items.length; i++) {
+            if (items[i].kind !== 'file') continue;
+            const entry = items[i].webkitGetAsEntry();
+            if (entry) entries.push(entry);
+          }
+        }
+
+        if (entries.some((en) => en.isDirectory)) {
+          prepareFolderDrop(entries);
+          return;
+        }
+
         const files = e.dataTransfer.files;
         if (!files || files.length === 0) return;
 
         const dt = new DataTransfer();
         for (let i = 0; i < files.length; i++) dt.items.add(files[i]);
 
+        pendingFolderUpload = null;
         openUploadModal();
         const fileInput = document.getElementById('fileInput');
         fileInput.files = dt.files;
         validateFile();
       });
+    }
+
+    // Flattens a dropped folder tree into files plus the folder each one belongs
+    // in, then stages them for the normal upload flow. Recreating the folders on
+    // the card is left to uploadFile(), which runs once the user confirms.
+    async function prepareFolderDrop(entries) {
+      const collected = [];
+      try {
+        for (const entry of entries) await walkDropEntry(entry, '', collected);
+      } catch (err) {
+        console.error('Folder drop scan failed:', err);
+        alert('Could not read the dropped folder: ' + (err && err.message ? err.message : err));
+        return;
+      }
+
+      if (collected.length === 0) {
+        alert('That folder contains no files.');
+        return;
+      }
+      if (collected.length >= MAX_DROP_FILES) {
+        alert(`Only the first ${MAX_DROP_FILES} files from the dropped folder will be uploaded.`);
+      }
+
+      const dt = new DataTransfer();
+      for (const item of collected) dt.items.add(item.file);
+
+      openUploadModal();
+      // After openUploadModal, which clears staging. Parallel to
+      // fileInput.files and in the same order: uploadFile() indexes both by
+      // the same counter.
+      pendingFolderUpload = collected.map((item) => ({
+        file: item.file,
+        relDir: item.relDir,
+        destPath: item.relDir ? joinBrowsePath(currentPath, item.relDir) : currentPath
+      }));
+
+      const fileInput = document.getElementById('fileInput');
+      fileInput.files = dt.files;
+      validateFile();
+    }
+
+    // Depth-first walk of a dropped FileSystemEntry. readEntries yields at most
+    // ~100 children per call and must be drained until it returns nothing, or
+    // large folders silently lose their tail.
+    async function walkDropEntry(entry, relDir, out) {
+      if (out.length >= MAX_DROP_FILES) return;
+
+      if (entry.isFile) {
+        const file = await new Promise((resolve, reject) => entry.file(resolve, reject));
+        out.push({ file, relDir });
+        return;
+      }
+      if (!entry.isDirectory) return;
+
+      const childRel = relDir ? relDir + '/' + entry.name : entry.name;
+      const reader = entry.createReader();
+      for (;;) {
+        const batch = await new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+        if (!batch.length) break;
+        for (const child of batch) {
+          await walkDropEntry(child, childRel, out);
+          if (out.length >= MAX_DROP_FILES) return;
+        }
+      }
+    }
+
+    // Every folder level a dropped tree needs, shallowest first so each mkdir
+    // finds its parent already there.
+    function foldersNeededForDrop(staged) {
+      const set = new Set();
+      for (const item of staged) {
+        if (!item.relDir) continue;
+        const parts = item.relDir.split('/');
+        for (let i = 1; i <= parts.length; i++) set.add(parts.slice(0, i).join('/'));
+      }
+      return Array.from(set).sort((a, b) => a.split('/').length - b.split('/').length);
+    }
+
+    async function createDroppedFolders(staged) {
+      for (const rel of foldersNeededForDrop(staged)) {
+        const parts = rel.split('/');
+        const name = parts.pop();
+        const parent = parts.length ? joinBrowsePath(currentPath, parts.join('/')) : currentPath;
+
+        const formData = new FormData();
+        formData.append('name', name);
+        formData.append('path', parent);
+        const resp = await fetch('/mkdir', { method: 'POST', body: formData });
+        if (!resp.ok) {
+          const text = await resp.text().catch(() => '');
+          // Re-dropping the same tree is normal; only a real failure should stop us.
+          if (!/exists/i.test(text)) throw new Error(`Could not create ${rel}: ${text || resp.status}`);
+        }
+      }
+    }
+
+    function joinBrowsePath(base, rel) {
+      return (base === '/' ? '' : base) + '/' + rel;
     }
 
     function openFolderModal() {
@@ -3587,6 +3709,13 @@
     let uploadGeneration = 0;       // Incremented each uploadFile() call; guards stale restoreAfterCancel()
     let currentUploadWs = null;     // Active WebSocket reference for external abort
     let currentUploadXhr = null;    // Active XHR reference for external abort
+    // Set only by a folder drop: entries parallel to fileInput.files, carrying
+    // the destination folder for each file. Null for every other upload.
+    let pendingFolderUpload = null;
+    // Bounds a runaway drop (a whole library, or a symlink loop) rather than
+    // queueing tens of thousands of sequential uploads against a device that
+    // serves one connection at a time.
+    const MAX_DROP_FILES = 500;
     const WS_PORT = 81;
     const WS_CHUNK_SIZE = 4096; // 4KB chunks - smaller for ESP32 stability
 
@@ -5303,7 +5432,9 @@
     }
 
     // Upload file via WebSocket (faster, binary protocol)
-    function uploadFileWebSocket(file, onProgress, onComplete, onError) {
+    // destPath defaults to the browsed folder; a folder drop passes the
+    // per-file destination so a dropped tree keeps its shape on the card.
+    function uploadFileWebSocket(file, onProgress, onComplete, onError, destPath) {
       return new Promise((resolve, reject) => {
         const ws = new WebSocket(getWsUrl());
         currentUploadWs = ws;
@@ -5316,7 +5447,7 @@
         ws.onopen = function () {
           console.log('[WS] Connected, starting upload:', file.name);
           // Send start message: START:<filename>:<size>:<path>
-          ws.send(`START:${file.name}:${file.size}:${currentPath}`);
+          ws.send(`START:${file.name}:${file.size}:${destPath || currentPath}`);
         };
 
         ws.onmessage = async function (event) {
@@ -5421,14 +5552,14 @@
     }
 
     // Upload file via HTTP (fallback method)
-    function uploadFileHTTP(file, onProgress, onComplete, onError) {
+    function uploadFileHTTP(file, onProgress, onComplete, onError, destPath) {
       return new Promise((resolve, reject) => {
         const formData = new FormData();
         formData.append('file', file);
 
         const xhr = new XMLHttpRequest();
         currentUploadXhr = xhr;
-        xhr.open('POST', '/upload?path=' + encodeURIComponent(currentPath), true);
+        xhr.open('POST', '/upload?path=' + encodeURIComponent(destPath || currentPath), true);
 
         xhr.upload.onprogress = function (e) {
           if (e.lengthComputable && onProgress) {
@@ -5491,6 +5622,7 @@
       let currentIndex = 0;
       const failedFiles = [];
       let useWebSocket = true; // Try WebSocket first
+      const stagedFolders = pendingFolderUpload;
 
       // Check if we should use batch logging mode
       const epubFilesToConvert = files.filter(f => f.name.toLowerCase().endsWith('.epub') && convertEnabled);
@@ -5549,6 +5681,9 @@
         }
 
         let file = files[currentIndex];
+        // Only a folder drop supplies destinations; everything else uploads
+        // into the folder currently being browsed.
+        const destPath = pendingFolderUpload ? pendingFolderUpload[currentIndex].destPath : currentPath;
         const originalFile = file;
         // Reset progress bar instantly without transition when starting a new file
         progressFill.classList.add('no-transition');
@@ -5710,9 +5845,9 @@
           }
 
           if (useWebSocket) {
-            await uploadFileWebSocket(file, onProgress, null, null);
+            await uploadFileWebSocket(file, onProgress, null, null, destPath);
           } else {
-            await uploadFileHTTP(file, onProgress, null, null);
+            await uploadFileHTTP(file, onProgress, null, null, destPath);
           }
           // Ensure progress bar shows 100% before moving to next file
           progressFill.style.width = '100%';
@@ -5732,7 +5867,7 @@
             useWebSocket = false;
             // Retry this file with HTTP
             try {
-              await uploadFileHTTP(file, onProgress, null, null);
+              await uploadFileHTTP(file, onProgress, null, null, destPath);
               onComplete();
             } catch (httpError) {
               onError(httpError.message);
@@ -5743,7 +5878,20 @@
         }
       }
 
-      uploadNextFile();
+      if (stagedFolders) {
+        // Recreate the dropped tree first: a missing folder would fail every
+        // file inside it.
+        progressText.textContent = 'Creating folders...';
+        createDroppedFolders(stagedFolders).then(uploadNextFile).catch((err) => {
+          progressFill.style.backgroundColor = '#e74c3c';
+          progressText.textContent = err && err.message ? err.message : String(err);
+          isUploadInProgress = false;
+          uploadBtn.disabled = false;
+          document.getElementById('uploadModalClose').classList.remove('disabled');
+        });
+      } else {
+        uploadNextFile();
+      }
     }
 
     function showFailedUploadsBanner() {


### PR DESCRIPTION
Two independent web-asset changes: dropping a folder onto the File Manager now uploads the folder, and the embedded pages are minified with terser.

**Net effect on flash: 96.8% → 96.6%** (6,341,109 → 6,331,551 bytes), despite adding a feature. RAM unchanged at 17.2%.

## 1. Folder drop (`b1ec059c`)

Dropping a folder created a **0-byte file named after it**. `dataTransfer.files` cannot represent a directory — it reports a single zero-length `File` — and that went straight into the upload flow.

The handler now reads `dataTransfer.items` via `webkitGetAsEntry`, which does distinguish directories, walks each into its files, recreates the folders on the card with `/mkdir`, and uploads each file into its own folder.

Three details that are load-bearing rather than incidental:

- **Entries are read synchronously.** The `DataTransfer` is neutered as soon as the handler returns, so they are collected before any `await`.
- **`readEntries` is drained in a loop.** It yields at most ~100 children per call; a single call silently truncates large folders.
- **Folders are created up front, shallowest first.** Not tidiness — the WebSocket upload handler builds its path but does **not** create missing directories, so a file would otherwise fail.

Both upload transports take an optional destination defaulting to the browsed folder, so ordinary uploads and the manual picker are unchanged. Only a folder drop supplies per-file destinations, staged parallel to `fileInput.files`; picking files by hand or reopening the modal clears that staging, since a stale list would send files to the wrong folders.

Bounded at 500 files per drop, with a warning when hit — a device serving one connection at a time should not be handed a whole library as one queue.

Cost: **+1,120 bytes**.

## 2. Terser minification (`b3178483`)

The pipeline only stripped comments and collapsed whitespace, so every identifier shipped at full length.

| Page | before | after | saved |
|---|---:|---:|---:|
| FilesPage | 37,486 | 29,693 | -7,793 (20.8%) |
| SettingsPage | 5,738 | 5,074 | -664 |
| StatsPage | 4,527 | 3,969 | -558 |
| FontsPage | 4,107 | 3,816 | -291 |
| HomePage | 3,080 | 2,825 | -255 |
| WelcomePage | 1,030 | 1,044 | +14 |
| **total** | **55,968** | **46,421** | **-9,547 (17.1%)** |

### The failure mode this had to avoid

`mangle` is used deliberately **without `toplevel`**. The pages call top-level functions from inline HTML attributes (`onclick="validateFile()"`) — 38 such references — which terser cannot see. With `toplevel` it would rename them into oblivion and drop the ones it judged unused, silently breaking every button.

Verified rather than assumed: every `on*=` handler name was extracted from the **shipped gzipped payloads** and confirmed to still resolve, and all six payloads pass `node --check`.

### Optional locally, mandatory in CI

Without terser the build warns loudly and falls back to the previous comment stripping, so a contributor without node still gets a working — just larger — firmware. CI installs it with `npm ci` and **fails the build if that warning appears**, because silently shipping the larger pages is exactly the regression this is meant to prevent.

Terser's own mtime joins the generated-header staleness check; without it, installing terser after a build would leave the cached headers at their old size.

`package-lock.json` is committed and terser pinned to `5.50.0`, so `npm ci` is reproducible. `node_modules/` is gitignored.

### What I measured and rejected

Before reaching for terser I checked the obvious refactor — factoring shared CSS/JS into the `#include` mechanism. The data killed it: **zero** byte-identical JS function bodies across the six pages, and CSS duplication totals only 2,673 raw bytes (~500 gzipped). It would have been churn for nothing.

Two larger options remain open and were **not** taken: replacing JSZip (27 KB gzipped, a third of all web assets) with fflate would save ~19 KB but rewrites the EPUB converter and breaks the plugin API; and the browser-side EPUB "Optimize" feature is ~24% of FilesPage's code, which is a product question rather than a cleanup.

## Testing

- **Verified on X4 hardware**: folder drop works, and the minified pages behave correctly across the web UI.
- All six shipped payloads parse under `node --check` after minification.
- All 38 inline-handler names confirmed to survive mangling.
- Folder-ordering logic unit-checked: parents before children, intermediate directories synthesized from deep paths, no duplicates.
- Graceful fallback verified by moving `node_modules` aside — warns and degrades rather than failing.
- Host suite unaffected (no C++ change); firmware build green.
