### PR TITLE
feat(epub): read a Calibre book.opf metadata sidecar, and manage covers from the web UI

### DIFF
--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -67,6 +67,7 @@ heading shows an untitled card.
 | `name` | the folder name |
 | `title` | `manifest.json`'s title, falling back to `name` — use it if you want the heading to track the manifest rather than hardcoding it |
 | `pluginFile(filename)` | URL for another file in this plugin's folder |
+| `currentPath` | the folder the File Manager is showing. Default to it rather than asking for a path the user has already navigated to; always `/` on Settings |
 
 Everything else is the web server's own
 same-origin API — a plugin uses `fetch()` against the endpoints in

--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -132,7 +132,7 @@ are never compiled, so they cost no flash.
 | `hello-plugin` | settings | Minimal reference and smoke test - renders a card and lists `/` |
 | `find-duplicates` | files | Reports files sharing an exact size. Report only: never writes, and never downloads a book |
 | `organize-by-author` | files | Sorts loose EPUBs into `<Author>/` folders. Preview first, moves only on Apply, carries sidecars along |
-| `metadata-editor` | files | Edits title, author, language, series, series index and description, saving them to a `book.opf` sidecar. Never rewrites the book |
+| `metadata-editor` | files | Edits title, author, language, series, series index and description into a `book.opf` sidecar, and manages the cover sidecar (file, clipboard paste, Open Library). Never rewrites the book |
 
 ## Loading order and failures
 

--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -117,8 +117,10 @@ Prefer `opf:file-as` over the element text when deriving a folder name - that is
 the sortable form, and what Calibre's own author folders use.
 
 This mirrors the existing cover-sidecar rule, and the same priority applies:
-sidecar wins over what is embedded in the book. Note the firmware itself does
-not read `book.opf` today; this is a convention between plugins for now.
+sidecar wins over what is embedded in the book. **The firmware reads it too** -
+the title, author and series shown on the device come from `book.opf` when one
+is present, so a plugin writing one changes what the reader displays. See
+[sidecar-files.md](sidecar-files.md) for the device-side rules.
 
 ## Bundled plugins
 

--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -132,6 +132,7 @@ are never compiled, so they cost no flash.
 | `hello-plugin` | settings | Minimal reference and smoke test - renders a card and lists `/` |
 | `find-duplicates` | files | Reports files sharing an exact size. Report only: never writes, and never downloads a book |
 | `organize-by-author` | files | Sorts loose EPUBs into `<Author>/` folders. Preview first, moves only on Apply, carries sidecars along |
+| `metadata-editor` | files | Edits title, author, language, series, series index and description, saving them to a `book.opf` sidecar. Never rewrites the book |
 
 ## Loading order and failures
 

--- a/docs/sidecar-files.md
+++ b/docs/sidecar-files.md
@@ -38,6 +38,11 @@ Fields taken from the sidecar, when non-empty:
 | series index | `<meta name="calibre:series_index">` or `group-position` |
 | description | `<dc:description>` |
 
+The bundled `metadata-editor` plugin writes these from the web UI, so you do not
+have to hand-edit XML — see [sd-plugins.md](sd-plugins.md). It edits an existing
+sidecar in place rather than regenerating it, so publisher, identifiers, dates
+and other fields it does not manage survive untouched.
+
 A minimal sidecar:
 
 ```xml
@@ -80,5 +85,21 @@ Deleting the sidecar restores the book's embedded metadata, again on next load.
 
 A sidecar is tied to its book by filename, so **moving or renaming a book must
 carry its sidecars along** — otherwise the cover silently reverts to the embedded
-one and metadata corrections are lost. The bundled `organize-by-author` plugin
-does this; see [sd-plugins.md](sd-plugins.md).
+one and metadata corrections are lost.
+
+Who does this today:
+
+- **Move to `/COMPLETED`** (the optional finished-book action) moves the book
+  and every sidecar, resolving name collisions for each
+  (`moveSidecarFilesToCompleted`).
+- **The `organize-by-author` plugin** moves sidecars with the book — see
+  [sd-plugins.md](sd-plugins.md).
+- **Manual moves** through the web File Manager or a script are your own
+  responsibility: move `book.epub`, `book.jpg` and `book.opf` together.
+
+If you add another sidecar type, three places need to agree on what counts as
+one: `ReaderActivity::sidecarCoverPath` (images), `Epub::metadataSidecarPath`
+(`.opf`), and the extension list in `moveSidecarFilesToCompleted`.
+
+Deleting a book does **not** currently delete its sidecars; they are left behind
+as harmless orphans.

--- a/docs/sidecar-files.md
+++ b/docs/sidecar-files.md
@@ -22,6 +22,17 @@ When present it replaces the book's embedded cover on the home screen and in the
 book browser, and the firmware skips extracting the embedded cover entirely.
 Implemented by `ReaderActivity::sidecarCoverPath()`.
 
+The bundled `metadata-editor` plugin manages this from the web UI — preview the
+current cover, replace it from a local file, paste an image copied from any
+website, search Open Library, or remove it. See [sd-plugins.md](sd-plugins.md).
+
+**Replacing a cover takes effect on the next load.** The rendered thumbnail is
+cached per book, and `ReaderActivity::ensureCoverThumb()` compares the sidecar's
+modification time against it: a newer sidecar wins and the thumbnail is
+regenerated. Note this depends on the clock — files written while the RTC is
+unsynced all carry 1980-01-01, so on hardware without a working RTC a replaced
+cover may need a cache clear.
+
 ## Metadata sidecar — `book.opf`
 
 A Calibre-style OPF. Calibre writes one beside every book it exports, so a

--- a/docs/sidecar-files.md
+++ b/docs/sidecar-files.md
@@ -1,0 +1,84 @@
+# Sidecar files
+
+A sidecar is a file sitting beside a book, sharing its name but with a different
+extension. The firmware prefers it over the equivalent data embedded in the book,
+so you can correct a cover or a title without rewriting the EPUB.
+
+```
+/Books/
+    Some Book.epub      the book
+    Some Book.jpg       cover sidecar     (optional)
+    Some Book.opf       metadata sidecar  (optional)
+```
+
+The rule is the same for both: **a sidecar wins over what is inside the book.**
+
+## Cover sidecar — `book.jpg`
+
+Recognised extensions, in this order: `.jpg`, `.jpeg`, `.png`, `.bmp` (and their
+uppercase forms). The first one found wins.
+
+When present it replaces the book's embedded cover on the home screen and in the
+book browser, and the firmware skips extracting the embedded cover entirely.
+Implemented by `ReaderActivity::sidecarCoverPath()`.
+
+## Metadata sidecar — `book.opf`
+
+A Calibre-style OPF. Calibre writes one beside every book it exports, so a
+library exported from Calibre already has these and needs no extra work.
+
+Fields taken from the sidecar, when non-empty:
+
+| Field | Source in the OPF |
+|---|---|
+| title | `<dc:title>` |
+| author | `<dc:creator>` |
+| language | `<dc:language>` |
+| series | `<meta name="calibre:series">` or `belongs-to-collection` |
+| series index | `<meta name="calibre:series_index">` or `group-position` |
+| description | `<dc:description>` |
+
+A minimal sidecar:
+
+```xml
+<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uuid_id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>The Title As You Want It Shown</dc:title>
+    <dc:creator opf:file-as="Lastname, First" opf:role="aut">First Lastname</dc:creator>
+    <meta name="calibre:series" content="Series Name"/>
+    <meta name="calibre:series_index" content="4"/>
+  </metadata>
+</package>
+```
+
+### Rules
+
+- **Empty fields are ignored.** A sidecar supplying only an author leaves the
+  book's own title alone, so a partial sidecar cannot blank out good metadata.
+- **Cover references are not taken from it.** `coverItemHref` points inside the
+  ZIP, which a sidecar cannot meaningfully supply — use a cover sidecar instead.
+- **Only metadata.** The spine, manifest and reading order always come from the
+  book itself. A sidecar cannot change what you read, only how it is labelled.
+- **A malformed or oversized sidecar is ignored**, and the book opens normally
+  with its embedded metadata. The cap is 16KB
+  (`Epub::MAX_METADATA_SIDECAR_BYTES`); a real Calibre OPF is a couple of KB.
+
+### When changes take effect
+
+Immediately — on the next time the book's metadata is loaded.
+
+The sidecar is deliberately **not** baked into the `book.bin` cache. That cache
+is only rebuilt when the EPUB's own bytes change, so a baked value would leave an
+edited sidecar silently ineffective. Instead the overlay is applied on every
+load, including the cached path (`Epub::applyMetadataSidecar()`). Cost when no
+sidecar exists is a single file-existence check.
+
+Deleting the sidecar restores the book's embedded metadata, again on next load.
+
+## Moving books
+
+A sidecar is tied to its book by filename, so **moving or renaming a book must
+carry its sidecars along** — otherwise the cover silently reverts to the embedded
+one and metadata corrections are lost. The bundled `organize-by-author` plugin
+does this; see [sd-plugins.md](sd-plugins.md).

--- a/docs/sidecar-files.md
+++ b/docs/sidecar-files.md
@@ -97,9 +97,17 @@ Who does this today:
 - **Manual moves** through the web File Manager or a script are your own
   responsibility: move `book.epub`, `book.jpg` and `book.opf` together.
 
-If you add another sidecar type, three places need to agree on what counts as
-one: `ReaderActivity::sidecarCoverPath` (images), `Epub::metadataSidecarPath`
-(`.opf`), and the extension list in `moveSidecarFilesToCompleted`.
+Adding another sidecar type means adding it to **one** place:
+`lib/FsHelpers/SidecarFiles.h`. Cover resolution, metadata resolution and the
+move-with-the-book path all read those tables — `ReaderActivity::sidecarCoverPath`
+and `Epub::metadataSidecarPath` are one-line delegates that add only their own
+logging.
+
+This used to be three independent copies, which is exactly how `.opf` came to be
+readable by the reader but left behind when a finished book moved. The copies had
+also drifted: the move path derived its base name without checking for a path
+separator, so a book with no extension inside a dotted folder (`/My.Books/untitled`)
+took the dot from the folder.
 
 Deleting a book does **not** currently delete its sidecars; they are left behind
 as harmless orphans.

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -643,6 +643,7 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
         Storage.removeDir((cachePath + "/sections").c_str());
       }
     }
+    applyMetadataSidecar();
     LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());
     return true;
   }
@@ -766,8 +767,66 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   // Pin the content this cache was built from (see the staleness check above).
   if (haveFp) writeStoredFingerprint(zipFp);
 
+  applyMetadataSidecar();
   LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());
   return true;
+}
+
+std::string Epub::metadataSidecarPath(const std::string& bookPath) {
+  const auto sep = bookPath.find_last_of("/\\");
+  const auto dot = bookPath.rfind('.');
+  if (dot == std::string::npos || (sep != std::string::npos && dot < sep)) return "";
+  const std::string base = bookPath.substr(0, dot);
+  for (const char* ext : {".opf", ".OPF"}) {
+    const std::string candidate = base + ext;
+    if (Storage.exists(candidate.c_str())) return candidate;
+  }
+  return "";
+}
+
+// Calibre writes an OPF beside each exported book. Where one sits next to the
+// EPUB it is authoritative for that book's descriptive metadata, so a user can
+// correct a title, author or series without rewriting the book - the same rule
+// the cover sidecar already follows.
+//
+// Only the descriptive fields are taken. coverItemHref and textReferenceHref
+// are zip-internal paths that a sidecar cannot meaningfully supply, and covers
+// have their own sidecar already. Empty sidecar fields are skipped, so a
+// partial sidecar cannot blank out good embedded metadata.
+void Epub::applyMetadataSidecar() const {
+  if (!bookMetadataCache) return;
+  const std::string path = metadataSidecarPath(filepath);
+  if (path.empty()) return;
+
+  size_t size = 0;
+  {
+    HalFile probe;
+    if (!Storage.openFileForRead("EBP", path, probe)) return;
+    size = probe.fileSize();
+  }
+  if (size == 0 || size > MAX_METADATA_SIDECAR_BYTES) {
+    LOG_DBG("EBP", "Ignoring metadata sidecar, %u bytes: %s", static_cast<unsigned>(size), path.c_str());
+    return;
+  }
+
+  // Null cache: a sidecar carries no real manifest or spine, so no item index
+  // must be built from it. cachePath/contentBasePath are passed because the
+  // parser holds them by reference - they must outlive it, so no temporaries.
+  ContentOpfParser parser(cachePath, contentBasePath, size, nullptr);
+  if (!parser.setup()) return;
+  if (!Storage.readFileToStream(path.c_str(), parser, 1024)) {
+    LOG_DBG("EBP", "Could not read metadata sidecar: %s", path.c_str());
+    return;
+  }
+
+  auto& md = bookMetadataCache->coreMetadata;
+  if (!parser.title.empty()) md.title = parser.title;
+  if (!parser.author.empty()) md.author = parser.author;
+  if (!parser.language.empty()) md.language = parser.language;
+  if (!parser.series.empty()) md.series = parser.series;
+  if (!parser.seriesIndex.empty()) md.seriesIndex = parser.seriesIndex;
+  if (!parser.description.empty()) md.description = parser.description;
+  LOG_DBG("EBP", "Applied metadata sidecar: %s", path.c_str());
 }
 
 bool Epub::loadForCover() {
@@ -779,6 +838,7 @@ bool Epub::loadForCover() {
 
   // Fast path: a book.bin already exists — it carries coverItemHref, no OPF parse needed.
   if (bookMetadataCache->load()) {
+    applyMetadataSidecar();
     return true;
   }
 
@@ -795,6 +855,7 @@ bool Epub::loadForCover() {
   // Mark loaded so ensureCoverImageCached()'s isLoaded() gate passes. Spine/TOC stay empty — the
   // caller uses only the cover path (documented on loadForCover / markCoverMetadataLoaded).
   bookMetadataCache->markCoverMetadataLoaded();
+  applyMetadataSidecar();
   return true;
 }
 
@@ -807,6 +868,7 @@ bool Epub::loadForMetadata() {
 
   // Fast path: an existing book.bin already carries title/author/series, no OPF parse needed.
   if (bookMetadataCache->load()) {
+    applyMetadataSidecar();
     return true;
   }
 
@@ -818,6 +880,7 @@ bool Epub::loadForMetadata() {
   }
   // Mark loaded for API symmetry with loadForCover(); spine/TOC stay empty and must not be used.
   bookMetadataCache->markCoverMetadataLoaded();
+  applyMetadataSidecar();
   return true;
 }
 

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -9,6 +9,7 @@
 #include <Logging.h>
 #include <PngToBmpConverter.h>
 #include <Serialization.h>
+#include <SidecarFiles.h>
 #include <ZipFile.h>
 #include <esp_system.h>
 
@@ -772,17 +773,7 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   return true;
 }
 
-std::string Epub::metadataSidecarPath(const std::string& bookPath) {
-  const auto sep = bookPath.find_last_of("/\\");
-  const auto dot = bookPath.rfind('.');
-  if (dot == std::string::npos || (sep != std::string::npos && dot < sep)) return "";
-  const std::string base = bookPath.substr(0, dot);
-  for (const char* ext : {".opf", ".OPF"}) {
-    const std::string candidate = base + ext;
-    if (Storage.exists(candidate.c_str())) return candidate;
-  }
-  return "";
-}
+std::string Epub::metadataSidecarPath(const std::string& bookPath) { return SidecarFiles::metadataPath(bookPath); }
 
 // Calibre writes an OPF beside each exported book. Where one sits next to the
 // EPUB it is authoritative for that book's descriptive metadata, so a user can

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -104,6 +104,13 @@ class Epub {
   bool readStoredFingerprint(uint64_t* out) const;
   void writeStoredFingerprint(uint64_t fp) const;
 
+  // Overlay a "<book>.opf" metadata sidecar onto the loaded coreMetadata, if one
+  // exists. Called from every load path once coreMetadata is final — including
+  // the cached ones, which is the point: the sidecar is never baked into
+  // book.bin, so editing it takes effect on the next open rather than waiting
+  // for the EPUB's own bytes to change. Cheap when absent (one Storage.exists).
+  void applyMetadataSidecar() const;
+
  public:
   explicit Epub(std::string filepath, const std::string& cacheDir) : filepath(std::move(filepath)) {
     // create a cache key based on the filepath
@@ -139,6 +146,16 @@ class Epub {
   // cache is missing. Cheap (only file-existence checks) so callers can decide
   // whether to show a progress popup before calling load().
   bool needsFirstOpenIndexing() const;
+
+  // Path of the Calibre-style metadata sidecar for a book ("/Books/x.epub" ->
+  // "/Books/x.opf"), or "" when there is none. Mirrors
+  // ReaderActivity::sidecarCoverPath, and the same rule applies: a file beside
+  // the book wins over what is embedded in it.
+  static std::string metadataSidecarPath(const std::string& bookPath);
+  // Sidecars above this are treated as not-a-metadata-file and ignored. A
+  // Calibre metadata OPF is a couple of KB; the cap stops a stray large file
+  // sharing the book's basename from being read into the heap.
+  static constexpr size_t MAX_METADATA_SIDECAR_BYTES = 16384;
 
   bool clearCache(bool preserveThumbs = false) const;
   void setupCacheDir() const;

--- a/lib/FsHelpers/SidecarFiles.cpp
+++ b/lib/FsHelpers/SidecarFiles.cpp
@@ -1,0 +1,84 @@
+#include "SidecarFiles.h"
+
+#include <HalStorage.h>
+
+#include <cctype>
+
+namespace SidecarFiles {
+namespace {
+
+// Local rather than strcasecmp/_stricmp, which differ by platform and would
+// need a portability shim for a four-character comparison.
+bool sameExtensionIgnoringCase(const char* a, const char* b) {
+  while (*a && *b) {
+    if (std::tolower(static_cast<unsigned char>(*a)) != std::tolower(static_cast<unsigned char>(*b))) return false;
+    ++a;
+    ++b;
+  }
+  return *a == *b;
+}
+
+// First extension in `exts` for which "<base><ext>" exists on the card.
+std::string firstExisting(const std::string& bookPath, const char* const* exts, size_t count) {
+  const std::string base = basePath(bookPath);
+  if (base.empty()) return "";
+  for (size_t i = 0; i < count; i++) {
+    std::string candidate = base + exts[i];
+    if (Storage.exists(candidate.c_str())) return candidate;
+  }
+  return "";
+}
+
+}  // namespace
+
+std::string basePath(const std::string& bookPath) {
+  const auto sep = bookPath.find_last_of("/\\");
+  const auto dot = bookPath.rfind('.');
+  // No dot at all, or the only dot belongs to a parent directory.
+  if (dot == std::string::npos || (sep != std::string::npos && dot < sep)) return "";
+  return bookPath.substr(0, dot);
+}
+
+std::string coverPath(const std::string& bookPath) {
+  return firstExisting(bookPath, kCoverExtensions, sizeof(kCoverExtensions) / sizeof(kCoverExtensions[0]));
+}
+
+std::string metadataPath(const std::string& bookPath) {
+  return firstExisting(bookPath, kMetadataExtensions, sizeof(kMetadataExtensions) / sizeof(kMetadataExtensions[0]));
+}
+
+std::vector<const char*> existingExtensions(const std::string& bookPath) {
+  std::vector<const char*> found;
+  const std::string base = basePath(bookPath);
+  if (base.empty()) return found;
+
+  // Small and bounded by the tables above; reserve once rather than grow.
+  found.reserve(sizeof(kCoverExtensions) / sizeof(kCoverExtensions[0]) +
+                sizeof(kMetadataExtensions) / sizeof(kMetadataExtensions[0]));
+
+  // The tables list each extension in both cases, but the SD card is FAT/exFAT
+  // and answers to either - so "book.jpg" matches ".jpg" AND ".JPG", and
+  // reporting both would have a caller that moves them rename the same file
+  // twice, the second failing because the first already moved it. Report the
+  // first case that matched and skip its variants. On a case-sensitive
+  // filesystem nothing is skipped that did not genuinely match first.
+  const auto alreadyMatched = [&found](const char* ext) {
+    for (const char* seen : found) {
+      if (sameExtensionIgnoringCase(seen, ext)) return true;
+    }
+    return false;
+  };
+
+  for (const char* const* table : {kCoverExtensions, kMetadataExtensions}) {
+    const size_t count = (table == kCoverExtensions) ? sizeof(kCoverExtensions) / sizeof(kCoverExtensions[0])
+                                                     : sizeof(kMetadataExtensions) / sizeof(kMetadataExtensions[0]);
+    for (size_t i = 0; i < count; i++) {
+      const char* ext = table[i];
+      if (alreadyMatched(ext)) continue;
+      if (Storage.exists((base + ext).c_str())) found.push_back(ext);
+    }
+  }
+  return found;
+}
+
+}  // namespace SidecarFiles

--- a/lib/FsHelpers/SidecarFiles.h
+++ b/lib/FsHelpers/SidecarFiles.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <string>
+#include <vector>
+
+// Sidecar files: companions sitting beside a book, sharing its name with a
+// different extension. The firmware prefers them over the equivalent data
+// embedded in the book, so "Some Book.jpg" overrides its cover and
+// "Some Book.opf" overrides its metadata (see docs/sidecar-files.md).
+//
+// This is the single definition of what counts as a sidecar. It used to be
+// spread across three places - the cover resolver, the metadata resolver and
+// the move-to-/COMPLETED extension list - which is precisely how .opf came to
+// be readable by the reader but left behind when a finished book moved.
+//
+// ADDING A NEW KIND OF SIDECAR MEANS ADDING IT HERE AND NOWHERE ELSE.
+namespace SidecarFiles {
+
+// Cover images, in resolution order: the first one that exists wins.
+inline constexpr const char* kCoverExtensions[] = {".jpg", ".jpeg", ".png", ".bmp", ".JPG", ".JPEG", ".PNG", ".BMP"};
+// Calibre-style metadata OPF.
+inline constexpr const char* kMetadataExtensions[] = {".opf", ".OPF"};
+
+// "/Books/Some Book.epub" -> "/Books/Some Book". Empty when the path carries no
+// extension of its own - a bare name, or one whose only dot belongs to a parent
+// directory ("/My.Books/untitled"), which must not be mistaken for one.
+std::string basePath(const std::string& bookPath);
+
+// Full path of the first existing sidecar of that kind, or "" when there is
+// none. Both hit the filesystem once per candidate extension.
+std::string coverPath(const std::string& bookPath);
+std::string metadataPath(const std::string& bookPath);
+
+// Extensions of every sidecar that actually exists beside this book, covers and
+// metadata alike. For callers that must treat them as a set rather than resolve
+// one - moving a book has to carry all of them, or it silently strands the
+// cover and the metadata corrections behind.
+std::vector<const char*> existingExtensions(const std::string& bookPath);
+
+}  // namespace SidecarFiles

--- a/plugins/find-duplicates/plugin.js
+++ b/plugins/find-duplicates/plugin.js
@@ -23,7 +23,8 @@ CrossPoint.registerPlugin((container, api) => {
     '<h2>' + esc(api.title) + '</h2>' +
     '<p>Lists files that share an exact size - usually the same book stored twice. ' +
     'Reads only the folder listing, so it never downloads a book, and never changes anything.</p>' +
-    '<p><label>Start folder <input type="text" id="fd-root" value="/" style="width:16em"></label> ' +
+    '<p><label>Start folder <input type="text" id="fd-root" value="' + esc(api.currentPath) +
+    '" style="width:16em"></label> ' +
     '<label><input type="checkbox" id="fd-epub" checked> EPUBs only</label></p>' +
     '<p><button id="fd-scan">Scan</button> <span id="fd-status"></span></p>' +
     '<div id="fd-out"></div>';

--- a/plugins/metadata-editor/manifest.json
+++ b/plugins/metadata-editor/manifest.json
@@ -1,0 +1,4 @@
+{
+  "title": "Metadata Editor",
+  "mount": "files"
+}

--- a/plugins/metadata-editor/plugin.js
+++ b/plugins/metadata-editor/plugin.js
@@ -35,14 +35,15 @@ CrossPoint.registerPlugin((container, api) => {
     '<p>Edits a book\'s metadata and saves it as a <code>book.opf</code> sidecar beside it. ' +
     'The book itself is never modified. Clearing a field removes it from the sidecar, so the ' +
     'book\'s own value shows again.</p>' +
-    '<p><label>Folder <input type="text" id="me-dir" value="/" style="width:16em"></label> ' +
+    '<p><label>Folder <input type="text" id="me-dir" value="' + esc(api.currentPath) +
+    '" style="width:16em"></label> ' +
     '<button id="me-scan">Scan</button> <span id="me-status"></span></p>' +
     '<div id="me-list"></div>' +
     '<div id="me-form"></div>';
 
   const el = (id) => container.querySelector(id);
   const status = (t) => { el('#me-status').textContent = t; };
-  let dir = '/';
+  let dir = api.currentPath;
   let books = [];
   let editing = null;   // { name, base, hasSidecar }
   let sourceDoc = null; // parsed existing sidecar, or null when creating fresh

--- a/plugins/metadata-editor/plugin.js
+++ b/plugins/metadata-editor/plugin.js
@@ -1,0 +1,283 @@
+// Metadata Editor - edits a book's title, author, language, series, series
+// index and description, and saves them to a "book.opf" sidecar.
+//
+// It never rewrites the EPUB. The firmware prefers a sidecar over the metadata
+// embedded in the book (docs/sidecar-files.md), so writing one is enough to
+// change what the reader displays - without a multi-megabyte round trip, without
+// any risk of corrupting the book, and reversible by deleting one small file.
+//
+// An existing sidecar is edited in place as XML rather than regenerated, so
+// everything this editor does not manage - publisher, identifiers, dates, the
+// Calibre UUID, guide entries - survives untouched. Only when there is no
+// sidecar at all is a fresh minimal one created.
+//
+// Reading order matches the firmware's: an existing book.opf wins; otherwise
+// the book's own OPF is read via JSZip, which costs a full download.
+//
+// Everything is inside this closure: plugins share the page's global scope.
+CrossPoint.registerPlugin((container, api) => {
+  const DC_NS = 'http://purl.org/dc/elements/1.1/';
+  const OPF_NS = 'http://www.idpf.org/2007/opf';
+
+  // name -> how it is stored in an OPF. "dc" elements carry their value as text;
+  // "meta" fields are Calibre's <meta name=... content=.../> form.
+  const FIELDS = [
+    { key: 'title', label: 'Title', kind: 'dc', tag: 'title' },
+    { key: 'author', label: 'Author', kind: 'dc', tag: 'creator' },
+    { key: 'language', label: 'Language', kind: 'dc', tag: 'language', hint: 'e.g. en, de' },
+    { key: 'series', label: 'Series', kind: 'meta', metaName: 'calibre:series' },
+    { key: 'seriesIndex', label: 'Series index', kind: 'meta', metaName: 'calibre:series_index' },
+    { key: 'description', label: 'Description', kind: 'dc', tag: 'description', multiline: true }
+  ];
+
+  container.innerHTML =
+    '<h2>' + esc(api.title) + '</h2>' +
+    '<p>Edits a book\'s metadata and saves it as a <code>book.opf</code> sidecar beside it. ' +
+    'The book itself is never modified. Clearing a field removes it from the sidecar, so the ' +
+    'book\'s own value shows again.</p>' +
+    '<p><label>Folder <input type="text" id="me-dir" value="/" style="width:16em"></label> ' +
+    '<button id="me-scan">Scan</button> <span id="me-status"></span></p>' +
+    '<div id="me-list"></div>' +
+    '<div id="me-form"></div>';
+
+  const el = (id) => container.querySelector(id);
+  const status = (t) => { el('#me-status').textContent = t; };
+  let dir = '/';
+  let books = [];
+  let editing = null;   // { name, base, hasSidecar }
+  let sourceDoc = null; // parsed existing sidecar, or null when creating fresh
+
+  el('#me-scan').onclick = async () => {
+    dir = normalize(el('#me-dir').value.trim() || '/');
+    el('#me-form').textContent = '';
+    el('#me-list').textContent = '';
+    editing = null;
+    try {
+      status('Listing ' + dir + '...');
+      const entries = await getJson('/api/files?path=' + encodeURIComponent(dir));
+      const names = new Set(entries.filter((e) => !e.isDirectory).map((e) => e.name));
+      books = entries.filter((e) => !e.isDirectory && e.isEpub)
+        .map((e) => ({ name: e.name, base: stripExt(e.name), hasSidecar: names.has(stripExt(e.name) + '.opf') }));
+      renderList();
+      status(books.length + ' book(s)');
+    } catch (e) {
+      status('Failed: ' + msg(e));
+    }
+  };
+
+  function renderList() {
+    if (!books.length) { el('#me-list').innerHTML = '<p>No EPUBs directly in this folder.</p>'; return; }
+    let html = '<div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse">' +
+      '<tr><th align="left">Book</th><th align="left">Sidecar</th><th></th></tr>';
+    books.forEach((b, i) => {
+      html += '<tr style="border-top:1px solid rgba(128,128,128,.35)">' +
+        '<td>' + esc(b.name) + '</td>' +
+        '<td>' + (b.hasSidecar ? 'book.opf' : '<em>none yet</em>') + '</td>' +
+        '<td><button data-i="' + i + '" class="me-edit">Edit</button></td></tr>';
+    });
+    el('#me-list').innerHTML = html + '</table></div>';
+    container.querySelectorAll('.me-edit').forEach((btn) => {
+      btn.onclick = () => openEditor(books[Number(btn.dataset.i)]);
+    });
+  }
+
+  async function openEditor(book) {
+    editing = book;
+    sourceDoc = null;
+    el('#me-form').innerHTML = '<p>Loading metadata...</p>';
+    let values;
+    try {
+      if (book.hasSidecar) {
+        status('Reading ' + book.base + '.opf...');
+        sourceDoc = xml(await getText(dl(join(dir, book.base + '.opf'))));
+        values = readFrom(sourceDoc);
+      } else {
+        status('No sidecar - downloading ' + book.name + ' to read its metadata...');
+        values = readFrom(xml(await opfFromEpub(join(dir, book.name))));
+      }
+    } catch (e) {
+      el('#me-form').innerHTML = '<p class="plugin-error">Could not read metadata: ' + esc(msg(e)) + '</p>';
+      status('');
+      return;
+    }
+    renderForm(book, values);
+    status('');
+  }
+
+  function renderForm(book, values) {
+    let html = '<h3>' + esc(book.name) + '</h3>';
+    for (const f of FIELDS) {
+      const v = esc(values[f.key] || '');
+      html += '<p><label style="display:block"><strong>' + esc(f.label) + '</strong>' +
+        (f.hint ? ' <span style="opacity:.7">' + esc(f.hint) + '</span>' : '') + '<br>' +
+        (f.multiline
+          ? '<textarea id="me-f-' + f.key + '" rows="4" style="width:100%">' + v + '</textarea>'
+          : '<input type="text" id="me-f-' + f.key + '" value="' + v + '" style="width:100%">') +
+        '</label></p>';
+    }
+    html += '<p><button id="me-save">Save sidecar</button> ' +
+      '<button id="me-cancel">Cancel</button> <span id="me-saved"></span></p>';
+    el('#me-form').innerHTML = html;
+    el('#me-cancel').onclick = () => { el('#me-form').textContent = ''; editing = null; };
+    el('#me-save').onclick = save;
+  }
+
+  async function save() {
+    if (!editing) return;
+    const values = {};
+    for (const f of FIELDS) values[f.key] = el('#me-f-' + f.key).value.trim();
+
+    el('#me-save').disabled = true;
+    el('#me-saved').textContent = 'Saving...';
+    try {
+      // Edit the existing sidecar so unmanaged fields survive; only build a new
+      // document when there is nothing to preserve.
+      const doc = sourceDoc || freshDoc();
+      writeInto(doc, values);
+      const serialized = '<?xml version="1.0" encoding="utf-8"?>\n' +
+        new XMLSerializer().serializeToString(doc.documentElement) + '\n';
+      await upload(editing.base + '.opf', serialized);
+
+      editing.hasSidecar = true;
+      sourceDoc = doc;
+      renderList();
+      el('#me-saved').textContent = 'Saved ' + editing.base + '.opf';
+    } catch (e) {
+      el('#me-saved').textContent = 'Failed: ' + msg(e);
+    } finally {
+      el('#me-save').disabled = false;
+    }
+  }
+
+  // --- OPF read/write -------------------------------------------------------
+  function readFrom(doc) {
+    const out = {};
+    for (const f of FIELDS) {
+      if (f.kind === 'dc') {
+        const n = dcElement(doc, f.tag);
+        out[f.key] = n ? (n.textContent || '').trim() : '';
+      } else {
+        const n = metaElement(doc, f.metaName);
+        out[f.key] = n ? (n.getAttribute('content') || '').trim() : '';
+      }
+    }
+    return out;
+  }
+
+  function writeInto(doc, values) {
+    const metadata = metadataElement(doc);
+    for (const f of FIELDS) {
+      const value = values[f.key];
+      if (f.kind === 'dc') {
+        let n = dcElement(doc, f.tag);
+        if (!value) { if (n && n.parentNode) n.parentNode.removeChild(n); continue; }
+        if (!n) {
+          n = doc.createElementNS(DC_NS, 'dc:' + f.tag);
+          metadata.appendChild(n);
+        }
+        n.textContent = value;
+      } else {
+        let n = metaElement(doc, f.metaName);
+        if (!value) { if (n && n.parentNode) n.parentNode.removeChild(n); continue; }
+        if (!n) {
+          n = doc.createElementNS(OPF_NS, 'meta');
+          n.setAttribute('name', f.metaName);
+          metadata.appendChild(n);
+        }
+        n.setAttribute('content', value);
+      }
+    }
+    // The firmware also accepts the EPUB 3 spelling of series. Leaving a stale
+    // one behind would give two sources of truth whose winner depends on
+    // document order, so drop them once we manage the Calibre pair.
+    for (const prop of ['belongs-to-collection', 'group-position']) {
+      Array.from(doc.getElementsByTagName('meta'))
+        .filter((m) => m.getAttribute('property') === prop)
+        .forEach((m) => m.parentNode && m.parentNode.removeChild(m));
+    }
+  }
+
+  function metadataElement(doc) {
+    const found = doc.getElementsByTagName('metadata')[0] ||
+      doc.getElementsByTagNameNS(OPF_NS, 'metadata')[0];
+    if (found) return found;
+    const m = doc.createElementNS(OPF_NS, 'metadata');
+    doc.documentElement.appendChild(m);
+    return m;
+  }
+
+  function dcElement(doc, tag) {
+    return doc.getElementsByTagNameNS(DC_NS, tag)[0] || doc.getElementsByTagName('dc:' + tag)[0] || null;
+  }
+
+  function metaElement(doc, name) {
+    return Array.from(doc.getElementsByTagName('meta')).find((m) => m.getAttribute('name') === name) || null;
+  }
+
+  function freshDoc() {
+    return xml(
+      '<?xml version="1.0" encoding="utf-8"?>\n' +
+      '<package xmlns="' + OPF_NS + '" version="2.0" unique-identifier="uuid_id">\n' +
+      '  <metadata xmlns:dc="' + DC_NS + '" xmlns:opf="' + OPF_NS + '"/>\n' +
+      '</package>\n');
+  }
+
+  async function opfFromEpub(path) {
+    if (typeof JSZip === 'undefined') throw new Error('JSZip unavailable on this page');
+    const r = await fetch(dl(path));
+    if (!r.ok) throw new Error('download ' + r.status);
+    const zip = await JSZip.loadAsync(await r.blob());
+    const containerFile = zip.file('META-INF/container.xml');
+    if (!containerFile) throw new Error('no container.xml');
+    const rootfile = xml(await containerFile.async('string')).getElementsByTagName('rootfile')[0];
+    const opfPath = rootfile && rootfile.getAttribute('full-path');
+    if (!opfPath) throw new Error('no rootfile');
+    const opfFile = zip.file(opfPath);
+    if (!opfFile) throw new Error('missing ' + opfPath);
+    return opfFile.async('string');
+  }
+
+  // --- helpers --------------------------------------------------------------
+  async function upload(filename, text) {
+    const fd = new FormData();
+    // The path is a query parameter, matching how the File Manager itself
+    // uploads; /upload overwrites an existing file of the same name.
+    fd.append('file', new Blob([text], { type: 'application/oebps-package+xml' }), filename);
+    const r = await fetch('/upload?path=' + encodeURIComponent(dir), { method: 'POST', body: fd });
+    if (!r.ok) throw new Error('upload ' + r.status + ' ' + (await r.text().catch(() => '')));
+  }
+
+  function xml(text) {
+    const doc = new DOMParser().parseFromString(text, 'application/xml');
+    if (doc.getElementsByTagName('parsererror').length) throw new Error('malformed XML');
+    return doc;
+  }
+
+  async function getJson(url) {
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(url + ' -> ' + r.status);
+    return r.json();
+  }
+
+  async function getText(url) {
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(url + ' -> ' + r.status);
+    return r.text();
+  }
+
+  function dl(p) { return '/download?path=' + encodeURIComponent(p); }
+  function join(d, name) { return (d === '/' ? '' : d) + '/' + name; }
+  function stripExt(n) { const d = n.lastIndexOf('.'); return d > 0 ? n.slice(0, d) : n; }
+  function msg(e) { return (e && e.message) || String(e); }
+
+  function normalize(p) {
+    if (!p.startsWith('/')) p = '/' + p;
+    if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+    return p;
+  }
+
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+});

--- a/plugins/metadata-editor/plugin.js
+++ b/plugins/metadata-editor/plugin.js
@@ -116,10 +116,205 @@ CrossPoint.registerPlugin((container, api) => {
         '</label></p>';
     }
     html += '<p><button id="me-save">Save sidecar</button> ' +
-      '<button id="me-cancel">Cancel</button> <span id="me-saved"></span></p>';
+      '<button id="me-cancel">Cancel</button> <span id="me-saved"></span></p>' +
+      '<hr><div id="me-cover"></div>';
     el('#me-form').innerHTML = html;
     el('#me-cancel').onclick = () => { el('#me-form').textContent = ''; editing = null; };
     el('#me-save').onclick = save;
+    renderCover(book, values);
+  }
+
+  // --- cover sidecar --------------------------------------------------------
+  // A cover beside the book overrides the one embedded in it, exactly like the
+  // metadata sidecar, and is written the same way: the book is never touched.
+  //
+  // No image is ever fetched cross-origin. A page served from the device cannot
+  // read a response from goodreads.com or books.google.com - they send no CORS
+  // headers, and drawing such an image to a canvas taints it, so its bytes could
+  // never be saved anyway. Hence the three sources here: a local file, the
+  // clipboard (which is how you take a cover from any site at all - right-click
+  // the image, Copy image, paste here), and Open Library, which does serve both
+  // its search API and its covers with Access-Control-Allow-Origin.
+  function renderCover(book, values) {
+    const host = el('#me-cover');
+    host.innerHTML =
+      '<h3>Cover</h3>' +
+      '<p id="me-cover-state">Checking...</p>' +
+      '<div id="me-cover-preview"></div>' +
+      '<p><label>Replace from file <input type="file" id="me-cover-file" accept="image/*"></label></p>' +
+      '<p id="me-paste" tabindex="0" style="border:1px dashed rgba(128,128,128,.6);padding:10px">' +
+      'Click here and press Ctrl+V to paste a copied image. Works with any site: copy the ' +
+      'image in your browser, then paste it here.</p>' +
+      '<p><button id="me-search">Search Open Library</button> ' +
+      '<button id="me-remove">Remove cover</button> <span id="me-cover-msg"></span></p>' +
+      '<div id="me-results"></div>';
+
+    refreshCoverState();
+
+    el('#me-cover-file').onchange = async (e) => {
+      const file = e.target.files && e.target.files[0];
+      if (file) await installCover(file, file.name);
+    };
+
+    el('#me-paste').onpaste = async (e) => {
+      const items = (e.clipboardData && e.clipboardData.items) || [];
+      for (const item of items) {
+        if (item.type && item.type.indexOf('image/') === 0) {
+          e.preventDefault();
+          await installCover(item.getAsFile(), 'pasted.' + item.type.split('/')[1]);
+          return;
+        }
+      }
+      coverMsg('No image found in the clipboard.');
+    };
+
+    el('#me-remove').onclick = removeCover;
+    el('#me-search').onclick = () => searchOpenLibrary(values);
+  }
+
+  function coverMsg(t) {
+    const m = el('#me-cover-msg');
+    if (m) m.textContent = t;
+  }
+
+  // Must stay in step with SidecarFiles::kCoverExtensions in the firmware: the
+  // device resolves the cover by this order, so writing a .jpg while an older
+  // .png remains would be decided by the list rather than by what you chose.
+  const COVER_EXTS = ['.jpg', '.jpeg', '.png', '.bmp', '.JPG', '.JPEG', '.PNG', '.BMP'];
+
+  async function currentCoverName() {
+    const entries = await getJson('/api/files?path=' + encodeURIComponent(dir));
+    const names = new Set(entries.filter((e) => !e.isDirectory).map((e) => e.name));
+    for (const ext of COVER_EXTS) {
+      if (names.has(editing.base + ext)) return editing.base + ext;
+    }
+    return null;
+  }
+
+  async function refreshCoverState() {
+    try {
+      const name = await currentCoverName();
+      el('#me-cover-state').textContent = name
+        ? 'Sidecar cover: ' + name
+        : 'No cover sidecar - the cover inside the book is used.';
+      el('#me-cover-preview').innerHTML = name
+        // Cache-busted: the filename stays the same when the image changes.
+        ? '<img alt="cover" style="max-height:160px" src="' + dl(join(dir, name)) + '&t=' + Date.now() + '">'
+        : '';
+    } catch (e) {
+      el('#me-cover-state').textContent = 'Could not read the folder: ' + msg(e);
+    }
+  }
+
+  async function installCover(blob, sourceName) {
+    if (!blob) return;
+    const ext = coverExtFor(blob.type, sourceName);
+    if (!ext) {
+      coverMsg('Unsupported image type - use JPEG, PNG or BMP.');
+      return;
+    }
+    coverMsg('Saving...');
+    try {
+      // Drop any other variant first, so exactly one cover sidecar exists.
+      const existing = await currentCoverName();
+      if (existing && existing !== editing.base + ext) await del(join(dir, existing));
+
+      const fd = new FormData();
+      fd.append('file', blob, editing.base + ext);
+      const r = await fetch('/upload?path=' + encodeURIComponent(dir), { method: 'POST', body: fd });
+      if (!r.ok) throw new Error('upload ' + r.status);
+      coverMsg('Saved ' + editing.base + ext);
+      await refreshCoverState();
+    } catch (e) {
+      coverMsg('Failed: ' + msg(e));
+    }
+  }
+
+  async function removeCover() {
+    coverMsg('');
+    try {
+      const name = await currentCoverName();
+      if (!name) {
+        coverMsg('There is no cover sidecar to remove.');
+        return;
+      }
+      if (!confirm('Delete ' + name + '? The cover inside the book will be used again.')) return;
+      await del(join(dir, name));
+      coverMsg('Removed ' + name);
+      await refreshCoverState();
+    } catch (e) {
+      coverMsg('Failed: ' + msg(e));
+    }
+  }
+
+  function coverExtFor(mime, name) {
+    const m = (mime || '').toLowerCase();
+    if (m === 'image/jpeg' || m === 'image/jpg') return '.jpg';
+    if (m === 'image/png') return '.png';
+    if (m === 'image/bmp' || m === 'image/x-ms-bmp') return '.bmp';
+    const n = (name || '').toLowerCase();
+    if (n.endsWith('.jpg') || n.endsWith('.jpeg')) return '.jpg';
+    if (n.endsWith('.png')) return '.png';
+    if (n.endsWith('.bmp')) return '.bmp';
+    return '';
+  }
+
+  async function searchOpenLibrary(values) {
+    const results = el('#me-results');
+    const title = (el('#me-f-title').value || values.title || '').trim();
+    const author = (el('#me-f-author').value || values.author || '').trim();
+    if (!title) {
+      coverMsg('Enter a title first.');
+      return;
+    }
+
+    coverMsg('Searching Open Library...');
+    results.textContent = '';
+    try {
+      const url = 'https://openlibrary.org/search.json?limit=8&fields=title,author_name,cover_i' +
+        '&title=' + encodeURIComponent(title) +
+        (author ? '&author=' + encodeURIComponent(author) : '');
+      const data = await (await fetch(url)).json();
+      const hits = (data.docs || []).filter((d) => d.cover_i);
+      if (!hits.length) {
+        coverMsg('No covers found.');
+        return;
+      }
+
+      coverMsg(hits.length + ' result(s) - click one to use it');
+      results.innerHTML = hits.map((d, i) =>
+        '<figure style="display:inline-block;margin:4px;text-align:center;width:110px">' +
+        '<img data-i="' + i + '" class="me-hit" style="max-height:140px;cursor:pointer"' +
+        ' src="https://covers.openlibrary.org/b/id/' + d.cover_i + '-M.jpg" alt="">' +
+        '<figcaption style="font-size:.8em">' + esc((d.author_name || []).join(', ')) + '</figcaption>' +
+        '</figure>').join('');
+
+      results.querySelectorAll('.me-hit').forEach((img) => {
+        img.onclick = async () => {
+          const hit = hits[Number(img.dataset.i)];
+          coverMsg('Fetching cover...');
+          try {
+            // -L is the large size. Readable only because Open Library sends CORS.
+            const resp = await fetch('https://covers.openlibrary.org/b/id/' + hit.cover_i + '-L.jpg');
+            if (!resp.ok) throw new Error('cover ' + resp.status);
+            await installCover(await resp.blob(), 'openlibrary.jpg');
+            results.textContent = '';
+          } catch (e) {
+            coverMsg('Could not fetch that cover: ' + msg(e));
+          }
+        };
+      });
+    } catch (e) {
+      coverMsg('Search failed: ' + msg(e));
+    }
+  }
+
+  async function del(path) {
+    const fd = new FormData();
+    fd.append('path', path);
+    fd.append('type', 'file');
+    const r = await fetch('/delete', { method: 'POST', body: fd });
+    if (!r.ok) throw new Error('delete ' + r.status + ' ' + (await r.text().catch(() => '')));
   }
 
   async function save() {

--- a/plugins/organize-by-author/plugin.js
+++ b/plugins/organize-by-author/plugin.js
@@ -31,7 +31,8 @@ CrossPoint.registerPlugin((container, api) => {
     '<p>Sorts loose EPUBs in one folder into <code>&lt;Author&gt;/</code> subfolders. ' +
     'Reads a Calibre <code>book.opf</code> sidecar when there is one, otherwise downloads ' +
     'the book to read its metadata. Nothing moves until you press Apply.</p>' +
-    '<p><label>Folder <input type="text" id="oba-dir" value="/" style="width:16em"></label> ' +
+    '<p><label>Folder <input type="text" id="oba-dir" value="' + esc(api.currentPath) +
+    '" style="width:16em"></label> ' +
     '<label><input type="checkbox" id="oba-sortname" checked> Prefer sort name (Lastname, First)</label></p>' +
     '<p><button id="oba-scan">Scan</button> ' +
     '<button id="oba-apply" disabled>Apply</button> <span id="oba-status"></span></p>' +

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -137,7 +137,12 @@ bool moveSidecarFilesToCompleted(const std::string& currentBookPath, const std::
 
   const std::string srcBase = currentBookPath.substr(0, srcDot);
   const std::string dstBase = targetBookPath.substr(0, dstDot);
-  const char* extensions[] = {".bmp", ".jpg", ".jpeg", ".png", ".BMP", ".JPG", ".JPEG", ".PNG"};
+  // A sidecar is bound to its book by filename, so every one of them has to
+  // travel with it - a book that arrives in /COMPLETED without its sidecars
+  // silently loses its cover and reverts to the metadata embedded in the EPUB.
+  // Keep in step with the two resolvers that decide what counts as a sidecar:
+  // ReaderActivity::sidecarCoverPath (images) and Epub::metadataSidecarPath (.opf).
+  const char* extensions[] = {".bmp", ".jpg", ".jpeg", ".png", ".opf", ".BMP", ".JPG", ".JPEG", ".PNG", ".OPF"};
   bool success = true;
   for (const char* ext : extensions) {
     const std::string srcSidecar = srcBase + ext;

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -9,6 +9,7 @@
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
 #include <PngToBmpConverter.h>
+#include <SidecarFiles.h>
 #include <Txt.h>
 #include <Xtc.h>
 #include <esp_task_wdt.h>
@@ -128,28 +129,20 @@ std::string getSidecarCoverBmpPath(const std::string& bookPath, int width, int h
   return convertSidecarToBmp(ReaderActivity::bookCacheDir(bookPath), sidecarPath, width, height, fileName);
 }
 
+// A sidecar is bound to its book by filename, so every one of them has to
+// travel with it - a book that arrives in /COMPLETED without its sidecars
+// silently loses its cover and reverts to the metadata embedded in the EPUB.
+// Which extensions those are is SidecarFiles' business, not this function's.
 bool moveSidecarFilesToCompleted(const std::string& currentBookPath, const std::string& targetBookPath) {
-  const auto srcDot = currentBookPath.rfind('.');
-  const auto dstDot = targetBookPath.rfind('.');
-  if (srcDot == std::string::npos || dstDot == std::string::npos) {
+  const std::string srcBase = SidecarFiles::basePath(currentBookPath);
+  const std::string dstBase = SidecarFiles::basePath(targetBookPath);
+  if (srcBase.empty() || dstBase.empty()) {
     return false;
   }
 
-  const std::string srcBase = currentBookPath.substr(0, srcDot);
-  const std::string dstBase = targetBookPath.substr(0, dstDot);
-  // A sidecar is bound to its book by filename, so every one of them has to
-  // travel with it - a book that arrives in /COMPLETED without its sidecars
-  // silently loses its cover and reverts to the metadata embedded in the EPUB.
-  // Keep in step with the two resolvers that decide what counts as a sidecar:
-  // ReaderActivity::sidecarCoverPath (images) and Epub::metadataSidecarPath (.opf).
-  const char* extensions[] = {".bmp", ".jpg", ".jpeg", ".png", ".opf", ".BMP", ".JPG", ".JPEG", ".PNG", ".OPF"};
   bool success = true;
-  for (const char* ext : extensions) {
+  for (const char* ext : SidecarFiles::existingExtensions(currentBookPath)) {
     const std::string srcSidecar = srcBase + ext;
-    if (!Storage.exists(srcSidecar.c_str())) {
-      continue;
-    }
-
     std::string dstSidecar = dstBase + ext;
     if (Storage.exists(dstSidecar.c_str())) {
       dstSidecar = findUniqueCompletedSidecarPath(dstSidecar);

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -8,6 +8,7 @@
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
 #include <PngToBmpConverter.h>
+#include <SidecarFiles.h>
 #include <ZipFile.h>
 #include <esp_heap_caps.h>
 #include <esp_system.h>
@@ -163,19 +164,12 @@ bool ReaderActivity::isImageFile(const std::string& path) {
   return FsHelpers::hasBmpExtension(path) || FsHelpers::hasJpgExtension(path) || FsHelpers::hasPngExtension(path);
 }
 
+// Which extensions count, and how the base name is derived, live in
+// SidecarFiles - see the header there for why this is one definition.
 std::string ReaderActivity::sidecarCoverPath(const std::string& bookPath) {
-  const auto sep = bookPath.find_last_of("/\\");
-  const auto dot = bookPath.rfind('.');
-  if (dot == std::string::npos || (sep != std::string::npos && dot < sep)) return "";
-  const std::string base = bookPath.substr(0, dot);
-  for (const char* ext : {".jpg", ".jpeg", ".png", ".bmp", ".JPG", ".JPEG", ".PNG", ".BMP"}) {
-    const std::string candidate = base + ext;
-    if (Storage.exists(candidate.c_str())) {
-      LOG_DBG("SIDECAR", "Found sidecar cover: %s", candidate.c_str());
-      return candidate;
-    }
-  }
-  return "";
+  const std::string candidate = SidecarFiles::coverPath(bookPath);
+  if (!candidate.empty()) LOG_DBG("SIDECAR", "Found sidecar cover: %s", candidate.c_str());
+  return candidate;
 }
 
 std::string ReaderActivity::bookCacheDir(const std::string& bookPath) {

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -335,6 +335,33 @@ bool thumbFileValid(const std::string& path, int width, int height) {
 // calling them, or the "regeneration" silently no-ops and the stale file survives every pass
 // (observed: "larger than slot — regenerating" + "ok" with no decode between, every boot,
 // forever). 0-byte sentinels are kept: they encode "structurally absent" for the Epub generator.
+// FAT packs the modify date and time so that (date << 16) | time increases
+// monotonically, which is all the ordering this needs. False when either stamp
+// is unreadable, so an unknown age never triggers a rebuild.
+//
+// Note the device clock gates this: HalStorage writes 1980-01-01 to every file
+// created while the RTC is unsynced, so two such files compare equal and the
+// cover is left alone. On hardware with the DS3231 that does not arise.
+bool fileModifiedStamp(const std::string& path, uint32_t* out) {
+  FsFile f;
+  if (!Storage.openFileForRead("COVER", path, f)) return false;
+  uint16_t date = 0, time = 0;
+  const bool ok = f.getModifyDateTime(&date, &time);
+  f.close();
+  if (!ok) return false;
+  *out = (static_cast<uint32_t>(date) << 16) | time;
+  return true;
+}
+
+// True when the sidecar has been replaced since the thumb was cached.
+bool sidecarNewerThanThumb(const std::string& sidecarPath, const std::string& thumbPath) {
+  uint32_t sidecarStamp = 0;
+  uint32_t thumbStamp = 0;
+  if (!fileModifiedStamp(sidecarPath, &sidecarStamp)) return false;
+  if (!fileModifiedStamp(thumbPath, &thumbStamp)) return false;
+  return sidecarStamp > thumbStamp;
+}
+
 void removeStaleThumb(const std::string& path) {
   FsFile stale;
   if (!Storage.openFileForRead("COVER", path, stale)) return;
@@ -375,11 +402,22 @@ ThumbResult ReaderActivity::ensureCoverThumb(const std::string& bookPath, int wi
   const std::string dir = bookCacheDir(bookPath);
   const std::string name = "thumb_" + std::to_string(width) + "x" + std::to_string(height) + ".bmp";
   const std::string file = dir + "/" + name;
-  if (thumbFileValid(file, width, height)) return ThumbResult::Ok;
-  removeStaleThumb(file);
 
   // Source preference: a sidecar image beside the book wins over the embedded cover.
   const std::string sidecar = sidecarCoverPath(bookPath);
+
+  // Replacing a cover must take effect. Nothing else invalidates this thumb, so
+  // without the check the short circuit below serves the previous image forever
+  // — the cover editor's whole workflow, and replacing a cover by hand, both
+  // looked like they had silently failed.
+  if (!sidecar.empty() && sidecarNewerThanThumb(sidecar, file)) {
+    LOG_DBG("COVER", "Sidecar newer than cached thumb, regenerating: %s", sidecar.c_str());
+    Storage.remove(file.c_str());
+  }
+
+  if (thumbFileValid(file, width, height)) return ThumbResult::Ok;
+  removeStaleThumb(file);
+
   if (!sidecar.empty()) {
     // A sidecar may have changed since the sentinel was written — clear it so the
     // sidecar conversion runs fresh.

--- a/src/network/html/shared/PluginHost.js.inc
+++ b/src/network/html/shared/PluginHost.js.inc
@@ -69,7 +69,16 @@ async function loadPlugins(mount) {
         // URL of another file in this plugin's folder, for a plugin that ships
         // its own assets. Flat: the server serves no subdirectories.
         pluginFile: (f) => '/plugin?name=' + encodeURIComponent(p.name) +
-          '&file=' + encodeURIComponent(f)
+          '&file=' + encodeURIComponent(f),
+        // Folder the File Manager is showing, so a plugin can act on what the
+        // user is already looking at instead of asking them to type a path
+        // again. A getter, not a captured value, so it stays right if the page
+        // ever navigates in place rather than reloading. Reads the host page's
+        // global; typeof keeps it safe on Settings, which has no file browser
+        // and where this is always '/'.
+        get currentPath() {
+          return typeof currentPath === 'string' ? currentPath : '/';
+        }
       });
     } catch (e) {
       const title = document.createElement('h2');

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -41,6 +41,7 @@ set(PIPELINE_SOURCES
   ${REPO_ROOT}/lib/InflateReader/InflateReader.cpp
   ${REPO_ROOT}/lib/uzlib/src/tinflate.c
   ${REPO_ROOT}/lib/FsHelpers/FsHelpers.cpp
+  ${REPO_ROOT}/lib/FsHelpers/SidecarFiles.cpp
   ${REPO_ROOT}/lib/CooperativeAbort/CooperativeAbort.cpp
   ${REPO_ROOT}/lib/Utf8/Utf8.cpp
   ${REPO_ROOT}/lib/GfxRenderer/Bitmap.cpp
@@ -87,6 +88,7 @@ add_executable(EpubPipelineTest
   EpubPipelineTest.cpp
   FingerprintTest.cpp
   MetadataSidecarTest.cpp
+  SidecarFilesTest.cpp
   SectionAbortTest.cpp
   ${PIPELINE_SOURCES}
 )

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -86,6 +86,7 @@ set(PIPELINE_INCLUDES
 add_executable(EpubPipelineTest
   EpubPipelineTest.cpp
   FingerprintTest.cpp
+  MetadataSidecarTest.cpp
   SectionAbortTest.cpp
   ${PIPELINE_SOURCES}
 )

--- a/test/epub_pipeline/MetadataSidecarTest.cpp
+++ b/test/epub_pipeline/MetadataSidecarTest.cpp
@@ -146,6 +146,35 @@ TEST_F(MetadataSidecarFixture, OversizedSidecarIsIgnored) {
   EXPECT_EQ(epub.getTitle(), kEmbeddedTitle);
 }
 
+// Contract with the metadata-editor plugin (plugins/metadata-editor): the exact
+// document its freshDoc() + writeInto() produce must be readable here, for all
+// six fields it edits. The plugin's XML handling runs in a browser and cannot be
+// unit-tested from this suite, so this pins the format they agree on - if the
+// editor's output shape ever drifts, this is what catches it.
+TEST_F(MetadataSidecarFixture, ReadsTheShapeTheMetadataEditorWrites) {
+  writeSidecar(
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+      "<package xmlns=\"http://www.idpf.org/2007/opf\" version=\"2.0\" unique-identifier=\"uuid_id\">\n"
+      "  <metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:opf=\"http://www.idpf.org/2007/opf\">"
+      "<dc:title>Edited Title</dc:title>"
+      "<dc:creator>Edited Author</dc:creator>"
+      "<dc:language>de</dc:language>"
+      "<meta name=\"calibre:series\" content=\"Edited Series\"/>"
+      "<meta name=\"calibre:series_index\" content=\"7\"/>"
+      "<dc:description>Edited description text.</dc:description>"
+      "</metadata>\n"
+      "</package>\n");
+
+  Epub epub(bookPath.string(), cacheDir);
+  ASSERT_TRUE(epub.load(true));
+  EXPECT_EQ(epub.getTitle(), "Edited Title");
+  EXPECT_EQ(epub.getAuthor(), "Edited Author");
+  EXPECT_EQ(epub.getLanguage(), "de");
+  EXPECT_EQ(epub.getSeries(), "Edited Series");
+  EXPECT_EQ(epub.getSeriesIndex(), "7");
+  EXPECT_EQ(epub.getDescription(), "Edited description text.");
+}
+
 TEST_F(MetadataSidecarFixture, MetadataSidecarPathResolves) {
   EXPECT_EQ(Epub::metadataSidecarPath(bookPath.string()), "");
   writeSidecar(sidecarXml("T", "A"));

--- a/test/epub_pipeline/MetadataSidecarTest.cpp
+++ b/test/epub_pipeline/MetadataSidecarTest.cpp
@@ -1,0 +1,157 @@
+// Calibre-style "<book>.opf" metadata sidecar: a file beside the book wins over
+// what is embedded in it, mirroring the cover sidecar rule.
+//
+// The property that matters, and the reason the overlay is applied on every load
+// rather than baked into book.bin: editing the sidecar must take effect on the
+// next open, even though the EPUB's own bytes never changed and the cache
+// therefore stays valid. A baked implementation passes the first case below and
+// fails SidecarEditTakesEffectOnCachedLoad.
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "Epub.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+const char* kBook = CORPUS_DIR "/test_headings.epub";
+const char* kEmbeddedTitle = "Heading Font Size Test";
+
+// Minimal Calibre-shaped metadata OPF. Calibre writes series as
+// <meta name="calibre:series">, which ContentOpfParser already understands.
+std::string sidecarXml(const std::string& title, const std::string& author, const std::string& series = "",
+                       const std::string& seriesIndex = "") {
+  std::string s =
+      "<?xml version='1.0' encoding='utf-8'?>\n"
+      "<package xmlns=\"http://www.idpf.org/2007/opf\" version=\"2.0\" unique-identifier=\"uuid_id\">\n"
+      "  <metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\" "
+      "xmlns:opf=\"http://www.idpf.org/2007/opf\">\n";
+  if (!title.empty()) s += "    <dc:title>" + title + "</dc:title>\n";
+  if (!author.empty())
+    s += "    <dc:creator opf:file-as=\"Sorted, Name\" opf:role=\"aut\">" + author + "</dc:creator>\n";
+  if (!series.empty()) s += "    <meta name=\"calibre:series\" content=\"" + series + "\"/>\n";
+  if (!seriesIndex.empty()) s += "    <meta name=\"calibre:series_index\" content=\"" + seriesIndex + "\"/>\n";
+  s += "  </metadata>\n</package>\n";
+  return s;
+}
+
+struct MetadataSidecarFixture : testing::Test {
+  fs::path work;
+  fs::path bookPath;
+  fs::path sidecarPath;
+  std::string cacheDir;
+
+  void SetUp() override {
+    // Per-test dir: ctest -j runs these as parallel processes.
+    work = fs::temp_directory_path() /
+           (std::string("epub_sidecar_") + testing::UnitTest::GetInstance()->current_test_info()->name());
+    fs::remove_all(work);
+    fs::create_directories(work);
+    bookPath = work / "book.epub";
+    sidecarPath = work / "book.opf";
+    cacheDir = (work / "cache").string();
+    fs::create_directories(cacheDir);
+    fs::copy_file(kBook, bookPath);
+  }
+  void TearDown() override { fs::remove_all(work); }
+
+  void writeSidecar(const std::string& xml) { std::ofstream(sidecarPath, std::ios::binary) << xml; }
+};
+
+TEST_F(MetadataSidecarFixture, NoSidecarLeavesEmbeddedMetadata) {
+  Epub epub(bookPath.string(), cacheDir);
+  ASSERT_TRUE(epub.load(true));
+  EXPECT_EQ(epub.getTitle(), kEmbeddedTitle);
+}
+
+TEST_F(MetadataSidecarFixture, SidecarOverridesEmbeddedMetadata) {
+  writeSidecar(sidecarXml("Sidecar Title", "Sidecar Author", "Sidecar Series", "3"));
+  Epub epub(bookPath.string(), cacheDir);
+  ASSERT_TRUE(epub.load(true));
+  EXPECT_EQ(epub.getTitle(), "Sidecar Title");
+  EXPECT_EQ(epub.getAuthor(), "Sidecar Author");
+  EXPECT_EQ(epub.getSeries(), "Sidecar Series");
+  EXPECT_EQ(epub.getSeriesIndex(), "3");
+}
+
+// The reason for overlaying live instead of baking into book.bin. First load
+// builds and caches; the second hits the cached path, where parseContentOpf is
+// never called - the sidecar must still be applied.
+TEST_F(MetadataSidecarFixture, SidecarEditTakesEffectOnCachedLoad) {
+  writeSidecar(sidecarXml("First Title", "First Author"));
+  {
+    Epub epub(bookPath.string(), cacheDir);
+    ASSERT_TRUE(epub.load(true));
+    ASSERT_EQ(epub.getTitle(), "First Title");
+  }
+
+  // Book bytes unchanged, so the cache stays valid and book.bin still holds
+  // "First Title". Only the sidecar changed.
+  writeSidecar(sidecarXml("Second Title", "Second Author"));
+  {
+    Epub epub(bookPath.string(), cacheDir);
+    ASSERT_TRUE(epub.load(true));
+    EXPECT_EQ(epub.getTitle(), "Second Title") << "sidecar was baked into book.bin instead of applied on load";
+    EXPECT_EQ(epub.getAuthor(), "Second Author");
+  }
+}
+
+// Removing the sidecar must fall back to the book's own metadata, not keep
+// serving the overridden values from a previous run.
+TEST_F(MetadataSidecarFixture, RemovingSidecarRestoresEmbeddedMetadata) {
+  writeSidecar(sidecarXml("Sidecar Title", "Sidecar Author"));
+  {
+    Epub epub(bookPath.string(), cacheDir);
+    ASSERT_TRUE(epub.load(true));
+    ASSERT_EQ(epub.getTitle(), "Sidecar Title");
+  }
+  fs::remove(sidecarPath);
+  {
+    Epub epub(bookPath.string(), cacheDir);
+    ASSERT_TRUE(epub.load(true));
+    EXPECT_EQ(epub.getTitle(), kEmbeddedTitle);
+  }
+}
+
+// A sidecar supplying only some fields must not blank out the rest.
+TEST_F(MetadataSidecarFixture, PartialSidecarLeavesOtherFieldsIntact) {
+  writeSidecar(sidecarXml("", "Only The Author"));
+  Epub epub(bookPath.string(), cacheDir);
+  ASSERT_TRUE(epub.load(true));
+  EXPECT_EQ(epub.getAuthor(), "Only The Author");
+  EXPECT_EQ(epub.getTitle(), kEmbeddedTitle) << "empty sidecar field must not overwrite embedded metadata";
+}
+
+// Malformed XML must leave the book usable with its embedded metadata rather
+// than failing the load.
+TEST_F(MetadataSidecarFixture, MalformedSidecarIsIgnored) {
+  writeSidecar("<package><metadata><dc:title>Broken");
+  Epub epub(bookPath.string(), cacheDir);
+  ASSERT_TRUE(epub.load(true)) << "a bad sidecar must not make the book unopenable";
+  EXPECT_EQ(epub.getTitle(), kEmbeddedTitle);
+}
+
+// Guards the size cap: a large file that happens to share the basename is not
+// read into the heap.
+TEST_F(MetadataSidecarFixture, OversizedSidecarIsIgnored) {
+  std::string big = sidecarXml("Should Be Ignored", "Nobody");
+  big += std::string(Epub::MAX_METADATA_SIDECAR_BYTES, ' ');
+  writeSidecar(big);
+  Epub epub(bookPath.string(), cacheDir);
+  ASSERT_TRUE(epub.load(true));
+  EXPECT_EQ(epub.getTitle(), kEmbeddedTitle);
+}
+
+TEST_F(MetadataSidecarFixture, MetadataSidecarPathResolves) {
+  EXPECT_EQ(Epub::metadataSidecarPath(bookPath.string()), "");
+  writeSidecar(sidecarXml("T", "A"));
+  EXPECT_EQ(Epub::metadataSidecarPath(bookPath.string()), sidecarPath.string());
+  // An extension-less path has nothing to swap.
+  EXPECT_EQ(Epub::metadataSidecarPath((work / "noext").string()), "");
+}
+
+}  // namespace

--- a/test/epub_pipeline/SidecarFilesTest.cpp
+++ b/test/epub_pipeline/SidecarFilesTest.cpp
@@ -1,0 +1,119 @@
+// The single definition of what counts as a sidecar (lib/FsHelpers/SidecarFiles).
+//
+// This logic used to be copied into three places - the cover resolver, the
+// metadata resolver, and the move-to-/COMPLETED extension list - and the copies
+// had drifted: the move path derived its base name with rfind('.') alone, with
+// no separator check, so a book with no extension inside a dotted folder took
+// the dot from the folder. Centralising it made that reachable from a test,
+// which is most of the point.
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "SidecarFiles.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct SidecarFilesFixture : testing::Test {
+  fs::path work;
+
+  void SetUp() override {
+    work = fs::temp_directory_path() /
+           (std::string("sidecar_files_") + testing::UnitTest::GetInstance()->current_test_info()->name());
+    fs::remove_all(work);
+    fs::create_directories(work);
+  }
+  void TearDown() override { fs::remove_all(work); }
+
+  void touch(const std::string& name) {
+    fs::create_directories(fs::path(work / name).parent_path());
+    std::ofstream(work / name, std::ios::binary) << "x";
+  }
+  std::string p(const std::string& name) const { return (work / name).string(); }
+};
+
+TEST_F(SidecarFilesFixture, BasePathStripsTheExtension) {
+  EXPECT_EQ(SidecarFiles::basePath("/Books/Some Book.epub"), "/Books/Some Book");
+  EXPECT_EQ(SidecarFiles::basePath("/Books/Dotted.Name.epub"), "/Books/Dotted.Name");
+}
+
+TEST_F(SidecarFilesFixture, BasePathRejectsPathsWithoutTheirOwnExtension) {
+  EXPECT_EQ(SidecarFiles::basePath("/Books/untitled"), "");
+  EXPECT_EQ(SidecarFiles::basePath("untitled"), "");
+  // The regression the old move-to-/COMPLETED copy had: the only dot belongs to
+  // the folder, so there is no extension to swap and no sidecar to find.
+  EXPECT_EQ(SidecarFiles::basePath("/My.Books/untitled"), "");
+  EXPECT_EQ(SidecarFiles::basePath("/My.Books/real.epub"), "/My.Books/real");
+}
+
+TEST_F(SidecarFilesFixture, NoSidecarsFound) {
+  touch("book.epub");
+  EXPECT_EQ(SidecarFiles::coverPath(p("book.epub")), "");
+  EXPECT_EQ(SidecarFiles::metadataPath(p("book.epub")), "");
+  EXPECT_TRUE(SidecarFiles::existingExtensions(p("book.epub")).empty());
+}
+
+TEST_F(SidecarFilesFixture, ResolvesCoverAndMetadataIndependently) {
+  touch("book.epub");
+  touch("book.png");
+  touch("book.opf");
+  EXPECT_EQ(SidecarFiles::coverPath(p("book.epub")), p("book.png"));
+  EXPECT_EQ(SidecarFiles::metadataPath(p("book.epub")), p("book.opf"));
+}
+
+// Declared order decides the winner, so a book carrying several images resolves
+// predictably rather than by directory-iteration luck.
+TEST_F(SidecarFilesFixture, CoverResolutionFollowsDeclaredOrder) {
+  touch("book.epub");
+  touch("book.bmp");
+  touch("book.jpg");
+  EXPECT_EQ(SidecarFiles::coverPath(p("book.epub")), p("book.jpg")) << ".jpg is declared before .bmp";
+}
+
+// What the /COMPLETED move iterates: it has to see covers and metadata alike,
+// or a finished book strands whichever kind it missed.
+TEST_F(SidecarFilesFixture, ExistingExtensionsCoversBothKinds) {
+  touch("book.epub");
+  touch("book.jpg");
+  touch("book.opf");
+  const auto found = SidecarFiles::existingExtensions(p("book.epub"));
+  ASSERT_EQ(found.size(), 2u);
+  EXPECT_STREQ(found[0], ".jpg");
+  EXPECT_STREQ(found[1], ".opf") << "metadata sidecar must travel with the book too";
+}
+
+TEST_F(SidecarFilesFixture, ExistingExtensionsIgnoresUnrelatedNeighbours) {
+  touch("book.epub");
+  touch("book.opf");
+  touch("bookmark.jpg");  // shares a prefix, not the base name
+  touch("other.png");
+  const auto found = SidecarFiles::existingExtensions(p("book.epub"));
+  ASSERT_EQ(found.size(), 1u);
+  EXPECT_STREQ(found[0], ".opf");
+}
+
+// The tables list every extension in both cases, and the SD card is FAT/exFAT,
+// which answers to either. One file must therefore be reported once - a caller
+// that moves them would otherwise rename it twice, the second failing because
+// the first already moved it. (On a case-sensitive host this passes trivially;
+// it is the case-insensitive platforms, including the device, that need it.)
+TEST_F(SidecarFilesFixture, OneFileIsReportedOncePerExtension) {
+  touch("book.epub");
+  touch("book.jpg");
+  const auto found = SidecarFiles::existingExtensions(p("book.epub"));
+  ASSERT_EQ(found.size(), 1u) << "a single cover reported under both .jpg and .JPG";
+  EXPECT_STREQ(found[0], ".jpg");
+}
+
+TEST_F(SidecarFilesFixture, ExtensionlessBookHasNoSidecars) {
+  touch("untitled");
+  touch("untitled.opf");
+  EXPECT_EQ(SidecarFiles::metadataPath(p("untitled")), "");
+  EXPECT_TRUE(SidecarFiles::existingExtensions(p("untitled")).empty());
+}
+
+}  // namespace

--- a/test/zip_entry_reader/HalStorage.h
+++ b/test/zip_entry_reader/HalStorage.h
@@ -132,6 +132,21 @@ class HalStorage {
   bool openFileForRead(const char*, const char* path, HalFile& f) { return f.openForRead(path); }
   bool openFileForWrite(const char*, const std::string& path, HalFile& f) { return f.openForWrite(path); }
   bool exists(const char* path) { return std::filesystem::exists(path); }
+  // Mirrors the device HalStorage: stream a whole file into a Print sink in
+  // chunks. Epub::applyMetadataSidecar() feeds ContentOpfParser through this,
+  // so the host pipeline exercises the same code path the device runs.
+  bool readFileToStream(const char* path, Print& out, size_t chunkSize = 256) {
+    HalFile f;
+    if (!f.openForRead(path)) return false;
+    std::vector<uint8_t> buf(chunkSize ? chunkSize : 256);
+    for (;;) {
+      const int n = f.read(buf.data(), buf.size());
+      if (n < 0) return false;
+      if (n == 0) break;
+      if (out.write(buf.data(), static_cast<size_t>(n)) != static_cast<size_t>(n)) return false;
+    }
+    return true;
+  }
   bool mkdir(const char* path, bool recursive = true) {
     std::error_code ec;
     return recursive ? std::filesystem::create_directories(path, ec) : std::filesystem::create_directory(path, ec);


### PR DESCRIPTION
Where `book.opf` sits beside `book.epub`, its metadata now wins over what is embedded in the book — so a wrong title, author or series can be corrected without rewriting the EPUB. Calibre writes one beside every book it exports, so a Calibre-managed library gets this for free.

This mirrors the cover sidecar the firmware already had (`book.jpg` beside `book.epub`), and unifies both under one definition.

**Device: flash +~1.5KB net (96.6%), RAM unchanged. Host suite 455/455** (446 before, +9 new).

## What is in here

| | |
|---|---|
| `dfd9592f` | firmware reads a `book.opf` metadata sidecar |
| `9bcef494` | the move to `/COMPLETED` carries the `.opf` too |
| `16bc7e3a` | `metadata-editor` plugin |
| `e99f109d` | one definition of what counts as a sidecar |
| `ac37b0ef` | cover management in the editor, plus a thumbnail-cache fix |
| `b72bad20` | plugins get the folder the file browser is showing |

## Design decisions worth reviewing

**The sidecar is applied on every load, not baked into `book.bin`.** That cache is only rebuilt when the EPUB's own bytes change, so a baked value would leave an edited sidecar silently ineffective. `MetadataSidecarTest.SidecarEditTakesEffectOnCachedLoad` exists to catch exactly that regression — a baked implementation passes every other test in the file and fails that one.

**Only descriptive fields are taken** — title, author, language, series, series index, description — and only when non-empty, so a partial sidecar cannot blank out good embedded metadata. The spine, manifest and reading order always come from the book: a sidecar changes how a book is *labelled*, never what you read.

**No new XML code.** `ContentOpfParser` already extracts these fields and already understands `calibre:series`, and it is a `Print` sink, so `HalStorage::readFileToStream` feeds it the sidecar directly.

## Three bugs found along the way

**`.opf` was left behind when a finished book moved.** `moveSidecarFilesToCompleted` knew about cover images only, so the moment the firmware started reading `book.opf`, finishing a book would move it to `/COMPLETED` with its cover intact and its metadata orphaned. This is what motivated the centralization: three places independently decided what counted as a sidecar.

**The copies had drifted.** The move path derived its base name with `rfind('.')` and no separator check, so a book with no extension inside a dotted folder (`/My.Books/untitled`) took the dot from the folder.

**A case-insensitivity hazard, introduced and then caught.** Collecting extensions up front — rather than acting as it iterates, which is what the move did — meant one cover was reported under both `.jpg` and `.JPG`, since FAT answers to either. The old loop got away with it by accident: by the time it reached `.JPG` the file had already been renamed away. Collected up front, the move would rename the same file twice, the second failing. `existingExtensions` now reports the first case that matched and skips its variants.

## Replacing a cover needed a firmware fix to work at all

`ensureCoverThumb` returned the cached thumbnail whenever it was structurally valid, and nothing else invalidated it — so the regeneration path below, whose comment already anticipated a changed sidecar, was unreachable in exactly this case. The sidecar is now resolved before that short circuit, and one newer than the cached thumb forces a regenerate.

This also fixes replacing a cover **by hand**, which is broken on master today.

The comparison uses FAT modify stamps, which the device clock gates: files written while the RTC is unsynced all carry 1980-01-01 and compare equal, so the cover is left alone. Hardware with the DS3231 is unaffected. Documented in `docs/sidecar-files.md`.

## Plugins

`metadata-editor` edits all six fields into a `book.opf` sidecar and manages the cover — preview, replace from a local file, paste an image copied from any website, search Open Library, or remove it. **It never rewrites the EPUB**: no multi-megabyte round trip, no risk of corrupting a book, and reversible by deleting one small file. An existing sidecar is edited as XML in place rather than regenerated, so Calibre's UUID, identifiers, publisher and dates survive.

All three bundled plugins now default their folder to the one the File Manager is showing, via `api.currentPath`.

## Testing

- **Verified on hardware**: metadata sidecar overriding a book's title/author, and cover sidecar replacement — the latter confirming the thumbnail-cache fix fires and the FAT mtime comparison works with a real RTC.
- **Host suite 455/455**, including 9 new `SidecarFiles` tests covering the `/COMPLETED` move's extension logic, which had no coverage at all before.
- Plugin JS syntax-checked; manifests validated.

**Not covered by any test:** `moveSidecarFilesToCompleted` itself. It sits in an anonymous namespace inside an activity pulling in GfxRenderer/I18n/Bitmap/Txt/Xtc, so testing it would mean a refactor rather than a test file. The new tests pin what it iterates, not the move. Worth a manual check: finish a book carrying both a `.jpg` and a `.opf` and confirm all three land in `/COMPLETED` together.

## Follow-up, deliberately not here

The device-capability endpoints (`/api/relay`, `/api/fetch`, `/api/plugin-fs`) and the Goodreads/Google Books cover sources built on them are on `feat/plugin-device-endpoints`, stacked on this branch. They are independent of the sidecar work and have not been tested on hardware yet, which is why they are separate.
