### PR TITLE
feat(web): plugin device endpoints (relay, fetch-to-SD, small-file write) with a host allowlist

### DIFF
--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -82,6 +82,37 @@ same doors the web UI already opens, and it cannot make the reader talk to the
 internet. Anything needing a remote service must be done by the browser
 directly, subject to normal CORS rules.
 
+### Reaching the internet: `allowedHosts`
+
+A plugin runs in a browser page served by the device, so it can only read a
+cross-origin response when the remote site sends CORS headers. Most do not —
+Goodreads and `books.google.com` among them — and an image without CORS taints a
+canvas, so its bytes can be displayed but never saved.
+
+`GET /api/relay?plugin=<name>&url=<url>` fetches on the page's behalf and answers
+same-origin. It is opt-in per plugin: the host must be listed in that plugin's
+own `manifest.json`, so a plugin's reach is readable before you install it.
+
+```jsonc
+{
+  "title": "Metadata Editor",
+  "mount": "files",
+  "allowedHosts": [
+    "openlibrary.org",        // exact match
+    ".openlibrary.org"        // any subdomain, e.g. covers.openlibrary.org
+  ]
+}
+```
+
+No list means no access. `GET` only — a plugin cannot make the device POST
+anywhere. Redirects are **not** followed: a 3xx comes back as-is, and the plugin
+may relay the `Location` itself so the new host is judged on its own merits.
+The body streams back rather than being buffered, so a large image does not have
+to fit in the device's largest free block.
+
+Prefer a direct `fetch()` when the site sends CORS (Open Library does) and keep
+the relay for sites that do not — it costs the device a network round trip.
+
 ### Mount points
 
 | `mount` | Page | Suits |

--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -60,14 +60,32 @@ The plugin is handed an empty `<div class="card">` and owns all of it, heading
 included — the firmware renders no chrome of its own, so a plugin that draws no
 heading shows an untitled card.
 
-`api` carries three things:
+`api` carries:
 
 | Field | Description |
 |---|---|
 | `name` | the folder name |
 | `title` | `manifest.json`'s title, falling back to `name` — use it if you want the heading to track the manifest rather than hardcoding it |
 | `pluginFile(filename)` | URL for another file in this plugin's folder |
+| `relay(url)` | GET a URL the browser cannot reach itself; resolves to a `Response`. Allowlisted — see below |
+| `fetchToSd(url, dest)` | download straight to the card, one transfer instead of two |
+| `writeFile(path, data)` | write one small file (≤64KB); `data` may be a string, Blob or ArrayBuffer |
 | `currentPath` | the folder the File Manager is showing. Default to it rather than asking for a path the user has already navigated to; always `/` on Settings |
+
+**`api.crypto` is not provided.** The browser's own `crypto.subtle` covers
+hashing, HMAC, AES and RSA, so a device-side implementation would only duplicate
+it. A plugin written against the upstream API that calls `api.crypto` gets a
+readable error rather than `is not a function`.
+
+A plugin may declare what it needs, and one asking for something this firmware
+does not implement is refused with a visible message instead of failing somewhere
+inside its own code:
+
+```jsonc
+{ "requires": ["relay", "fetchToSd"] }
+```
+
+Supported: `relay`, `fetchToSd`, `writeFile`, `pluginFile`.
 
 Everything else is the web server's own
 same-origin API — a plugin uses `fetch()` against the endpoints in

--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -10,9 +10,11 @@ card on that page. Adding or changing a plugin never needs a firmware build.
 > Mitchell ([@itsthisjustin](https://github.com/itsthisjustin)). The folder
 > layout, the `/api/plugins` and `/plugin` contract, the `registerPlugin`
 > handshake and the `mount` convention are his design, and are kept compatible
-> so a plugin written for either firmware works on both. This port deliberately
-> carries none of that branch's device-capability endpoints, on-device catalog
-> screens or content-protection work — see [Trust](#trust) for why.
+> so a plugin written for either firmware works on both. This port takes a
+> subset of that branch: the relay, fetch-to-SD and small-file endpoints are
+> here (with the host allowlist upstream had removed), while its crypto
+> endpoint, job queue, on-device catalog screens and content-protection work
+> are not — see [Trust](#trust) and `allowedHosts` below.
 
 Plugins extend the **web interface**, not the reader. Nothing runs on the
 device: the firmware only enumerates the folders and serves their bytes, and the
@@ -94,11 +96,13 @@ same-origin API — a plugin uses `fetch()` against the endpoints in
 The File Manager page also has JSZip already loaded, so a plugin mounted there
 can open and rewrite an EPUB in the browser.
 
-That set is deliberate. There is **no** device endpoint for outbound HTTP,
-crypto, or arbitrary file writes: a plugin can reach the SD card through the
-same doors the web UI already opens, and it cannot make the reader talk to the
-internet. Anything needing a remote service must be done by the browser
-directly, subject to normal CORS rules.
+Prefer these same-origin endpoints wherever they suffice — they cost the device
+nothing beyond the request itself. A plugin reaches the SD card through the same
+doors the web UI already opens, so it gains no privilege the page does not have.
+
+Reaching *outward* is different, and is fenced separately: see `allowedHosts`
+below. Where a remote site sends CORS headers, call it directly with `fetch()`
+and leave the device out of it entirely.
 
 ### Reaching the internet: `allowedHosts`
 

--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -67,25 +67,25 @@ heading shows an untitled card.
 | `name` | the folder name |
 | `title` | `manifest.json`'s title, falling back to `name` — use it if you want the heading to track the manifest rather than hardcoding it |
 | `pluginFile(filename)` | URL for another file in this plugin's folder |
-| `relay(url)` | GET a URL the browser cannot reach itself; resolves to a `Response`. Allowlisted — see below |
-| `fetchToSd(url, dest)` | download straight to the card, one transfer instead of two |
-| `writeFile(path, data)` | write one small file (≤64KB); `data` may be a string, Blob or ArrayBuffer |
+| `relay(url)` | GET a URL the browser cannot reach itself; resolves to a `Response`. Allowlisted — see below |
+| `fetchToSd(url, dest)` | download straight to the card, one transfer instead of two |
+| `writeFile(path, data)` | write one small file (≤64KB); `data` may be a string, Blob or ArrayBuffer |
 | `currentPath` | the folder the File Manager is showing. Default to it rather than asking for a path the user has already navigated to; always `/` on Settings |
-
-**`api.crypto` is not provided.** The browser's own `crypto.subtle` covers
-hashing, HMAC, AES and RSA, so a device-side implementation would only duplicate
-it. A plugin written against the upstream API that calls `api.crypto` gets a
-readable error rather than `is not a function`.
-
-A plugin may declare what it needs, and one asking for something this firmware
-does not implement is refused with a visible message instead of failing somewhere
-inside its own code:
-
-```jsonc
-{ "requires": ["relay", "fetchToSd"] }
-```
-
-Supported: `relay`, `fetchToSd`, `writeFile`, `pluginFile`.
+
+**`api.crypto` is not provided.** The browser's own `crypto.subtle` covers
+hashing, HMAC, AES and RSA, so a device-side implementation would only duplicate
+it. A plugin written against the upstream API that calls `api.crypto` gets a
+readable error rather than `is not a function`.
+
+A plugin may declare what it needs, and one asking for something this firmware
+does not implement is refused with a visible message instead of failing somewhere
+inside its own code:
+
+```jsonc
+{ "requires": ["relay", "fetchToSd"] }
+```
+
+Supported: `relay`, `fetchToSd`, `writeFile`, `pluginFile`.
 
 Everything else is the web server's own
 same-origin API — a plugin uses `fetch()` against the endpoints in
@@ -182,7 +182,27 @@ are never compiled, so they cost no flash.
 | `hello-plugin` | settings | Minimal reference and smoke test - renders a card and lists `/` |
 | `find-duplicates` | files | Reports files sharing an exact size. Report only: never writes, and never downloads a book |
 | `organize-by-author` | files | Sorts loose EPUBs into `<Author>/` folders. Preview first, moves only on Apply, carries sidecars along |
-| `metadata-editor` | files | Edits title, author, language, series, series index and description into a `book.opf` sidecar, and manages the cover sidecar (file, clipboard paste, Open Library). Never rewrites the book |
+| `metadata-editor` | files | Edits title, author, language, series, series index and description into a `book.opf` sidecar, and manages the cover sidecar (local file, clipboard paste, or a search of Open Library / Goodreads / Google Books). Never rewrites the book |
+
+### Cover sources, and why they differ
+
+`metadata-editor` is the worked example of the CORS rules above:
+
+| Source | Search | Cover bytes |
+|---|---|---|
+| Open Library | direct — it sends CORS | direct |
+| Google Books | direct — the API sends CORS | **relay** — images are on `books.google.com`, which does not |
+| Goodreads | **relay** — no API since 2020, so the search page is scraped | **relay** — images are on `i.gr-assets.com` |
+
+Result thumbnails are plain `<img>` tags pointing at the remote host, because
+*displaying* a cross-origin image was never restricted — only reading its pixels
+is. The relay is used for one thing: reading the bytes of the cover you actually
+pick. The device does work for one image, not for the whole grid.
+
+Two caveats. The Goodreads path scrapes HTML and will break if they change their
+markup — it looks for `img.bookCover` and strips the `._SX50_` size segment to
+get the full-size image. And Google's covers are small (~128px), so Open Library
+or Goodreads give a better result on the device.
 
 ## Loading order and failures
 

--- a/docs/sidecar-files.md
+++ b/docs/sidecar-files.md
@@ -24,7 +24,8 @@ Implemented by `ReaderActivity::sidecarCoverPath()`.
 
 The bundled `metadata-editor` plugin manages this from the web UI — preview the
 current cover, replace it from a local file, paste an image copied from any
-website, search Open Library, or remove it. See [sd-plugins.md](sd-plugins.md).
+website, search Open Library / Goodreads / Google Books, or remove it. See
+[sd-plugins.md](sd-plugins.md).
 
 **Replacing a cover takes effect on the next load.** The rendered thumbnail is
 cached per book, and `ReaderActivity::ensureCoverThumb()` compares the sidecar's

--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -290,6 +290,53 @@ curl http://crosspoint.local/api/plugins
 
 Always 200 with an array; an unreadable or absent plugins folder yields `[]`.
 
+### GET `/api/relay` - Fetch a URL for a Plugin
+
+Fetches a URL the browser cannot reach itself and streams the body back. A page
+served from the device may not read a cross-origin response unless the remote
+sends CORS headers, and most do not; the device is not a browser, so it fetches
+on the page's behalf and answers same-origin.
+
+**Request:**
+```bash
+curl "http://crosspoint.local/api/relay?plugin=metadata-editor&url=https%3A%2F%2Fcovers.example.org%2Fb%2F1.jpg"
+```
+
+**Query Parameters:**
+
+| Parameter | Required | Description                                   |
+| --------- | -------- | --------------------------------------------- |
+| `plugin`  | Yes      | Plugin folder name; its manifest is the allowlist |
+| `url`     | Yes      | Absolute `http://` or `https://` URL           |
+
+The body streams back as `application/octet-stream` — response headers are not
+forwarded, so the caller infers the type from what it asked for.
+
+**Constraints:**
+
+- **GET only.** A plugin cannot make the device POST anywhere.
+- **Allowlisted per plugin.** The host must appear in that plugin's
+  `manifest.json` `allowedHosts`. A bare entry matches exactly; one starting
+  with a dot matches that suffix. No list, no access.
+- **Redirects are not followed.** A 3xx is returned as-is. Following them would
+  mean the host actually fetched was never checked against the allowlist — the
+  plugin may relay the `Location` itself, which is judged on its own merits.
+- **Streamed, not buffered**, with a 4MB ceiling. Nothing large is resident:
+  during a web session the largest free block is around 53KB, so a buffered
+  response would fail on an ordinary cover image.
+
+**Error Responses:**
+
+| Status | Cause                                                        |
+| ------ | ------------------------------------------------------------ |
+| 400    | Missing `plugin`/`url`, or a non-http(s) URL                  |
+| 403    | Host not listed in the plugin's `allowedHosts`                |
+| 502    | The fetch failed before any data arrived                      |
+| 503    | Heap too low to serve the request                             |
+
+A transfer that fails or hits the ceiling *after* data has been sent ends as a
+truncated 200; the failure is logged (`[WEB]`).
+
 ### GET `/plugin` - Serve a Plugin File
 
 Serves one file from a plugin's folder.

--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -337,6 +337,48 @@ forwarded, so the caller infers the type from what it asked for.
 A transfer that fails or hits the ceiling *after* data has been sent ends as a
 truncated 200; the failure is logged (`[WEB]`).
 
+### POST `/api/fetch` - Download to the SD Card
+
+Downloads a URL straight to the card. Relaying through the browser and uploading
+the bytes back would move the file twice over WiFi and hold all of it in browser
+memory — tolerable for a cover, prohibitive for a book.
+
+```bash
+curl -X POST "http://crosspoint.local/api/fetch?plugin=my-plugin&url=https%3A%2F%2Fexample.org%2Fbook.epub&dest=%2FBooks%2Fbook.epub"
+# -> {"ok":true,"dest":"/Books/book.epub"}
+```
+
+Same allowlist and no-redirect rules as `/api/relay`. `dest` must pass the same
+check `/upload` applies: inside the card, no `..`, and not a hidden or protected
+item. The book's layout cache is invalidated on success.
+
+| Status | Cause                                          |
+| ------ | ---------------------------------------------- |
+| 400    | Missing `plugin`/`url`/`dest`, bad scheme, or a refused destination |
+| 403    | Host not in the plugin's `allowedHosts`        |
+| 502    | Download failed                                 |
+
+### POST `/api/plugin-fs` - Write a Small File
+
+Writes one small file, with the raw request body as its contents. `/upload`
+already does this; it exists for compatibility with plugins written against the
+upstream API.
+
+```bash
+curl -X POST --data-binary @cover.jpg \
+  "http://crosspoint.local/api/plugin-fs?plugin=my-plugin&path=%2FBooks%2Fbook.jpg"
+# -> {"ok":true,"path":"/Books/book.jpg"}
+```
+
+Capped at 64KB — the body is buffered by the web server, so bulk transfers
+belong in `/upload`, which streams. `path` passes the same check as `dest` above.
+
+| Status | Cause                                   |
+| ------ | --------------------------------------- |
+| 400    | Missing `plugin`/`path`, or a refused path |
+| 413    | Body over 64KB — use `/upload`          |
+| 500    | Could not create the file, or short write |
+
 ### GET `/plugin` - Serve a Plugin File
 
 Serves one file from a plugin's folder.

--- a/plugins/metadata-editor/manifest.json
+++ b/plugins/metadata-editor/manifest.json
@@ -1,4 +1,10 @@
 {
   "title": "Metadata Editor",
-  "mount": "files"
+  "mount": "files",
+  "requires": ["relay"],
+  "allowedHosts": [
+    "www.goodreads.com",
+    ".gr-assets.com",
+    "books.google.com"
+  ]
 }

--- a/plugins/metadata-editor/plugin.js
+++ b/plugins/metadata-editor/plugin.js
@@ -146,7 +146,11 @@ CrossPoint.registerPlugin((container, api) => {
       '<p id="me-paste" tabindex="0" style="border:1px dashed rgba(128,128,128,.6);padding:10px">' +
       'Click here and press Ctrl+V to paste a copied image. Works with any site: copy the ' +
       'image in your browser, then paste it here.</p>' +
-      '<p><button id="me-search">Search Open Library</button> ' +
+      '<p><label>Search <select id="me-source">' +
+      '<option value="openlibrary">Open Library</option>' +
+      '<option value="goodreads">Goodreads</option>' +
+      '<option value="google">Google Books</option>' +
+      '</select></label> <button id="me-search">Find covers</button> ' +
       '<button id="me-remove">Remove cover</button> <span id="me-cover-msg"></span></p>' +
       '<div id="me-results"></div>';
 
@@ -170,7 +174,7 @@ CrossPoint.registerPlugin((container, api) => {
     };
 
     el('#me-remove').onclick = removeCover;
-    el('#me-search').onclick = () => searchOpenLibrary(values);
+    el('#me-search').onclick = () => searchCovers(el('#me-source').value, values);
   }
 
   function coverMsg(t) {
@@ -260,7 +264,29 @@ CrossPoint.registerPlugin((container, api) => {
     return '';
   }
 
-  async function searchOpenLibrary(values) {
+  // Covers come from three sources with different constraints.
+  //
+  // Open Library serves both its search API and its images with CORS, so it is
+  // fetched directly and never troubles the device.
+  //
+  // Goodreads has no public API - it was retired in 2020 - so its search page is
+  // scraped, which means this breaks if they change their markup. Google Books
+  // does have an API and it does send CORS, so the search is direct; only its
+  // images are on books.google.com, which does not.
+  //
+  // For both of those the relay is used for ONE thing: reading the bytes of the
+  // cover actually chosen. Previews are plain <img> tags pointing straight at the
+  // remote thumbnail, because displaying a cross-origin image was never
+  // restricted - only reading its pixels is. So the device does work for the one
+  // cover you pick, not for the whole grid.
+  const SOURCES = {
+    openlibrary: { label: 'Open Library', search: searchOpenLibrary, direct: true },
+    goodreads: { label: 'Goodreads', search: searchGoodreads, direct: false },
+    google: { label: 'Google Books', search: searchGoogleBooks, direct: false }
+  };
+
+  async function searchCovers(sourceKey, values) {
+    const source = SOURCES[sourceKey] || SOURCES.openlibrary;
     const results = el('#me-results');
     const title = (el('#me-f-title').value || values.title || '').trim();
     const author = (el('#me-f-author').value || values.author || '').trim();
@@ -269,45 +295,90 @@ CrossPoint.registerPlugin((container, api) => {
       return;
     }
 
-    coverMsg('Searching Open Library...');
+    coverMsg('Searching ' + source.label + '...');
     results.textContent = '';
     try {
-      const url = 'https://openlibrary.org/search.json?limit=8&fields=title,author_name,cover_i' +
-        '&title=' + encodeURIComponent(title) +
-        (author ? '&author=' + encodeURIComponent(author) : '');
-      const data = await (await fetch(url)).json();
-      const hits = (data.docs || []).filter((d) => d.cover_i);
+      const hits = await source.search(title, author);
       if (!hits.length) {
-        coverMsg('No covers found.');
+        coverMsg('No covers found on ' + source.label + '.');
         return;
       }
-
-      coverMsg(hits.length + ' result(s) - click one to use it');
-      results.innerHTML = hits.map((d, i) =>
-        '<figure style="display:inline-block;margin:4px;text-align:center;width:110px">' +
-        '<img data-i="' + i + '" class="me-hit" style="max-height:140px;cursor:pointer"' +
-        ' src="https://covers.openlibrary.org/b/id/' + d.cover_i + '-M.jpg" alt="">' +
-        '<figcaption style="font-size:.8em">' + esc((d.author_name || []).join(', ')) + '</figcaption>' +
-        '</figure>').join('');
-
-      results.querySelectorAll('.me-hit').forEach((img) => {
-        img.onclick = async () => {
-          const hit = hits[Number(img.dataset.i)];
-          coverMsg('Fetching cover...');
-          try {
-            // -L is the large size. Readable only because Open Library sends CORS.
-            const resp = await fetch('https://covers.openlibrary.org/b/id/' + hit.cover_i + '-L.jpg');
-            if (!resp.ok) throw new Error('cover ' + resp.status);
-            await installCover(await resp.blob(), 'openlibrary.jpg');
-            results.textContent = '';
-          } catch (e) {
-            coverMsg('Could not fetch that cover: ' + msg(e));
-          }
-        };
-      });
+      renderHits(hits, source);
     } catch (e) {
-      coverMsg('Search failed: ' + msg(e));
+      coverMsg(source.label + ' search failed: ' + msg(e));
     }
+  }
+
+  // hit = { thumb, full, label, direct }
+  function renderHits(hits, source) {
+    const results = el('#me-results');
+    coverMsg(hits.length + ' result(s) - click one to use it');
+    results.innerHTML = hits.map((h, i) =>
+      '<figure style="display:inline-block;margin:4px;text-align:center;width:110px">' +
+      '<img data-i="' + i + '" class="me-hit" style="max-height:140px;cursor:pointer"' +
+      ' src="' + h.thumb + '" alt="" loading="lazy">' +
+      '<figcaption style="font-size:.8em">' + esc(h.label || '') + '</figcaption>' +
+      '</figure>').join('');
+
+    results.querySelectorAll('.me-hit').forEach((img) => {
+      img.onclick = async () => {
+        const hit = hits[Number(img.dataset.i)];
+        coverMsg('Fetching cover...');
+        try {
+          // Direct where the host allows it; through the device where it does not.
+          const resp = source.direct ? await fetch(hit.full) : await api.relay(hit.full);
+          if (!resp.ok) throw new Error('cover ' + resp.status);
+          await installCover(await resp.blob(), 'cover.jpg');
+          results.textContent = '';
+        } catch (e) {
+          coverMsg('Could not fetch that cover: ' + msg(e));
+        }
+      };
+    });
+  }
+
+  async function searchOpenLibrary(title, author) {
+    const url = 'https://openlibrary.org/search.json?limit=8&fields=title,author_name,cover_i' +
+      '&title=' + encodeURIComponent(title) +
+      (author ? '&author=' + encodeURIComponent(author) : '');
+    const data = await (await fetch(url)).json();
+    return (data.docs || []).filter((d) => d.cover_i).map((d) => ({
+      thumb: 'https://covers.openlibrary.org/b/id/' + d.cover_i + '-M.jpg',
+      full: 'https://covers.openlibrary.org/b/id/' + d.cover_i + '-L.jpg',
+      label: (d.author_name || []).join(', ')
+    }));
+  }
+
+  async function searchGoodreads(title, author) {
+    const query = title + (author ? ' ' + author : '');
+    const html = await (await api.relay(
+      'https://www.goodreads.com/search?q=' + encodeURIComponent(query))).text();
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+
+    return Array.from(doc.querySelectorAll('img.bookCover')).slice(0, 8).map((img) => {
+      const thumb = img.getAttribute('src') || '';
+      // Search results are ~50px wide. Goodreads encodes the size as a "._SX50_"
+      // segment before the extension; dropping it yields the full-size cover
+      // (verified: 1.8KB thumbnail vs 266KB full).
+      const full = thumb.replace(/\._S[XY]\d+_(?=\.[a-z]+$)/i, '');
+      return { thumb, full, label: (img.getAttribute('alt') || '').trim() };
+    }).filter((h) => h.thumb);
+  }
+
+  async function searchGoogleBooks(title, author) {
+    const q = 'intitle:' + title + (author ? ' inauthor:' + author : '');
+    const url = 'https://www.googleapis.com/books/v1/volumes?maxResults=8&q=' + encodeURIComponent(q);
+    const data = await (await fetch(url)).json();
+    return (data.items || []).map((item) => {
+      const info = item.volumeInfo || {};
+      const links = info.imageLinks || {};
+      const thumb = links.thumbnail || links.smallThumbnail;
+      if (!thumb) return null;
+      // Served over http in the payload, and edge=curl draws a page-curl effect
+      // that has no business on a cover.
+      const clean = thumb.replace(/^http:/, 'https:').replace(/&edge=curl/, '');
+      return { thumb: clean, full: clean, label: (info.authors || []).join(', ') };
+    }).filter(Boolean);
   }
 
   async function del(path) {

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -201,6 +201,10 @@ const char* pluginContentType(const String& file) {
 // the handful of fields the format defines.
 constexpr size_t PLUGIN_MANIFEST_MAX_BYTES = 4096;
 
+// /api/plugin-fs is the small-file door; anything bigger belongs in /upload,
+// which streams instead of buffering the whole body in the request.
+constexpr size_t PLUGIN_FS_MAX_BYTES = 64u * 1024u;
+
 // Host of a URL: between "://" and the next "/", minus any port, and minus any
 // userinfo. Dropping everything before an "@" matters - "https://ok.com@evil.com/"
 // connects to evil.com, so that is the host the allowlist must judge.
@@ -248,6 +252,23 @@ bool relayHostAllowed(const String& plugin, const std::string& url) {
     }
   }
   return false;
+}
+
+// Where a plugin may write. Normalised, must stay inside the card, must not
+// name a hidden or protected item, and must have a filename - the same fence
+// /upload and /delete already apply, so a plugin gains no reach the web UI
+// does not already have. Returns "" when the path is refused.
+String pluginWriteTarget(const String& rawPath) {
+  String path = normalizeWebPath(rawPath);
+  if (path.isEmpty() || path == "/" || path.endsWith("/")) return "";
+  // normalizeWebPath keeps "..", which would climb out of the card.
+  if (path.indexOf("..") >= 0) return "";
+
+  const int lastSlash = path.lastIndexOf('/');
+  if (lastSlash < 0) return "";
+  const String name = path.substring(lastSlash + 1);
+  if (name.isEmpty() || isProtectedItemName(name)) return "";
+  return path;
 }
 
 // Ceiling on a relayed response. Nothing is buffered (see handleRelay), so this
@@ -358,6 +379,8 @@ void CrossPointWebServer::begin() {
   server->on("/api/plugins", HTTP_GET, [this] { handlePluginList(); });
   server->on("/plugin", HTTP_GET, [this] { handlePluginFile(); });
   server->on("/api/relay", HTTP_GET, [this] { handleRelay(); });
+  server->on("/api/fetch", HTTP_POST, [this] { handleFetchToSd(); });
+  server->on("/api/plugin-fs", HTTP_POST, [this] { handlePluginFs(); });
 
   server->on("/api/wifi", HTTP_GET, [this] { handleGetWifiNetworks(); });
   server->on("/api/wifi", HTTP_POST, [this] { handlePostWifiNetwork(); });
@@ -2877,6 +2900,98 @@ void CrossPointWebServer::handleRelay() {
   } else {
     LOG_DBG("WEB", "Relay served %u bytes", static_cast<unsigned>(total));
   }
+}
+
+// POST /api/fetch?plugin=<name>&url=<url>&dest=<sd path>
+//
+// Downloads straight to the card. Doing this through /api/relay plus /upload
+// would move the file twice over WiFi and hold all of it in browser memory;
+// for a cover that is merely wasteful, for a book it is prohibitive.
+//
+// Same fence as the relay - allowlisted per plugin manifest, no redirects -
+// plus the write target must pass the same check /upload applies.
+void CrossPointWebServer::handleFetchToSd() {
+  if (rejectIfLowMemory(server.get())) return;
+
+  const String plugin = server->arg("plugin");
+  const std::string url = server->arg("url").c_str();
+  const String dest = pluginWriteTarget(server->arg("dest"));
+
+  if (!isSafePathComponent(plugin) || url.empty() || dest.isEmpty()) {
+    server->send(400, "application/json", "{\"error\":\"missing plugin, url or dest\"}");
+    return;
+  }
+  if (url.rfind("http://", 0) != 0 && url.rfind("https://", 0) != 0) {
+    server->send(400, "application/json", "{\"error\":\"only http(s) urls\"}");
+    return;
+  }
+  if (!relayHostAllowed(plugin, url)) {
+    LOG_DBG("WEB", "Fetch refused for %s: %s not in allowedHosts", plugin.c_str(), urlHost(url).c_str());
+    server->send(403, "application/json", "{\"error\":\"host not allowed by plugin manifest\"}");
+    return;
+  }
+
+  LOG_DBG("WEB", "Fetch %s -> %s", url.c_str(), dest.c_str());
+  const HttpDownloader::DownloadError result = HttpDownloader::downloadToFile(url, dest.c_str());
+  if (result != HttpDownloader::OK) {
+    LOG_ERR("WEB", "Fetch to SD failed (%d): %s", static_cast<int>(result), url.c_str());
+    server->send(502, "application/json", "{\"error\":\"download failed\"}");
+    return;
+  }
+
+  // A downloaded book replaces whatever was cached for that path.
+  clearBookCacheIfNeeded(dest);
+  JsonDocument doc;
+  doc["ok"] = true;
+  doc["dest"] = dest.c_str();
+  sendJson(server.get(), 200, doc);
+}
+
+// POST /api/plugin-fs?plugin=<name>&path=<sd path>  (raw body = file contents)
+//
+// Writes one small file to the card. /upload already does this, so this exists
+// for compatibility with plugins written against the upstream API rather than
+// because the web UI needs it - hence the modest cap, which keeps it to the
+// small-file job it advertises and leaves bulk transfers to /upload.
+void CrossPointWebServer::handlePluginFs() {
+  if (rejectIfLowMemory(server.get())) return;
+
+  const String plugin = server->arg("plugin");
+  const String path = pluginWriteTarget(server->arg("path"));
+  if (!isSafePathComponent(plugin) || path.isEmpty()) {
+    server->send(400, "application/json", "{\"error\":\"missing plugin or path\"}");
+    return;
+  }
+
+  // WebServer has already buffered the body; "plain" is the raw payload for a
+  // non-form content type.
+  const String body = server->arg("plain");
+  if (body.length() > PLUGIN_FS_MAX_BYTES) {
+    server->send(413, "application/json", "{\"error\":\"file too large, use /upload\"}");
+    return;
+  }
+
+  FsFile out;
+  if (!Storage.openFileForWrite("WEB", path.c_str(), out)) {
+    server->send(500, "application/json", "{\"error\":\"could not create file\"}");
+    return;
+  }
+  const size_t written = body.length() ? out.write(body.c_str(), body.length()) : 0;
+  out.close();
+
+  if (written != static_cast<size_t>(body.length())) {
+    LOG_ERR("WEB", "plugin-fs short write: %u of %u to %s", static_cast<unsigned>(written),
+            static_cast<unsigned>(body.length()), path.c_str());
+    server->send(500, "application/json", "{\"error\":\"short write\"}");
+    return;
+  }
+
+  LOG_DBG("WEB", "plugin-fs wrote %u bytes to %s", static_cast<unsigned>(written), path.c_str());
+  clearBookCacheIfNeeded(path);
+  JsonDocument doc;
+  doc["ok"] = true;
+  doc["path"] = path.c_str();
+  sendJson(server.get(), 200, doc);
 }
 
 // WebSocket callback trampoline

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -254,15 +254,19 @@ bool relayHostAllowed(const String& plugin, const std::string& url) {
   return false;
 }
 
-// Where a plugin may write. Normalised, must stay inside the card, must not
-// name a hidden or protected item, and must have a filename - the same fence
-// /upload and /delete already apply, so a plugin gains no reach the web UI
-// does not already have. Returns "" when the path is refused.
+// Where a plugin may write, or "" when the path is refused.
+//
+// Containment comes from normalizeWebPath: FsHelpers::normalisePath resolves
+// every ".." against the components before it and no-ops once nothing is left,
+// so the result cannot climb above the card root. No separate ".." check is
+// needed - and a textual one would be wrong, because by this point ".." can
+// only survive inside a filename ("my..book.epub"), which is legitimate.
+//
+// The name check is stricter than /upload, which applies none: a plugin may not
+// create a hidden or protected item even though the web UI's own upload can.
 String pluginWriteTarget(const String& rawPath) {
   String path = normalizeWebPath(rawPath);
   if (path.isEmpty() || path == "/" || path.endsWith("/")) return "";
-  // normalizeWebPath keeps "..", which would climb out of the card.
-  if (path.indexOf("..") >= 0) return "";
 
   const int lastSlash = path.lastIndexOf('/');
   if (lastSlash < 0) return "";

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -200,6 +200,60 @@ const char* pluginContentType(const String& file) {
 // file in a plugin folder from being read into the heap; 4KB is far more than
 // the handful of fields the format defines.
 constexpr size_t PLUGIN_MANIFEST_MAX_BYTES = 4096;
+
+// Host of a URL: between "://" and the next "/", minus any port, and minus any
+// userinfo. Dropping everything before an "@" matters - "https://ok.com@evil.com/"
+// connects to evil.com, so that is the host the allowlist must judge.
+std::string urlHost(const std::string& url) {
+  const size_t schemeEnd = url.find("://");
+  if (schemeEnd == std::string::npos) return {};
+  const size_t start = schemeEnd + 3;
+  size_t end = url.find('/', start);
+  if (end == std::string::npos) end = url.size();
+
+  std::string host = url.substr(start, end - start);
+  const size_t at = host.rfind('@');
+  if (at != std::string::npos) host = host.substr(at + 1);
+  const size_t colon = host.find(':');
+  if (colon != std::string::npos) host = host.substr(0, colon);
+  return host;
+}
+
+// True when the URL's host appears in the calling plugin's manifest
+// "allowedHosts". A bare entry must match exactly; one starting with a dot
+// matches that suffix (".example.org" allows "covers.example.org"). Absent or
+// empty list means nothing is allowed - the relay is opt-in per plugin, and a
+// plugin's reach is readable in its own folder before it is installed.
+bool relayHostAllowed(const String& plugin, const std::string& url) {
+  const std::string host = urlHost(url);
+  if (host.empty() || !isSafePathComponent(plugin)) return false;
+
+  const std::string dir = PluginLocations::findPluginDir(plugin.c_str());
+  if (dir.empty()) return false;
+
+  std::string manifest;
+  if (!Storage.readFileToString("WEB", dir + "/manifest.json", PLUGIN_MANIFEST_MAX_BYTES, manifest)) return false;
+
+  JsonDocument m;
+  if (deserializeJson(m, manifest) != DeserializationError::Ok || !m["allowedHosts"].is<JsonArray>()) return false;
+
+  for (JsonVariant entry : m["allowedHosts"].as<JsonArray>()) {
+    const char* pattern = entry.as<const char*>();
+    if (!pattern || !*pattern) continue;
+    const std::string pat = pattern;
+    if (pat[0] == '.') {
+      if (host.size() > pat.size() && host.compare(host.size() - pat.size(), pat.size(), pat) == 0) return true;
+    } else if (host == pat) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Ceiling on a relayed response. Nothing is buffered (see handleRelay), so this
+// only bounds how long one request may occupy the single-connection server.
+constexpr size_t MAX_RELAY_BYTES = 4u * 1024u * 1024u;
+
 }  // namespace
 
 // File listing page template - now using generated headers:
@@ -303,6 +357,7 @@ void CrossPointWebServer::begin() {
   // Web-UI plugins (SD card)
   server->on("/api/plugins", HTTP_GET, [this] { handlePluginList(); });
   server->on("/plugin", HTTP_GET, [this] { handlePluginFile(); });
+  server->on("/api/relay", HTTP_GET, [this] { handleRelay(); });
 
   server->on("/api/wifi", HTTP_GET, [this] { handleGetWifiNetworks(); });
   server->on("/api/wifi", HTTP_POST, [this] { handlePostWifiNetwork(); });
@@ -2744,6 +2799,83 @@ void CrossPointWebServer::handlePluginFile() const {
   f.close();
   if (!ok) {
     LOG_DBG("WEB", "Plugin file streaming interrupted: %s/%s", name.c_str(), file.c_str());
+  }
+}
+
+// GET /api/relay?plugin=<name>&url=<url>
+//
+// Fetches a URL the browser cannot reach itself. A page served from this device
+// may not read a cross-origin response unless the remote sends CORS headers, and
+// most do not; the device is not a browser and has no such restriction, so it
+// fetches on the page's behalf and answers same-origin.
+//
+// That is a real capability, so it is fenced: GET only, and only to hosts the
+// calling plugin declares in its own manifest. Redirects are NOT followed -
+// otherwise an allowed host could 302 anywhere and the host actually fetched
+// would never have been checked, which is how upstream's version could be
+// bypassed. A 3xx is returned to the plugin, which may relay the new location
+// and have it judged on its own merits.
+//
+// The body is streamed straight through rather than buffered: during a web
+// session the heap has around 110KB free with a ~53KB largest block, and a
+// single cover image can exceed that on its own.
+void CrossPointWebServer::handleRelay() {
+  if (rejectIfLowMemory(server.get())) return;
+
+  const String plugin = server->arg("plugin");
+  const String urlArg = server->arg("url");
+  const std::string url = urlArg.c_str();
+
+  if (!isSafePathComponent(plugin) || url.empty()) {
+    server->send(400, "application/json", "{\"error\":\"missing plugin or url\"}");
+    return;
+  }
+  // Only http(s): the client speaks nothing else, and this keeps the scheme out
+  // of the allowlist's business.
+  if (url.rfind("http://", 0) != 0 && url.rfind("https://", 0) != 0) {
+    server->send(400, "application/json", "{\"error\":\"only http(s) urls\"}");
+    return;
+  }
+  if (!relayHostAllowed(plugin, url)) {
+    LOG_DBG("WEB", "Relay refused for %s: %s not in allowedHosts", plugin.c_str(), urlHost(url).c_str());
+    server->send(403, "application/json", "{\"error\":\"host not allowed by plugin manifest\"}");
+    return;
+  }
+
+  LOG_DBG("WEB", "Relay %s -> %s", plugin.c_str(), url.c_str());
+
+  bool headerSent = false;
+  bool overLimit = false;
+  size_t total = 0;
+
+  const bool ok = HttpDownloader::fetchUrl(url, [&](const uint8_t* data, size_t len) {
+    if (total + len > MAX_RELAY_BYTES) {
+      overLimit = true;
+      return false;  // aborts the transfer
+    }
+    if (!headerSent) {
+      // Content type is not forwarded - HttpDownloader does not surface response
+      // headers - so the caller infers it from what it asked for.
+      server->setContentLength(CONTENT_LENGTH_UNKNOWN);
+      server->send(200, "application/octet-stream", "");
+      headerSent = true;
+    }
+    esp_task_wdt_reset();
+    server->sendContent(reinterpret_cast<const char*>(data), len);
+    total += len;
+    return true;
+  });
+
+  if (!headerSent) {
+    server->send(502, "application/json", "{\"error\":\"fetch failed\"}");
+    return;
+  }
+  server->sendContent("");  // terminate the chunked response
+  if (!ok || overLimit) {
+    LOG_ERR("WEB", "Relay truncated after %u bytes%s: %s", static_cast<unsigned>(total),
+            overLimit ? " (size limit)" : "", url.c_str());
+  } else {
+    LOG_DBG("WEB", "Relay served %u bytes", static_cast<unsigned>(total));
   }
 }
 

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -172,4 +172,8 @@ class CrossPointWebServer {
   // that branch's device-capability endpoints are ported.
   void handlePluginList() const;  // GET /api/plugins -> discovered plugins
   void handlePluginFile() const;  // GET /plugin?name&file -> one file from its folder
+  // GET /api/relay?plugin&url -> fetch a URL the browser cannot reach itself.
+  // GET only, allowlisted per plugin manifest, no redirects, streamed not
+  // buffered. See the definition for why each of those is load-bearing.
+  void handleRelay();
 };

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -176,4 +176,10 @@ class CrossPointWebServer {
   // GET only, allowlisted per plugin manifest, no redirects, streamed not
   // buffered. See the definition for why each of those is load-bearing.
   void handleRelay();
+  // POST /api/fetch?plugin&url&dest -> download straight to the card, avoiding
+  // the double transfer of relaying through the browser and uploading back.
+  void handleFetchToSd();
+  // POST /api/plugin-fs?plugin&path -> write one small file. /upload already
+  // covers this; kept for compatibility with upstream-written plugins.
+  void handlePluginFs();
 };

--- a/src/network/html/shared/PluginHost.js.inc
+++ b/src/network/html/shared/PluginHost.js.inc
@@ -22,6 +22,19 @@ window.CrossPoint = window.CrossPoint || {
   registerPlugin(fn) { this._pending = fn; }
 };
 
+// Device capabilities this firmware implements. A plugin may declare what it
+// needs as "requires" in its manifest, and one asking for something absent is
+// refused with a readable card instead of failing somewhere inside its own code.
+//
+// "crypto" is deliberately absent: the browser's own crypto.subtle covers
+// hashing, HMAC, AES and RSA, so a device-side implementation would duplicate it.
+const PLUGIN_CAPABILITIES = ['relay', 'fetchToSd', 'writeFile', 'pluginFile'];
+
+function missingCapabilities(plugin) {
+  const required = Array.isArray(plugin.requires) ? plugin.requires : [];
+  return required.filter((cap) => PLUGIN_CAPABILITIES.indexOf(cap) === -1);
+}
+
 // `mount` selects which page's plugins to load, matching the manifest's "mount"
 // field ("settings" or "files"); plugins omitting it default to "settings".
 //
@@ -47,6 +60,13 @@ async function loadPlugins(mount) {
     container.id = 'plugin-' + p.name;
     host.appendChild(container);
 
+    const missing = missingCapabilities(p);
+    if (missing.length) {
+      showPluginError(container, p, 'needs ' + missing.join(', ') +
+        ', which this firmware does not provide.');
+      continue;
+    }
+
     CrossPoint._pending = null;
     try {
       await new Promise((resolve, reject) => {
@@ -61,6 +81,38 @@ async function loadPlugins(mount) {
       }
       CrossPoint._pending(container, {
         name: p.name,
+        // Fetch a URL the browser cannot reach itself, via the device. GET only,
+        // and only to hosts this plugin's manifest lists in allowedHosts.
+        // Resolves to a Response so callers can pick .blob()/.text()/.json().
+        relay: async (url) => {
+          const r = await fetch('/api/relay?plugin=' + encodeURIComponent(p.name) +
+            '&url=' + encodeURIComponent(url));
+          if (!r.ok) throw new Error('relay ' + r.status + ': ' + (await r.text().catch(() => '')));
+          return r;
+        },
+        // Download straight to the card - one transfer instead of relaying
+        // through the browser and uploading the bytes back.
+        fetchToSd: async (url, dest) => {
+          const r = await fetch('/api/fetch?plugin=' + encodeURIComponent(p.name) +
+            '&url=' + encodeURIComponent(url) + '&dest=' + encodeURIComponent(dest),
+            { method: 'POST' });
+          if (!r.ok) throw new Error('fetch ' + r.status + ': ' + (await r.text().catch(() => '')));
+          return r.json();
+        },
+        // Write one small file. `data` may be a string, Blob or ArrayBuffer.
+        writeFile: async (path, data) => {
+          const r = await fetch('/api/plugin-fs?plugin=' + encodeURIComponent(p.name) +
+            '&path=' + encodeURIComponent(path),
+            { method: 'POST', headers: { 'Content-Type': 'application/octet-stream' }, body: data });
+          if (!r.ok) throw new Error('plugin-fs ' + r.status + ': ' + (await r.text().catch(() => '')));
+          return r.json();
+        },
+        // Present so a plugin written against the upstream API fails with a
+        // sentence rather than "api.crypto is not a function".
+        crypto: () => {
+          throw new Error('api.crypto is not available on this firmware - use the ' +
+            "browser's crypto.subtle instead");
+        },
         // manifest.json's title, falling back to the folder name. The host
         // renders no chrome - the plugin owns its whole card - so this is here
         // for a plugin that wants its heading to track the manifest instead of
@@ -81,12 +133,16 @@ async function loadPlugins(mount) {
         }
       });
     } catch (e) {
-      const title = document.createElement('h2');
-      title.textContent = p.title || p.name;
-      const msg = document.createElement('p');
-      msg.className = 'plugin-error';
-      msg.textContent = 'Failed to load plugin: ' + ((e && e.message) || e);
-      container.replaceChildren(title, msg);
+      showPluginError(container, p, 'failed to load: ' + ((e && e.message) || e));
     }
   }
+}
+
+function showPluginError(container, plugin, detail) {
+  const title = document.createElement('h2');
+  title.textContent = plugin.title || plugin.name;
+  const msg = document.createElement('p');
+  msg.className = 'plugin-error';
+  msg.textContent = 'This plugin ' + detail;
+  container.replaceChildren(title, msg);
 }


### PR DESCRIPTION
> Follows #135 (merged), which added the sidecar work these plugins build on.

Gives plugins three device capabilities they cannot have from the browser alone, each fenced by a per-plugin host allowlist — and uses them to add Goodreads and Google Books as cover sources in `metadata-editor`.

**Device: flash 96.7% (6,339,241), RAM unchanged. Host suite 455/455.**

## Why any of this is needed

A plugin runs in a page served by the device, so it can only read a cross-origin response when the remote sends CORS headers. Most book sites do not. Goodreads retired its public API in 2020 and sends none; Google Books' *API* does, but its cover images are on `books.google.com`, which does not — and a cross-origin image taints a canvas, so its bytes can be displayed and never saved.

Without a relay, "fetch a cover from the web" is limited to the handful of sites that opt in.

## The endpoints

| | |
|---|---|
| `GET /api/relay?plugin&url` | fetch a URL the browser cannot reach, streamed back |
| `POST /api/fetch?plugin&url&dest` | download straight to the card |
| `POST /api/plugin-fs?plugin&path` | write one small file (≤64KB) |

All three require the host — or for `plugin-fs`, the path — to be permitted for the *calling plugin*. Hosts come from that plugin's own `manifest.json`, so its reach is readable in a file before you copy it to the card.

## Three deliberate differences from upstream's version

**GET only.** Upstream accepted any method with arbitrary headers and body, which amounts to "make this device issue any HTTP request". Everything the cover work needs is a GET, and this way a plugin cannot make the reader POST anywhere.

**Redirects are not followed.** Upstream used the client default of five hops, so an allowed host could `302` anywhere and the host actually fetched was never checked — their allowlist did not do what it claimed. A `3xx` comes back as-is; a plugin may relay the `Location`, which is then judged on its own merits. `urlHost` also strips userinfo, since `https://ok.com@evil.com/` connects to `evil.com` and that is the host the allowlist must judge.

**The body is streamed, not buffered.** This is a functional requirement, not caution. `SecureHttpClient` buffers a whole response into a `std::string`, and during a web session the largest free block is around **53KB** — an ordinary cover image does not fit. Upstream's buffered relay would OOM on exactly the use case this exists for. Chunks go straight into a chunked response with a 4MB ceiling.

The cost of streaming is that response headers are not forwarded, so callers infer the content type from what they asked for.

## `/api/crypto` is deliberately absent

The browser's own `crypto.subtle` covers hashing, HMAC, AES and RSA; the content-protection work that motivated a device-side version upstream is not ours.

So that skipping it degrades legibly, `api.crypto` exists as a **stub that throws a sentence** — an upstream-written plugin would otherwise hit `api.crypto is not a function` from inside its own code with nothing pointing at the firmware. A plugin may also declare `"requires": [...]` and one asking for a missing capability is refused with a visible card before any of its code runs. The stub matters more in practice, since upstream-written plugins have no `requires` field.

## Cover sources, and why they differ

| Source | Search | Cover bytes |
|---|---|---|
| Open Library | direct — sends CORS | direct |
| Google Books | direct — API sends CORS | **relay** |
| Goodreads | **relay** — scraped, no API | **relay** |

Result thumbnails are plain `<img>` tags pointing at the remote host, because *displaying* a cross-origin image was never restricted — only reading its pixels is. The relay is used for one thing: the bytes of the cover you actually pick. The device fetches one image, not the whole grid, which keeps the single-connection server free while you browse.

Two caveats, in the docs rather than left to be discovered:

- **The Goodreads path scrapes HTML** and will break when they change their markup — not if. It looks for `img.bookCover` and strips the `._SX50_` size segment to get the full image (measured: 1.8KB thumbnail against 266KB full).
- **Google's covers are ~128px**, noticeably worse on-device than the other two. The URL is cleaned of `edge=curl`, which draws a page-curl effect across the artwork.

## A bug this review caught

`pluginWriteTarget` claimed `normalizeWebPath` keeps `..` and rejected any path containing it. Both halves were wrong. `FsHelpers::normalisePath` resolves each `..` against the preceding components and no-ops when nothing is left, so `/../../etc/passwd` → `/etc/passwd` and `/Books/..` → `/`, which the existing root check already refuses — containment never depended on the textual test. Worse, that test ran on the *already-normalised* path, where `..` can only survive inside a filename, so `/Books/my..book.epub` was refused as an escape attempt.

Also corrected the claim that this applies "the same fence /upload and /delete already apply": `/upload` applies none. This is stricter, and the comment now says so rather than implying parity.

## Testing

- Firmware build green; host suite 455/455 (unchanged — this adds no host-testable code).
- Allowlist matching checked against its negatives: `notgr-assets.com` does **not** match `.gr-assets.com`, and `books.google.com.evil.com` does **not** match `books.google.com`.
- Containment verified on the normalisation alone after removing the bogus check.
- `books.google.com` confirmed to answer 200 without redirecting, which matters because the relay does not follow them.
- Goodreads markup and the `._SX50_` strip verified against a real search page.
- Plugin JS syntax-checked; the shipped gzipped payloads parse and carry the api surface.

**Not yet run on hardware.** `/api/relay` and `/api/fetch` do TLS from inside a web request — the path itself is proven by the font installer and OPDS downloads, but this use of it is not, and the relay's streaming design has never executed on device. Worth testing in order: `/api/plugin-fs` (no network), then `/api/relay` against an allowed host and a disallowed one, then the Goodreads/Google cover sources, then `/api/fetch`.
