### PR TITLE
fix(parser): drop the explicit end tag of a repaired void element (#157)

### DIFF
--- a/lib/SaxParser/SaxParserYxml.cpp
+++ b/lib/SaxParser/SaxParserYxml.cpp
@@ -117,6 +117,20 @@ struct SaxParserImpl {
   // Opt-in (see SaxParser::init): repair is for HTML-flavored documents only.
   // Strict-XML documents (EPUB3 OPF) pair <meta>...</meta> and must not be touched.
   bool voidRepairEnabled = false;
+
+  // Explicit-end-tag suppression, armed whenever a self-close is synthesized.
+  //
+  // Self-closing <meta ...> into <meta ... /> is only half the job: an XHTML
+  // document may also carry the matching </meta>, which would then close an
+  // element that is no longer open and abort the parse. So after synthesizing,
+  // watch for that end tag and drop it if it comes.
+  //
+  // Buffered rather than decided byte-by-byte because the candidate can be
+  // split across feed() chunks, and because a non-match must be replayed to
+  // yxml intact — same shape as the entity pre-processor below.
+  char voidCloseName[kElemNameLen] = {0};  // element just self-closed; "" = not armed
+  char voidCloseBuf[kElemNameLen + 4];     // candidate "</name>" bytes seen so far
+  size_t voidCloseLen = 0;                 // 0 = armed but not yet buffering
 };
 
 // ---------------------------------------------------------------------------
@@ -329,12 +343,15 @@ bool SaxParser::feed(const uint8_t* buf, size_t len) {
   // PIs and DOCTYPE are left completely alone (identified by the byte right
   // after '<' and never tracked here), so this can't disturb them.
   //
-  // Caveat: a document that pairs a void element with a real end tag
-  // (<br>...</br>, valid but essentially never emitted by real tools) will
-  // have the opening tag self-closed here, turning the later </br> into a
-  // mismatched close — a parse error, not silent corruption. Given how rare
-  // that pairing is against how common bare <br>/<hr> is, this trade favours
-  // the common case.
+  // A document that pairs a void element with a real end tag (<meta ...></meta>)
+  // is handled too: synthesizing the self-close arms voidCloseName, and the
+  // matching end tag is dropped in feed() before yxml sees it.
+  //
+  // That pairing was once written off here as "essentially never emitted by real
+  // tools". It is not rare at all — XHTML 1.1 requires a void element to either
+  // self-close or be paired, so converters targeting it emit the paired form, and
+  // a FictionBook->XHTML book whose every content file began
+  // <meta ...></meta><link ...></link> failed to open on every single spine.
   // ---------------------------------------------------------------------------
   auto tagScanByte = [&](uint8_t c) -> bool {
     using TagScan = SaxParserImpl::TagScan;
@@ -382,6 +399,12 @@ bool SaxParser::feed(const uint8_t* buf, size_t len) {
       impl->tagScan = TagScan::kNone;
       if (impl->tagIsVoid && !impl->tagPrevSlash) {
         impl->truncFlags |= SaxParser::kVoidTagRepaired;
+        // Arm end-tag suppression: having just made this element self-closing, a
+        // matching </name> in the source would now close nothing. See the
+        // voidCloseName block in feed().
+        strncpy(impl->voidCloseName, impl->tagNameBuf, kElemNameLen - 1);
+        impl->voidCloseName[kElemNameLen - 1] = '\0';
+        impl->voidCloseLen = 0;
         return feedByte('/');  // synthesize self-close before the caller feeds the real '>'
       }
       return true;
@@ -394,6 +417,71 @@ bool SaxParser::feed(const uint8_t* buf, size_t len) {
     if (stopped_) break;
 
     const uint8_t c = buf[i];
+
+    // ---------------------------------------------------------------------------
+    // Explicit end tag after a synthesized self-close
+    //
+    // tagScanByte() rewrites <meta ...> into <meta ... />. If the document also
+    // supplies </meta> -- which XHTML 1.1 output does routinely, since there a void
+    // element must either self-close or be paired -- that end tag now closes an
+    // element that is no longer open, and yxml aborts the whole document. Observed
+    // on a FictionBook->XHTML conversion whose every content file opens with
+    // <meta ...></meta><link ...></link>, making the book unopenable.
+    //
+    // So drop the end tag that belongs to a self-close we synthesized. Only that
+    // one: the name must match, and anything else disarms. A partial candidate is
+    // replayed byte-for-byte, so a non-match costs nothing.
+    // ---------------------------------------------------------------------------
+    if (impl->voidCloseName[0] != '\0') {
+      if (impl->voidCloseLen == 0) {
+        // Armed, nothing buffered yet. Whitespace between the two tags is
+        // insignificant and passes through; anything else that is not the start of
+        // a tag means the end tag is not coming.
+        if (c == '<') {
+          impl->voidCloseBuf[impl->voidCloseLen++] = '<';
+          continue;
+        }
+        if (c != ' ' && c != '\t' && c != '\r' && c != '\n') {
+          impl->voidCloseName[0] = '\0';
+        }
+      } else {
+        const size_t pos = impl->voidCloseLen;
+        const size_t nameLen = strlen(impl->voidCloseName);
+        char expect;
+        if (pos == 1) {
+          expect = '/';
+        } else if (pos - 2 < nameLen) {
+          expect = impl->voidCloseName[pos - 2];
+        } else {
+          expect = '>';
+        }
+        const char cl = (c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : static_cast<char>(c);
+        const char el = (expect >= 'A' && expect <= 'Z') ? static_cast<char>(expect + 32) : expect;
+        if (cl == el) {
+          if (expect == '>') {
+            // Complete match — drop the buffered "</name>" entirely.
+            impl->voidCloseLen = 0;
+            impl->voidCloseName[0] = '\0';
+            continue;
+          }
+          if (impl->voidCloseLen < sizeof(impl->voidCloseBuf)) {
+            impl->voidCloseBuf[impl->voidCloseLen++] = static_cast<char>(c);
+          }
+          continue;
+        }
+        // Not our end tag. Replay what was withheld through the normal path (the
+        // scanner must see these bytes too — the candidate may itself have been the
+        // start of a tag), then fall through and process c as usual.
+        for (size_t j = 0; j < impl->voidCloseLen && !stopped_; ++j) {
+          const uint8_t b = static_cast<uint8_t>(impl->voidCloseBuf[j]);
+          if (!tagScanByte(b)) return false;
+          if (!feedByte(b)) return false;
+        }
+        impl->voidCloseLen = 0;
+        impl->voidCloseName[0] = '\0';
+        if (stopped_) break;
+      }
+    }
 
     if (!tagScanByte(c)) return false;
     if (stopped_) break;

--- a/test/sax_parser/SaxParserTest.cpp
+++ b/test/sax_parser/SaxParserTest.cpp
@@ -459,3 +459,211 @@ TEST(SaxParser, PairedMetaParsesWhenRepairDisabled) {
   EXPECT_TRUE(sawText);
   EXPECT_FALSE(p.truncationFlags() & SaxParser::kVoidTagRepaired);
 }
+
+// ---------------------------------------------------------------------------
+// Void elements that the document ALSO closes explicitly
+//
+// XHTML 1.1 requires a void element to either self-close or be paired, so
+// converters targeting it emit "<meta ...></meta>". Repairing the start tag into
+// "<meta ... />" leaves that end tag closing nothing, which aborts the parse --
+// issue #157, where every content file of a FictionBook->XHTML book began
+// <meta ...></meta><link ...></link> and the book would not open on any spine.
+// ---------------------------------------------------------------------------
+
+TEST(SaxParser, PairedVoidElementEndTagIsDropped) {
+  const char* xml = "<html><head><meta charset=\"UTF-8\"></meta><title>T</title></head></html>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml);
+  ASSERT_TRUE(p.feed(bytes, strlen(xml)));
+  ASSERT_TRUE(p.finalize());
+
+  // Exactly one start/end pair for meta -- the synthesized one; the source's own
+  // </meta> must not surface as a second end event.
+  int metaStarts = 0;
+  int metaEnds = 0;
+  for (const auto& e : c.events) {
+    if (e.name != "meta") continue;
+    if (e.type == Event::Type::Start) ++metaStarts;
+    if (e.type == Event::Type::End) ++metaEnds;
+  }
+  EXPECT_EQ(metaStarts, 1);
+  EXPECT_EQ(metaEnds, 1);
+}
+
+// The head shape from issue_157.epub, reduced: paired <meta> and <link>, both on
+// one line, with a real element between and after.
+TEST(SaxParser, Issue157HeadWithPairedMetaAndLinkParses) {
+  const char* xml =
+      "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head>"
+      "<meta http-equiv=\"content-type\" content=\"text/xhtml; charset=UTF-8\"></meta>"
+      "<title>Chapter</title>"
+      "<link rel=\"stylesheet\" type=\"text/css\" href=\"style.css\"></link>"
+      "<link rel=\"stylesheet\" type=\"text/css\" href=\"unicode_fonts.css\"></link>"
+      "</head><body><p>Body text</p></body></html>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml);
+  ASSERT_TRUE(p.feed(bytes, strlen(xml)));
+  ASSERT_TRUE(p.finalize());
+
+  // The body must survive: before the fix the parse died in <head> and no
+  // content ever reached the renderer.
+  bool sawBodyText = false;
+  for (const auto& e : c.events) {
+    if (e.text == "Body text") sawBodyText = true;
+  }
+  EXPECT_TRUE(sawBodyText);
+}
+
+TEST(SaxParser, PairedVoidEndTagToleratesWhitespaceBetween) {
+  const char* xml = "<head><meta charset=\"UTF-8\">\n  </meta><title>T</title></head>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml);
+  ASSERT_TRUE(p.feed(bytes, strlen(xml)));
+  ASSERT_TRUE(p.finalize());
+
+  int metaEnds = 0;
+  for (const auto& e : c.events) {
+    if (e.name == "meta" && e.type == Event::Type::End) ++metaEnds;
+  }
+  EXPECT_EQ(metaEnds, 1);
+}
+
+// Suppression must be exact: a DIFFERENT tag following a self-close is replayed
+// intact, not swallowed. This is the regression that a naive "skip the next end
+// tag" implementation would introduce.
+TEST(SaxParser, NonMatchingTagAfterSelfCloseIsReplayed) {
+  const char* xml = "<div><br><span>kept</span></div>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml);
+  ASSERT_TRUE(p.feed(bytes, strlen(xml)));
+  ASSERT_TRUE(p.finalize());
+
+  bool sawSpanStart = false;
+  bool sawSpanEnd = false;
+  bool sawText = false;
+  for (const auto& e : c.events) {
+    if (e.name == "span" && e.type == Event::Type::Start) sawSpanStart = true;
+    if (e.name == "span" && e.type == Event::Type::End) sawSpanEnd = true;
+    if (e.text == "kept") sawText = true;
+  }
+  EXPECT_TRUE(sawSpanStart);
+  EXPECT_TRUE(sawSpanEnd);
+  EXPECT_TRUE(sawText);
+}
+
+// Two void elements of the same name in a row: the second start tag must not be
+// mistaken for the first's end tag.
+TEST(SaxParser, ConsecutiveSameNameVoidElementsBothSurvive) {
+  const char* xml = "<head><meta name=\"a\"><meta name=\"b\"></head>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml);
+  ASSERT_TRUE(p.feed(bytes, strlen(xml)));
+  ASSERT_TRUE(p.finalize());
+
+  int metaStarts = 0;
+  for (const auto& e : c.events) {
+    if (e.name == "meta" && e.type == Event::Type::Start) ++metaStarts;
+  }
+  EXPECT_EQ(metaStarts, 2);
+}
+
+// The candidate end tag split across feed() chunks — the reason it is buffered in
+// the impl rather than decided byte-by-byte.
+TEST(SaxParser, PairedVoidEndTagSplitAcrossFeeds) {
+  const std::string xml = "<head><meta charset=\"UTF-8\"></meta><title>T</title></head>";
+  const size_t split = xml.find("</meta>") + 3;  // mid end-tag
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml.data());
+  ASSERT_TRUE(p.feed(bytes, split));
+  ASSERT_TRUE(p.feed(bytes + split, xml.size() - split));
+  ASSERT_TRUE(p.finalize());
+
+  int metaEnds = 0;
+  bool sawTitle = false;
+  for (const auto& e : c.events) {
+    if (e.name == "meta" && e.type == Event::Type::End) ++metaEnds;
+    if (e.name == "title" && e.type == Event::Type::Start) sawTitle = true;
+  }
+  EXPECT_EQ(metaEnds, 1);
+  EXPECT_TRUE(sawTitle);
+}
+
+// Strict-XML mode (the EPUB3 OPF path) is unchanged: no repair, no suppression.
+TEST(SaxParser, StrictModeLeavesPairedMetaAlone) {
+  const char* xml = "<package><metadata><meta property=\"x\">v</meta></metadata></package>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(
+      p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/false));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml);
+  ASSERT_TRUE(p.feed(bytes, strlen(xml)));
+  ASSERT_TRUE(p.finalize());
+
+  bool sawValue = false;
+  for (const auto& e : c.events) {
+    if (e.text == "v") sawValue = true;
+  }
+  EXPECT_TRUE(sawValue);
+  EXPECT_FALSE(p.truncationFlags() & SaxParser::kVoidTagRepaired);
+}
+
+// Not a meta/link special case: EVERY void element breaks the same way when the
+// document pairs it. In issue_157.epub the counts across 69 content files were
+// </br> 640, </link> 138, </img> 87, </meta> 69 -- so <br></br>, once written off
+// in this file as "essentially never emitted by real tools", was the single most
+// common form, and </img> meant even a repaired <head> would have died in <body>.
+TEST(SaxParser, PairedBrAndImgInBodyAreDropped) {
+  const char* xml =
+      "<body><p>One<br></br>Two</p>"
+      "<p><img src=\"i.png\" alt=\"a\"></img>after</p></body>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml);
+  ASSERT_TRUE(p.feed(bytes, strlen(xml)));
+  ASSERT_TRUE(p.finalize());
+
+  int brStarts = 0, brEnds = 0, imgStarts = 0, imgEnds = 0;
+  bool sawTwo = false, sawAfter = false;
+  for (const auto& e : c.events) {
+    if (e.name == "br") (e.type == Event::Type::Start ? brStarts : brEnds)++;
+    if (e.name == "img") (e.type == Event::Type::Start ? imgStarts : imgEnds)++;
+    if (e.text == "Two") sawTwo = true;
+    if (e.text == "after") sawAfter = true;
+  }
+  EXPECT_EQ(brStarts, 1);
+  EXPECT_EQ(brEnds, 1);
+  EXPECT_EQ(imgStarts, 1);
+  EXPECT_EQ(imgEnds, 1);
+  // Content after each paired void element must survive.
+  EXPECT_TRUE(sawTwo);
+  EXPECT_TRUE(sawAfter);
+}


### PR DESCRIPTION
Fixes issue #157 

Every spine of issue_157.epub failed with "yxml parse error" at line 2, so the book would not open at all -- 69 of 69 content files.

Cause: the void-element repair rewrites <meta ...> into <meta ... />, but the document also supplies </meta>. That end tag then closes an element which is no longer open, and yxml aborts the document. Line 2 of every content file is:
```
  <meta http-equiv="content-type" content="..."></meta>
  <link rel="stylesheet" type="text/css" href="style.css"></link>
```
This is not malformed input. XHTML 1.1 -- which this book declares -- requires a void element to either self-close or be paired, so converters targeting it emit the paired form. This one is a FictionBook->XHTML conversion.

It is also not a <meta>/<link> special case. Counting paired end tags across the 69 content files:

  ``</br>``    640
 ``</link>``  138
  ``</img>``    87
  ``</meta>``   69

So ``<br></br>`` -- which the comment in this file dismissed as "essentially never emitted by real tools" -- is the most common form of all, and ``</img>`` means even a repaired <head> would still have died in <body>. That comment is corrected.

Fix: synthesizing a self-close now also arms suppression of the matching end tag. The candidate is buffered (it can straddle a feed() chunk) and dropped only on an exact name match; anything else is replayed to yxml byte-for-byte, so a non-match costs nothing. Same shape as the entity pre-processor above it. Whitespace between the two tags is allowed through as insignificant.

Strict-XML mode (the EPUB3 OPF path, htmlVoidTagRepair=false) is untouched: no repair, so nothing to suppress.