### PR TITLE
fix(power): keep CPU at full speed for long presses and WiFi

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -337,6 +337,8 @@ bool HalGPIO::wasReleased(uint8_t buttonIndex) const { return (snapReleased_ & (
 
 bool HalGPIO::wasAnyReleased() const { return snapReleased_ != 0; }
 
+bool HalGPIO::isAnyPressed() const { return snapState_ != 0; }
+
 bool HalGPIO::isDebouncePending() const { return inputMgr.isDebouncePending(); }
 
 unsigned long HalGPIO::getHeldTime() const { return samplerRunning_ ? heldTimeSnapshot_ : inputMgr.getHeldTime(); }

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -157,6 +157,10 @@ class HalGPIO {
   bool wasAnyPressed() const;
   bool wasReleased(uint8_t buttonIndex) const;
   bool wasAnyReleased() const;
+  // True while ANY button is currently held down. Distinct from wasAnyPressed(), which is
+  // edge-triggered and therefore false for every loop iteration after the initial press —
+  // a held button looks exactly like an idle device to an edge-only check.
+  bool isAnyPressed() const;
   // True while a raw button-state change is still inside the debounce window.
   // The idle loop polls fast while this is set so the confirming sample lands
   // ~10 ms after the first; at the light-sleep cadence a short tap can

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -68,6 +68,35 @@ void HalPowerManager::setPowerSaving(bool enabled) {
   // Otherwise, no change needed
 }
 
+void HalPowerManager::ensureFullSpeedForRadio() {
+  if (normalFreq <= 0) {
+    return;  // begin() not called yet — nothing to restore to
+  }
+  // Clear BOTH downclock owners before touching the frequency. The idle governor
+  // (isLowPower) and the waveform hook (waveformLowPower_) track their drops separately, and
+  // whichever one is live would otherwise restore or re-drop the clock behind the radio's back.
+  xSemaphoreTake(modeMutex, portMAX_DELAY);
+  const bool wasIdleLow = isLowPower;
+  const bool wasWaveformLow = waveformLowPower_;
+  isLowPower = false;
+  waveformLowPower_ = false;
+  xSemaphoreGive(modeMutex);
+
+  const int current = getCpuFrequencyMhz();
+  if (current >= normalFreq) {
+    return;  // already at full speed; nothing to do beyond the flag reconciliation above
+  }
+  if (setCpuFrequencyMhz(normalFreq)) {
+    LOG_INF("PWR", "CPU %d -> %d MHz for radio bring-up (idleLow=%d waveformLow=%d)", current, normalFreq,
+            wasIdleLow ? 1 : 0, wasWaveformLow ? 1 : 0);
+  } else {
+    // Worth an error rather than a debug line: WiFi association from a 10 MHz clock does not
+    // fail cleanly, it hangs, and this is the only place that would have seen it coming.
+    LOG_ERR("PWR", "Failed to restore %d MHz before radio bring-up (still %d MHz) — WiFi may hang", normalFreq,
+            current);
+  }
+}
+
 void HalPowerManager::enterWaveformWait() {
   if (normalFreq <= 0) {
     return;  // begin() not called yet — nothing to restore to

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -81,6 +81,22 @@ class HalPowerManager {
   // Control CPU frequency for power saving
   void setPowerSaving(bool enabled);
 
+  // Force the CPU back to its normal frequency before bringing the radio up.
+  //
+  // CALL THIS IMMEDIATELY BEFORE WiFi.mode()/WiFi.begin()/softAP(). WiFi does not work below
+  // 80 MHz on this SoC — the same fact enterWaveformWait() relies on when it refuses to
+  // downclock while WiFi is up — and LOW_POWER_FREQ is 10 MHz. Bringing the radio up from
+  // there wedges PHY init.
+  //
+  // setPowerSaving(false) is NOT a substitute. It only acts when its own isLowPower flag is
+  // set, and it forces enabled=false only once WiFi.getMode() is already non-null — i.e. it
+  // protects a radio that is already up, and nothing raised the clock on the way in. It is also
+  // blind to a clock dropped by enterWaveformWait(), which tracks its own waveformLowPower_
+  // flag; that combination leaves the CPU at 10 MHz with isLowPower false, so every later
+  // setPowerSaving(false) is a silent no-op. This clears both flags and restores the frequency
+  // unconditionally.
+  void ensureFullSpeedForRadio();
+
   // Waveform-wait power hooks, installed on the display driver by HalDisplay:
   // drop the CPU clock while the render task sleeps on the e-ink BUSY-ISR
   // semaphore (nothing can run during the waveform — background work gates on

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -3,6 +3,7 @@
 #include <DNSServer.h>
 #include <ESPmDNS.h>
 #include <GfxRenderer.h>
+#include <HalPowerManager.h>
 #include <I18n.h>
 #include <Memory.h>
 #include <WiFi.h>
@@ -128,6 +129,7 @@ void CrossPointWebServerActivity::onNetworkModeSelected(const NetworkMode mode) 
   if (mode == NetworkMode::JOIN_NETWORK) {
     // STA mode - launch WiFi selection
     LOG_DBG("WEBACT", "Turning on WiFi (STA mode)...");
+    powerManager.ensureFullSpeedForRadio();  // WiFi needs >=80 MHz; see HalPowerManager
     WiFi.mode(WIFI_STA);
 
     state = WebServerActivityState::WIFI_SELECTION;
@@ -195,6 +197,7 @@ void CrossPointWebServerActivity::startAccessPoint() {
   LOG_DBG("WEBACT", "Free heap before AP start: %d bytes", ESP.getFreeHeap());
 
   // Configure and start the AP
+  powerManager.ensureFullSpeedForRadio();  // WiFi needs >=80 MHz; see HalPowerManager
   WiFi.mode(WIFI_AP);
   delay(100);
 

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -3,6 +3,7 @@
 #include <GfxRenderer.h>
 #include <HTTPClient.h>
 #include <HalClock.h>
+#include <HalPowerManager.h>
 #include <I18n.h>
 #include <Logging.h>
 #include <NetworkClient.h>
@@ -357,6 +358,14 @@ void WifiSelectionActivity::attemptConnection() {
 }
 
 void WifiSelectionActivity::prepareForConnect() {
+  // Before anything touches the radio. WiFi does not work below 80 MHz on this SoC and the idle
+  // governor parks the CPU at 10 MHz, so association from there hangs rather than failing — the
+  // observed symptom was a dead device after a long-press into KOReader sync, whose hold crossed
+  // the idle threshold before the action fired. main.cpp now keeps the clock up while a button is
+  // held, which removes that particular trigger; this stays as the guarantee at the point that
+  // actually depends on it, for every other way the clock could be low when we get here.
+  powerManager.ensureFullSpeedForRadio();
+
   WiFi.persistent(false);  // Credentials are managed by WifiCredentialStore; suppress SDK NVS auto-connect
 
   // Only switch mode if we're not already STA — the mode setter touches the netif and

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1223,7 +1223,14 @@ void loop() {
 
   // Check for any user activity (button press or release) or active background work
   static unsigned long lastActivityTime = millis();
-  if (gpio.wasAnyPressed() || gpio.wasAnyReleased() || halTiltSensor.hadActivity() ||
+  // isAnyPressed() alongside the edge checks: a button that is DOWN produces no press/release
+  // edges, so an edge-only test reads a held finger as an idle device. With IDLE_DOWNCLOCK_MS at
+  // 500 ms and ButtonEventManager's long-press at 1000 ms, every long press used to cross the
+  // idle threshold mid-hold — the CPU dropped to 10 MHz and the action the long press triggered
+  // then ran there. Harmless for most actions, fatal for one: a long press that brings WiFi up
+  // (reader -> KOReader sync) reached WiFi.begin() at 10 MHz and wedged. Holding a button is
+  // user activity by any reasonable reading, so count it as such.
+  if (gpio.wasAnyPressed() || gpio.wasAnyReleased() || gpio.isAnyPressed() || halTiltSensor.hadActivity() ||
       activityManager.preventAutoSleep()) {
     lastActivityTime = millis();         // Reset inactivity timer
     powerManager.setPowerSaving(false);  // Restore normal CPU frequency on user activity


### PR DESCRIPTION
## Problem

A long press that opens KOReader sync from the reader hung the device hard — unresponsive, reset required, no panic.

`gpio.wasAnyPressed()` / `wasAnyReleased()` are **edge**-triggered, so a button that is merely *held down* emits nothing and looks exactly like an idle device. `IDLE_DOWNCLOCK_MS` is 500 ms and `ButtonEventManager`'s long press is 1000 ms, so **every long press crosses the idle threshold while the finger is still down**. The CPU drops to `LOW_POWER_FREQ` (10 MHz) and the action the long press triggers then runs there.

Harmless for most actions. Fatal for one: WiFi does not work below 80 MHz on this SoC — the fact `enterWaveformWait()` already relies on when it refuses to downclock while WiFi is up — so `WiFi.begin()` at 10 MHz wedges PHY init rather than failing.

Two device logs of the same firmware, same AP, differ in exactly one line:

| | |
|---|---|
| **Works** (menu → Push progress) | `[17838] Going to low-power mode` → `[18346] Restoring normal CPU frequency` → … → `WiFi.begin` → associated |
| **Hangs** (long-press Confirm) | `[21701] Going to low-power mode` → *no "Restoring" line at all* → … → `Attempting to auto-connect` → silence |

It also explains why only the long-press entry hangs: the short-press menu path never sits idle 500 ms between the press and the transition.

## Fix

1. **`HalGPIO::isAnyPressed()`** (level, not edge) joins main.cpp's activity check, so a held button keeps the clock up. Root-cause fix; also stops every long-press action from executing at 10 MHz.
2. **`HalPowerManager::ensureFullSpeedForRadio()`** guards the point that actually depends on it — before `WiFi.mode()` in `WifiSelectionActivity::prepareForConnect()` and both `CrossPointWebServerActivity` sites (STA + AP).

`setPowerSaving(false)` is **not** a substitute for (2), which is why nothing caught this: it acts only when its own `isLowPower` flag is set, forces `enabled=false` only once `WiFi.getMode()` is already non-null (protecting a radio that is already up, never the way in), and is blind to a clock dropped by `enterWaveformWait()`, which tracks a separate `waveformLowPower_`. That combination parks the CPU at 10 MHz with `isLowPower` false, making every later `setPowerSaving(false)` a silent no-op — no log line, no clue.

## Validation

**Device-validated on X4.** The gesture that hung now completes end to end:

```
[20634] Standalone sync handoff          <- long press fires
[20785] WiFi.begin -> PYSY
[23254] EVT associated at 2518 ms
[24769] EVT got_ip at 4033 ms
[29810] GET .../syncs/progress -> 200
[31542] Smart sync: the two sides agree, nothing to do
[34018] Silent restart (target=reader)
[  417] Applying pending sync session outcome=2 -> spine=5 page=4
```

`ensureFullSpeedForRadio()` emitted no `CPU 10 -> 160 MHz` line, i.e. the clock was already at full speed when the radio came up — the condition that was missing before. It logs the transition when it does have to act, so a regression is visible in any capture.

`pio run -e default` and `-e gh_release` both clean, no new warnings. Host tests 467/468 — the one failure (`test_font_normalization` golden, `epub_pipeline`) is pre-existing and in a harness that compiles none of these files.

## Note on power

Keeping the clock up while a button is held costs a little idle power during holds. That seems clearly right: holding a button is user activity, and the alternative is that every long-press action runs 16× slower.