### PR TITLE
fix(reader): keep the rebuild anchor on the page being read

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1548,9 +1548,7 @@ void EpubReaderActivity::stepCurrentSectionBuild() {
   } else {
     navTarget.resolveInto(*section, currentSpineIndex);
   }
-  if (section) {
-    navTarget = NavigationTarget::makePage(section->currentPage);
-  }
+  anchorNavTargetToCurrentPage();
   forceLoadLargeImages = false;
   pageHasPlaceholders = false;
   buildingPopupShown_ = false;
@@ -1641,6 +1639,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
                                     : std::nullopt;
             if (resolvedPage) {
               section->currentPage = *resolvedPage;
+              anchorNavTargetToCurrentPage();
               forceLoadLargeImages = false;
               pageHasPlaceholders = false;
             } else {
@@ -2364,6 +2363,36 @@ void EpubReaderActivity::NavigationTarget::resolveInto(Section& sec, int spineIn
   }
 }
 
+// navTarget is the anchor a section (re)build resolves into. It used to be written only when a
+// section was ENTERED and then left frozen for the whole chapter, so every mid-chapter teardown
+// re-seeded currentPage from the entry page — page 0 for a chapter reached by reading forward.
+// The reader landed back at the top of the chapter, and the next render persisted that to
+// progress.bin (issue #147). Four teardowns can fire during ordinary reading:
+//
+//   - fallbackToReleasedRebuild(): a Background-C build aborting mid-build on low heap, or
+//     finishing truncated / CSS-degraded — the common one, since the reader is turning pages
+//     through a live build the whole time it runs;
+//   - renderNormalPass(): loadPageFromSectionFile() returning null (deserialize OOM, bad seek);
+//   - both footnote-preview gather triggers, which drop the section to rebuild it previews-ON.
+//
+// None of them can be expected to remember the position individually, so keep the anchor live
+// instead: after this call navTarget names what is on screen, and any teardown lands back there.
+void EpubReaderActivity::anchorNavTargetToCurrentPage() {
+  if (!section) {
+    return;
+  }
+  navTarget = NavigationTarget::makePage(section->currentPage);
+  // Carrying the page count lets resolveInto() rescale proportionally when the rebuild
+  // repaginates rather than landing on a raw index — the previews-ON variant does exactly
+  // that (it bakes preview text into the layout). Only meaningful once the count is final:
+  // during a build pageCount is "pages written so far", and rescaling a partial count
+  // against the finished one would throw the position far past where the reader was.
+  if (!section->hasActiveBuild() && section->pageCount > 0) {
+    navTarget.cachedPageCount = section->pageCount;
+    navTarget.cachedSpineIdx = currentSpineIndex;
+  }
+}
+
 bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
   if (!epub || !section) {
     return false;
@@ -2402,6 +2431,9 @@ bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
     // first post-build render overwrites with the real count. Skipped when the back-cross branch
     // reset the section (position resolves when the previous spine loads).
     if (section) {
+      // Mid-build turns are exactly the case the anchor was losing: a build that then falls
+      // back to the released path restarts this chapter from navTarget.
+      anchorNavTargetToCurrentPage();
       pendingProgressSave.spineIndex = currentSpineIndex;
       pendingProgressSave.page = section->currentPage;
       pendingProgressSave.pageCount = 0;
@@ -2455,6 +2487,9 @@ bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
     }
   }
 
+  // Only the within-section branches above reach here with a section still loaded; the
+  // cross-spine branches set their own target and reset it, and this no-ops for them.
+  anchorNavTargetToCurrentPage();
   lastPageTurnTime = millis();
   forceLoadLargeImages = false;
   pageHasPlaceholders = false;
@@ -2550,6 +2585,10 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
             pageTurnStatsWindow.turns, preRenderedPage.pageIndex);
     logPageTurnWindowIfReady();
     section->currentPage = preRenderedPage.pageIndex;
+    // This fast path advances the page without going through stepPageState(), so it owes the
+    // anchor update too — otherwise every pre-rendered turn (the common case) leaves navTarget
+    // behind on the page the section was entered at.
+    anchorNavTargetToCurrentPage();
     preRenderedPage.ready = false;
     usePreRenderedBuffer = true;
     sessionPagesAdvanced++;
@@ -3447,7 +3486,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
   LOG_DBG("ERS", "resolveInto: navTarget.kind=%d pageCount=%d", (int)navTarget.kind, (int)section->pageCount);
   navTarget.resolveInto(*section, currentSpineIndex);
   LOG_DBG("ERS", "resolveInto result: currentPage=%d", (int)section->currentPage);
-  navTarget = NavigationTarget::makePage(section->currentPage);
+  anchorNavTargetToCurrentPage();
   forceLoadLargeImages = false;
   pageHasPlaceholders = false;
   return true;
@@ -4899,6 +4938,7 @@ void EpubReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION 
                                          : std::nullopt;
                                  if (resolvedPage) {
                                    section->currentPage = *resolvedPage;
+                                   anchorNavTargetToCurrentPage();
                                    forceLoadLargeImages = false;
                                    pageHasPlaceholders = false;
                                  } else {
@@ -4934,6 +4974,7 @@ void EpubReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION 
             if (newSpineIndex == currentSpineIndex) {
               if (const auto resolvedPage = section->getPageForTocIndex(nextTocIndex)) {
                 section->currentPage = *resolvedPage;
+                anchorNavTargetToCurrentPage();
                 forceLoadLargeImages = false;
                 pageHasPlaceholders = false;
               }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -205,6 +205,9 @@ class EpubReaderActivity final : public Activity {
   bool backgroundBorrowActive_ = false;
   std::unique_ptr<Section> section = nullptr;
   int currentSpineIndex = 0;
+  // Where to land when this section is (re)built. INVARIANT: while a section is loaded this
+  // names the page currently on screen, not the page the section was entered at — see
+  // anchorNavTargetToCurrentPage().
   NavigationTarget navTarget;
   int pagesUntilFullRefresh =
       1;  // initialized to freq in onEnter(); 1 triggers HALF on first render if somehow not reset
@@ -773,6 +776,9 @@ class EpubReaderActivity final : public Activity {
   bool getEffectiveInlineFootnotePreviews() const;
   int getEffectiveReaderFontId() const;
   float getEffectiveReaderLineCompression() const;
+  // Re-point navTarget at the page currently displayed. Must be called after every move of
+  // section->currentPage that stays inside the loaded section — see the definition for why.
+  void anchorNavTargetToCurrentPage();
   bool stepPageState(bool isForwardTurn);
   void pageTurn(bool isForwardTurn);
 #if ENABLE_BENCHMARKS


### PR DESCRIPTION
Closes #147 — reading jumps back to the start of the chapter.

## Cause

`navTarget` is the anchor a section (re)build resolves into, but it was only written when a section was **entered** and then left frozen for the whole chapter. Reaching a chapter by reading forward sets it to `makePage(0)`, so any mid-chapter `section.reset()` re-seeded `currentPage` from the entry page and dropped the reader at the top of the chapter. The next render then persisted that to `progress.bin`, so the loss survived a reboot.

Four teardowns can fire during ordinary reading, and none could reasonably be expected to remember the position on its own:

- `fallbackToReleasedRebuild()` — a Background-C build aborting mid-build on low heap, or finishing truncated / CSS-degraded. The likeliest one, since the reader turns pages through a live build the whole time it runs.
- `renderNormalPass()` — `loadPageFromSectionFile()` returning null.
- Both footnote-preview gather triggers, which drop the section to rebuild it with previews baked in.

The tell that this was an oversight rather than design: every *deliberate* reset already re-anchors first (`navTarget = makePage(section->currentPage)`). These four did not.

## Fix

`anchorNavTargetToCurrentPage()` establishes the invariant **"while a section is loaded, navTarget names the page on screen"**, called from every site that moves `currentPage` inside the loaded section: both `stepPageState()` branches, the pre-render fast path in `pageTurn()` (which bypasses `stepPageState` entirely and is the common turn), `buildSection()`'s resolve, the Background-C completion resolve, and the three in-spine TOC/chapter jumps.

With the anchor live, the four teardown sites need no changes — they all land back where the reader was.

It carries `cachedPageCount`/`cachedSpineIdx` so `resolveInto()` rescales proportionally when a rebuild repaginates (the previews-ON variant does exactly that). Only when the count is final: mid-build `pageCount` is "pages written so far", and rescaling a partial count against the finished one would throw the position far past where the reader was.

## Why it surfaced at 2.22

`backgroundBorrowActive_` — Background-B building the next chapter in the borrowed framebuffer — appears **zero times in tag 2.21**; it landed in ff6b379e. 971a3dfa then cut B's quiet period 4000 ms to 1500 ms. The defect is older; 2.22 made the heap conditions that trigger it routine.

## Testing

- `pio run -e default`: SUCCESS (RAM 17.2%, Flash 97.0%)
- Host suite 395/397 — the two `test_tables` goldens fail identically on unmodified `master` (verified by stashing)
- **Device (X4)**, two sessions with the book cache deleted to force builds: mid-build page turns land correctly — turned to page 2 during the spine-16 build, `Page summary: spine=16 page=2/53` after completion.

**Honest limitation:** no teardown fired in either device session, so this is verified regression-free but its payoff is *not* reproduced on device. Confirming which teardown the reporter actually hits still wants a log from them — `Background-C spine=N ...; falling back to released` is the one I would expect.