### PR TITLE
fix(hal): guard the GPIO13 battery latch to Xteink C3 boards

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -74,6 +74,15 @@ HalGPIO::DeviceType nvsToDeviceType(NvsDeviceValue value) {
   return value == NvsDeviceValue::X3 ? HalGPIO::DeviceType::X3 : HalGPIO::DeviceType::X4;
 }
 
+// True when this binary targets one of the Xteink C3 variants. A binary holds
+// exactly one MCU family — BoardConfig enforces that with an #error — so
+// DEFAULT_DEVICE settles the question at compile time.
+constexpr bool buildTargetsXteinkC3() {
+  return BoardConfig::DEFAULT_DEVICE.board == BoardConfig::Board::XteinkX4 ||
+         BoardConfig::DEFAULT_DEVICE.board == BoardConfig::Board::XteinkX3 ||
+         BoardConfig::DEFAULT_DEVICE.board == BoardConfig::Board::XteinkX3Uc8279;
+}
+
 HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
   // Explicit override for recovery/support:
   // 0 = auto, 1 = force X4, 2 = force X3
@@ -113,18 +122,29 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
 }  // namespace
 
 void HalGPIO::begin() {
-  _deviceType = detectDeviceTypeWithFingerprint();
-  BoardConfig::selectDevice(deviceIsX3() ? BoardConfig::Board::XteinkX3 : BoardConfig::Board::XteinkX4);
+  // Both probes below poke C3 hardware — the X3/X4 fingerprint reads C3 pins and
+  // applyXteinkDisplayController() drives the Xteink display bus — so they must
+  // not run on another board. BoardConfig::ACTIVE would survive them intact
+  // (selectDevice() returns false for a board this binary was not built with,
+  // leaving the profile the build's own FREEINK_DEVICE_* flag chose), but the
+  // probes themselves would still touch pins that mean something else there.
+  if constexpr (buildTargetsXteinkC3()) {
+    _deviceType = detectDeviceTypeWithFingerprint();
+    BoardConfig::selectDevice(deviceIsX3() ? BoardConfig::Board::XteinkX3 : BoardConfig::Board::XteinkX4);
 
-  // Resolve the per-batch controller before SPI owns the display pins. FreeInk
-  // checks the OEM hw_calib/screenType value first, then falls back to its
-  // two-pass display-bus probe. X3's facade keys panel selection off the sibling
-  // board profile, so preserve a detected UC8279 through setDisplayX3().
-  freeink::applyXteinkDisplayController();
-  if (deviceIsX3() && BoardConfig::ACTIVE.displayController == BoardConfig::DisplayController::UC8279) {
-    BoardConfig::selectDevice(BoardConfig::Board::XteinkX3Uc8279);
+    // Resolve the per-batch controller before SPI owns the display pins. FreeInk
+    // checks the OEM hw_calib/screenType value first, then falls back to its
+    // two-pass display-bus probe. X3's facade keys panel selection off the sibling
+    // board profile, so preserve a detected UC8279 through setDisplayX3().
+    freeink::applyXteinkDisplayController();
+    if (deviceIsX3() && BoardConfig::ACTIVE.displayController == BoardConfig::DisplayController::UC8279) {
+      BoardConfig::selectDevice(BoardConfig::Board::XteinkX3Uc8279);
+    }
   }
 
+  // inputMgr.begin() is board-generic (it reads BoardConfig::ACTIVE.input). The
+  // rest below is still hardcoded to C3 Xteink pin macros — bringing up another
+  // board means sourcing these from BoardConfig::ACTIVE.display too.
   inputMgr.begin();
   SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
 
@@ -132,6 +152,15 @@ void HalGPIO::begin() {
     pinMode(BAT_GPIO0, INPUT);
     pinMode(UART0_RXD, INPUT);
   }
+}
+
+// Ported from crosspoint-reader PR #2998 ("fix: Guard GPIO13 power control for
+// Xteink C3 boards only", Justin Mitchell / @itsthisjustin). The predicate is
+// his, verbatim; the call sites differ because this fork has no light sleep.
+bool HalGPIO::isXteinkDevice() const {
+  return BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX3 ||
+         BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX3Uc8279 ||
+         BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX4;
 }
 
 // Push one debounced edge into the loop-drained FIFO. Caller holds inputMux_.

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -110,6 +110,14 @@ class HalGPIO {
   inline bool deviceIsX3() const { return _deviceType == DeviceType::X3; }
   inline bool deviceIsX4() const { return _deviceType == DeviceType::X4; }
 
+  // True only on the Xteink C3 boards (X3, X3/UC8279, X4). Guards the pin
+  // assumptions that hold for the C3 hardware but not for its S3 siblings or
+  // third-party boards — chiefly GPIO13, which is a power control here and an
+  // ordinary bus signal elsewhere. Note this is NOT !deviceIsX3(): X4 Pro is an
+  // Xteink board but not an Xteink *C3* board, and _deviceType only ever
+  // distinguishes the two C3 variants.
+  bool isXteinkDevice() const;
+
   // Start button GPIO and setup SPI for screen and SD card
   void begin();
 

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -128,11 +128,19 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio, bool keepClockAlive) const {
   // (which cuts the card's power and latches it off) instead of treating it as a
   // latch; SDCardManager::begin() releases that hold and re-powers on the next
   // boot. Doing both would make us a second, independent writer of the pin.
-  if (gpio.deviceIsX3()) {
-    freeink::PowerManager::powerDownRailsForSleep();
-    esp_sleep_config_gpio_isolate();
-    gpio_deep_sleep_hold_en();
-  } else {
+  //
+  // Non-Xteink boards share neither meaning and take the rail-teardown path too:
+  // GPIO13 is an ordinary signal there — SPI MOSI on the LilyGo T5S3
+  // (BoardT5S3Pins.h), display chip select on the X4 Pro — so driving it as an
+  // output and pad-holding it would clobber a live bus.
+  // Those boards also ignore keepClockAlive: nothing cuts MCU power there, so
+  // the LP timer and RTC memory survive deep sleep either way.
+  // Ported from crosspoint-reader PR #2998 ("fix: Guard GPIO13 power control for
+  // Xteink C3 boards only", Justin Mitchell / @itsthisjustin). His fix guards
+  // lightSleep()/onEinkBusyWaitSlice(), which this fork does not have; here the
+  // same predicate guards the one place we touch GPIO13.
+  const bool gpio13IsBatteryLatch = gpio.isXteinkDevice() && !gpio.deviceIsX3();
+  if (gpio13IsBatteryLatch) {
     constexpr gpio_num_t GPIO_SPIWP = GPIO_NUM_13;
     // Release any GPIO hold from a previous sleep cycle (keepClockAlive=true leaves GPIO13 held after wake).
     // Without this, gpio_set_level() below silently fails and GPIO13 is stuck in its prior state,
@@ -144,6 +152,10 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio, bool keepClockAlive) const {
     esp_sleep_config_gpio_isolate();
     gpio_deep_sleep_hold_en();
     gpio_hold_en(GPIO_SPIWP);
+  } else {
+    freeink::PowerManager::powerDownRailsForSleep();
+    esp_sleep_config_gpio_isolate();
+    gpio_deep_sleep_hold_en();
   }
   pinMode(InputManager::POWER_BUTTON_PIN, INPUT_PULLUP);
 


### PR DESCRIPTION
GPIO13 is the X4's battery-latch MOSFET gate, and startDeepSleep() drove and pad-held it on every board that is not an X3. That assumption only holds on the Xteink C3 hardware: on the LilyGo T5S3 GPIO13 is SPI MOSI (BoardT5S3Pins.h) and on the X4 Pro it is the display chip select, so the same code would drive and latch a live bus pin on the way into deep sleep.

Add HalGPIO::isXteinkDevice() and take the battery-latch path only on a C3 X4. Everything else falls through to the rail-teardown path X3 already used, which is also the right behaviour for boards with switched peripheral rails.

Also stop HalGPIO::begin() from running the C3 hardware probes on a board that is not a C3. BoardConfig::ACTIVE was never actually at risk -- selectDevice() returns false for a board the binary was not built with, and BoardConfig #errors on a binary that mixes MCU families, so an S3 build cannot carry the X3/X4 profiles at all -- but detectDeviceTypeWithFingerprint() and applyXteinkDisplayController() would still poke C3 pins and the Xteink display bus. Gate both on the build's compile-time default board.

No behaviour change on X3 or X4: buildTargetsXteinkC3() is true there, and the latch path is byte-identical apart from the branch condition. Verified by building -e default (SUCCESS, flash 96.6%, RAM 17.2% -- both unchanged).

Ported from crosspoint-reader PR #2998 ("fix: Guard GPIO13 power control for Xteink C3 boards only", Justin Mitchell / @itsthisjustin). isXteinkDevice() is his code verbatim. His fix guards lightSleep() and onEinkBusyWaitSlice(), which this fork does not have, so here the same predicate guards startDeepSleep() -- the one place we touch GPIO13.

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_
