### PR TITLE
fix(reader): return Background-B's borrowed buffer before opening an overlay

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -109,9 +109,28 @@ void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen)
   // upgraded to HALF on a cold panel), so the mode asked for is not always what ran.
   const unsigned long refreshStart = millis();
   einkDisplay.displayBuffer(convertRefreshMode(mode), turnOffScreen);
-  LOG_DBG("DISP", "displayBuffer mode=%s took %lu ms",
-          mode == RefreshMode::FAST_REFRESH ? "FAST" : (mode == RefreshMode::HALF_REFRESH ? "HALF" : "FULL"),
-          millis() - refreshStart);
+  const unsigned long refreshMs = millis() - refreshStart;
+  const char* const modeName =
+      mode == RefreshMode::FAST_REFRESH ? "FAST" : (mode == RefreshMode::HALF_REFRESH ? "HALF" : "FULL");
+
+  // The X4 differential keeps its previous-frame baseline in the host-managed secondary buffer,
+  // so a FAST requested without one is promoted to HALF inside the driver
+  // (FreeInkDisplay::resolveRefreshMode) — roughly 500 ms becoming 1700 ms. That used to be
+  // invisible: the line read "mode=FAST took 1755 ms", which reads as a stuck panel rather than
+  // a promotion, and cost a whole debugging session when Background-B's borrow of the secondary
+  // buffer degraded every refresh behind the reader menu.
+  //
+  // The two flags are reported rather than the resolved mode on purpose: resolveRefreshMode() is
+  // internal to the driver, and re-deriving its verdict here would be a second copy of the rule
+  // that can drift from the first. These are the inputs it decides on, which is enough to explain
+  // the duration without asserting what the driver did.
+  if (mode == RefreshMode::FAST_REFRESH && gpio.deviceIsX4() && !einkDisplay.hasSecondaryBuffer() &&
+      !einkDisplay.singleBufferFastDiff()) {
+    LOG_DBG("DISP", "displayBuffer mode=%s took %lu ms (no diff baseline: secondary=0 fastDiff=0 -> driver runs HALF)",
+            modeName, refreshMs);
+  } else {
+    LOG_DBG("DISP", "displayBuffer mode=%s took %lu ms", modeName, refreshMs);
+  }
 }
 
 void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen) {

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -76,7 +76,13 @@ class Activity {
 
   // Start a new activity without destroying the current one
   // Note: requestUpdate() will be invoked automatically once resultHandler finishes
-  void startActivityForResult(std::unique_ptr<Activity>&& activity, ActivityResultHandler resultHandler);
+  //
+  // Virtual because a suspended activity keeps whatever it was holding: the stack keeps this
+  // object alive but stops calling loop(), so any background work it owns freezes in place
+  // without releasing its resources. An activity that lends out a shared resource must hand it
+  // back here — see EpubReaderActivity, whose look-ahead build borrows the display's secondary
+  // framebuffer and silently degraded every refresh the child activity drew.
+  virtual void startActivityForResult(std::unique_ptr<Activity>&& activity, ActivityResultHandler resultHandler);
 
   // Set the result to be passed back to the previous activity when this activity finishes
   void setResult(ActivityResult&& result);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1002,6 +1002,31 @@ Section::BuildParams EpubReaderActivity::makeSectionBuildParams() const {
   return p;
 }
 
+void EpubReaderActivity::startActivityForResult(std::unique_ptr<Activity>&& activity,
+                                                ActivityResultHandler resultHandler) {
+  // See the header: B's borrow must not outlive the reader being the top activity, or every
+  // redraw the child makes runs a HALF waveform. No-op unless B currently holds the block.
+  //
+  // endBackgroundBorrow() rather than resetBackgroundBuild(): the former discards only a build
+  // that is still live, and keeps a COMPLETED one for buildSection() to adopt. Resetting would
+  // throw that finished section away and make the next page turn rebuild it — paying for the
+  // refresh fix with a page-turn stall.
+  if (backgroundBorrowActive_) {
+    LOG_INF("ERS", "Overlay '%s' opening; returning Background-B's borrowed buffer so its refreshes stay fast",
+            activity ? activity->getName().c_str() : "<null>");
+  }
+  // Not a preemption. backgroundPreemptCount_ measures one specific thing — a build that keeps
+  // losing the race against page turns — and BG_BUILD_MAX_PREEMPTIONS (2) makes B abandon the
+  // spine to the foreground once it is hit. An overlay opening says nothing about whether the
+  // parse fits between two turns, so letting it burn that budget would mean two visits to the
+  // reader menu permanently demote the next section to a blocking Background-C build with its
+  // popup. Restore the count so B resumes with exactly the budget it had.
+  const uint8_t preemptionsBeforeOverlay = backgroundPreemptCount_;
+  endBackgroundBorrow();
+  backgroundPreemptCount_ = preemptionsBeforeOverlay;
+  Activity::startActivityForResult(std::move(activity), std::move(resultHandler));
+}
+
 void EpubReaderActivity::resetBackgroundBuild() {
   endBackgroundBorrow();       // returns the lent buffer (and aborts the build) if B held it
   backgroundSection_.reset();  // ~Section aborts a partial build and deletes its partial file

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -811,6 +811,28 @@ class EpubReaderActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&& lock) override;
+
+  // Hands Background-B's borrow back before a child activity (the reader menu and everything
+  // reachable from it) is pushed on top.
+  //
+  // While a child is on top the stack keeps this object alive but stops calling loop(), so B
+  // makes no progress — yet it still holds the display's secondary framebuffer as its build
+  // arena. With no differential baseline the driver promotes every FAST refresh to HALF
+  // (FreeInkDisplay::resolveRefreshMode), so each of the child's redraws costs ~1700 ms instead
+  // of ~500. Measured X4 2026-08-19: four consecutive menu redraws at 1755 ms each, back to
+  // 476 ms on the first refresh after the borrow was returned.
+  //
+  // Nothing is lost. This is the same endBackgroundBorrow() the first render after the overlay
+  // closes would call anyway (via recoverSecondaryBufferIfNeeded), only earlier — and it was
+  // frozen for the whole overlay regardless. A build still in flight is discarded and re-probed
+  // exactly as it would have been; a COMPLETED one survives for buildSection() to adopt, which
+  // is why this is not resetBackgroundBuild().
+  //
+  // Background-C is deliberately left alone: it builds the section the reader is waiting on, the
+  // buffer is released (not borrowed) to give that build headroom, and reclaiming it here would
+  // starve a build the user is actively waiting for. That case still degrades refreshes, and the
+  // DISP log now says so out loud.
+  void startActivityForResult(std::unique_ptr<Activity>&& activity, ActivityResultHandler resultHandler) override;
   bool isReaderActivity() const override { return true; }
   bool preventAutoSleep() override { return section && section->hasActiveBuild(); }
   // Hold full speed while a section build is in flight. A build only ever runs during reader


### PR DESCRIPTION
Every refresh drawn by the reader menu ran a HALF waveform. Measured on X4: **four consecutive menu redraws at 1755 ms each**, where a FAST costs ~526.

## Diagnosis

Background-B borrows the display's secondary framebuffer as its build arena. On X4 the differential refresh keeps its previous-frame baseline in exactly that buffer, so [FreeInkDisplay.cpp:355](https://github.com/crosspoint-reader/crosspoint-reader/blob/master/freeink-sdk/libs/display/FreeInkDisplay/src/FreeInkDisplay.cpp) silently promotes every FAST to HALF while it is away:

```cpp
if (mode == FAST_REFRESH && _panelSel == PanelSel::X4 && !frameBufferActive && !_singleBufferFastDiff)
  return HALF_REFRESH;
```

Meanwhile a child activity on the stack keeps the reader alive but stops calling `loop()` — so B makes **no progress and still holds the block**. Pure loss on both sides: the build is frozen *and* the user pays an extra second of refresh per keypress.

