### PR TITLE
fix(tls): set the clock before TLS, tolerate cert dates without one

### DIFF
--- a/lib/KOReaderSync/KOReaderSyncClient.cpp
+++ b/lib/KOReaderSync/KOReaderSyncClient.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <CrossPointRoots.h>
+#include <HalClock.h>
 #include <Logging.h>
 #include <SecureHttpClient.h>
 #include <WiFi.h>
@@ -263,6 +264,13 @@ esp_err_t performKoRequest(const char* method, const std::string& url, const cha
   // insecure fallback) and passes http through a plain WiFiClient. Tiny JSON
   // payloads, so the small-buffer intent of the old 1 KB config is naturally met.
   http->setCACert(CROSSPOINT_ROOTS_PEM);
+  // Last-resort clock guard. The activities are expected to have run
+  // HalClock::ensureUsableForTls() once WiFi came up (they have SETTINGS and therefore the
+  // configured NTP server; this library does not). Asking here as well means a caller that
+  // forgets does not get the old failure mode — a trust store that refuses to load, reported as
+  // a bare "connect failed" with no verification error behind it. Chain, signature and hostname
+  // stay fully enforced either way; only the validity window is waived.
+  http->setAllowCertificateDateErrors(!HalClock::isPlausibleForTls());
   http->setTimeout(5000);
   http->setUserAgent("WitchReader-ESP32-" CROSSPOINT_VERSION);
   http->clearHeaders();

--- a/lib/SecureNet/include/SecureClient.h
+++ b/lib/SecureNet/include/SecureClient.h
@@ -45,6 +45,21 @@ class SecureClient : public Client {
   // When true (default) and a CA is set, a verification-class handshake failure
   // is retried once with verification disabled (logged). OTA sets this false.
   void setAllowInsecureFallback(bool allow) { _allowInsecureFallback = allow; }
+  // Keep CA-chain, signature, and hostname verification enabled, but tolerate certificate
+  // notBefore/notAfter errors because the device has no trustworthy wall clock. Unlike the
+  // insecure fallback this waives exactly one property: every non-date verification failure
+  // stays fatal. Off by default — callers turn it on only after HalClock::ensureUsableForTls()
+  // has failed, i.e. when full date validation is genuinely unobtainable.
+  //
+  // This has to act in TWO places, which is easy to get wrong:
+  //   1. loading the trust store. wolfSSL_CTX_load_verify_buffer() date-checks the ROOTS as it
+  //      parses them, so on a 1970 clock every curated root's notBefore is "in the future" and
+  //      the store fails to load outright — before any handshake, so no verify callback can
+  //      rescue it and no verification error is even produced to classify.
+  //   2. the handshake itself, for the peer chain, via a verify callback.
+  // Approach adapted from the Kapfilm/witchhunt-reader fork, which had (2); (1) is what makes
+  // it actually work on a cold-booted RTC-less board.
+  void setAllowCertificateDateErrors(bool allow) { _allowCertificateDateErrors = allow; }
   // True if the last successful connect() fell back to an unverified handshake.
   bool lastConnectWasInsecure() const { return _lastWasInsecure; }
 
@@ -82,6 +97,7 @@ class SecureClient : public Client {
   const char* _rootCA = nullptr;
   bool _insecure = false;
   bool _allowInsecureFallback = true;
+  bool _allowCertificateDateErrors = false;
   bool _lastWasInsecure = false;
   int _lastConnectErr = 0;                 // wolfSSL_get_error() from the last failed handshake
   size_t _handshakeMinFree = SIZE_MAX;     // heap trough during the last handshake

--- a/lib/SecureNet/include/SecureHttpClient.h
+++ b/lib/SecureNet/include/SecureHttpClient.h
@@ -44,6 +44,8 @@ class SecureHttpClient {
   // --- configuration (before request) ---
   void setCACert(const char* rootCA) { _rootCA = rootCA; }
   void setAllowInsecureFallback(bool allow) { _allowInsecureFallback = allow; }
+  // See SecureClient::setAllowCertificateDateErrors().
+  void setAllowCertificateDateErrors(bool allow) { _allowCertificateDateErrors = allow; }
   void setTimeout(uint32_t ms) { _timeoutMs = ms; }
   void setUserAgent(const std::string& ua) { _userAgent = ua; }
   void setBasicAuth(const std::string& user, const std::string& pass) {
@@ -146,6 +148,7 @@ class SecureHttpClient {
   // config
   const char* _rootCA = nullptr;
   bool _allowInsecureFallback = true;
+  bool _allowCertificateDateErrors = false;
   uint32_t _timeoutMs = 15000;
   std::string _userAgent = "CrossPoint-ESP32";
   std::string _user;

--- a/lib/SecureNet/src/SecureClient.cpp
+++ b/lib/SecureNet/src/SecureClient.cpp
@@ -9,6 +9,8 @@
 #include <wolfssl/error-ssl.h>  // VERIFY_CERT_ERROR, DOMAIN_NAME_MISMATCH (SSL-layer codes)
 #include <wolfssl/ssl.h>
 
+#include <ctime>  // time() for the clock reported alongside a cert-date load failure
+
 // The Arduino-wolfSSL library's logging.c references this hook, normally defined
 // in the library's wolfssl.h sketch glue (not compiled in a PlatformIO lib build),
 // so we provide it. Signature must match wolfcrypt/logging.h exactly (int return).
@@ -76,6 +78,19 @@ bool isVerificationError(int err) {
       return false;
   }
 }
+
+// Installed as wolfSSL's verify callback only when the caller could not obtain a trustworthy
+// clock. wolfSSL calls it for every verification failure; accept precisely the two
+// validity-window errors and pass everything else (chain, signature, trust anchor, hostname)
+// straight through as the failure it is.
+int allowCertificateDateErrors(int preverify, WOLFSSL_X509_STORE_CTX* store) {
+  if (preverify == 0 && store != nullptr && (store->error == ASN_BEFORE_DATE_E || store->error == ASN_AFTER_DATE_E)) {
+    LOG_INF("TLS", "Ignoring certificate date error %d (no trusted clock); chain and hostname still verified",
+            store->error);
+    return 1;
+  }
+  return preverify;
+}
 }  // namespace
 
 // One handshake attempt at a fixed verification level and TLS method.
@@ -91,13 +106,31 @@ int SecureClient::connectWithMethod(const char* host, uint16_t port, void* metho
   _ctx = ctx;
 
   if (verifyPeer && !_insecure && _rootCA) {
-    if (wolfSSL_CTX_load_verify_buffer(ctx, reinterpret_cast<const unsigned char*>(_rootCA), strlen(_rootCA),
-                                       WOLFSSL_FILETYPE_PEM) != WOLFSSL_SUCCESS) {
-      LOG_ERR("TLS", "load_verify_buffer failed for curated roots");
+    // The roots are date-checked AS THEY LOAD, not only during the handshake: plain
+    // load_verify_buffer() passes WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS (== WOLFSSL_LOAD_FLAG_NONE),
+    // so a cold-booted RTC-less board sitting at 1970 sees every curated root's notBefore as
+    // "in the future" and loads none of them. WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY switches the parse
+    // to VERIFY_SKIP_DATE, which suppresses the notBefore/notAfter test and nothing else — the
+    // signature and structural checks are unchanged (wolfcrypt/src/asn.c, `cert->badDate`).
+    const word32 loadFlags =
+        _allowCertificateDateErrors ? WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY : WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS;
+    const int loadRet = wolfSSL_CTX_load_verify_buffer_ex(ctx, reinterpret_cast<const unsigned char*>(_rootCA),
+                                                          strlen(_rootCA), WOLFSSL_FILETYPE_PEM, 0, loadFlags);
+    if (loadRet != WOLFSSL_SUCCESS) {
+      // Report the wolfSSL code and the epoch together. This failure happens before the
+      // handshake, so it leaves no verification error for connect() to classify and used to
+      // surface as a bare "connect failed" — with -150/-151 and a 1970 timestamp side by side,
+      // "the clock is wrong" is readable straight off the log.
+      LOG_ERR("TLS", "load_verify_buffer failed for curated roots: err=%d epoch=%lld (dateErrorsAllowed=%d)", loadRet,
+              static_cast<long long>(time(nullptr)), _allowCertificateDateErrors ? 1 : 0);
+      if (loadRet == ASN_BEFORE_DATE_E || loadRet == ASN_AFTER_DATE_E) {
+        LOG_ERR("TLS", "  -> the device clock is outside the roots' validity window; sync NTP before connecting");
+      }
       stop();
       return 0;
     }
-    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, nullptr);
+    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER,
+                           _allowCertificateDateErrors ? allowCertificateDateErrors : nullptr);
   } else {
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, nullptr);
   }

--- a/lib/SecureNet/src/SecureHttpClient.cpp
+++ b/lib/SecureNet/src/SecureHttpClient.cpp
@@ -72,6 +72,7 @@ bool SecureHttpClient::ensureConnected(const Url& u) {
   if (u.https()) {
     _secure.setCACert(_rootCA);
     _secure.setAllowInsecureFallback(_allowInsecureFallback);
+    _secure.setAllowCertificateDateErrors(_allowCertificateDateErrors);
     _secure.setTimeout(_timeoutMs / 1000);
     if (!_secure.connect(u.host.c_str(), u.port)) {
       LOG_ERR("HTTP", "https connect failed: %s:%u", u.host.c_str(), u.port);

--- a/lib/SecureNet/src/SecureNetSelfTest.cpp
+++ b/lib/SecureNet/src/SecureNetSelfTest.cpp
@@ -4,7 +4,10 @@
 // it is NOT part of the shipping firmware and has no callers otherwise.
 #if defined(SECURENET_SELFTEST)
 
+#include <HalClock.h>
 #include <Logging.h>
+
+#include <ctime>
 
 #include "CrossPointRoots.h"
 #include "SecureHttpClient.h"
@@ -27,9 +30,20 @@ void secureNetSelfTest() {
       "https://sync.koreader.rocks/",
       "https://timeapi.io/api/time/current/zone?timeZone=UTC",
   };
+  // The measurement env can be run straight off a cold boot, where an RTC-less board sits at
+  // 1970 and the curated roots fail to LOAD (their notBefore reads as "in the future"). Without
+  // this every host below reports a connect failure that says nothing about reachability — the
+  // thing this self-test exists to measure.
+  const bool clockReady = HalClock::ensureUsableForTls();
+  if (!clockReady) {
+    LOG_INF("SNTST", "No trusted clock (epoch %lld); tolerating certificate date errors only",
+            static_cast<long long>(time(nullptr)));
+  }
+
   for (const char* url : kHosts) {
     SecureHttpClient http;
     http.setCACert(CROSSPOINT_ROOTS_PEM);
+    http.setAllowCertificateDateErrors(!clockReady);
     http.setTimeout(15000);
     const int status = http.GET(url);
     LOG_INF("SNTST", "GET %s -> status=%d insecure=%d bodyLen=%u", url, status,

--- a/lib/hal/HalClock.cpp
+++ b/lib/hal/HalClock.cpp
@@ -795,6 +795,51 @@ bool isSynced() {
 
 bool isApproximate() { return clockApproximate; }
 
+bool isPlausibleForTls() {
+  // Lower bound: comfortably after the newest curated root's notBefore, so any clock at or
+  // past it satisfies every one of them. Upper bound: the curated set's latest notAfter is
+  // 2038, so cap below that — a wildly-wrong FUTURE clock breaks notAfter just as effectively
+  // as 1970 breaks notBefore, and must also be treated as "needs SNTP".
+  constexpr time_t MIN_PLAUSIBLE_EPOCH = 1735689600;  // 2025-01-01 00:00:00 UTC
+  constexpr time_t MAX_PLAUSIBLE_EPOCH = 2114380800;  // 2037-01-01 00:00:00 UTC
+  const time_t nowEpoch = time(nullptr);
+  return nowEpoch >= MIN_PLAUSIBLE_EPOCH && nowEpoch < MAX_PLAUSIBLE_EPOCH;
+}
+
+bool ensureUsableForTls(const char* preferredServer) {
+  if (isPlausibleForTls()) {
+    // Deliberately no SNTP round-trip here even when the clock is only "approximate": the
+    // cert-date check passes anywhere inside the roots' validity window, so an NVS-restored
+    // clock that is hours out still verifies. Syncing anyway would cost ~5 s (and an
+    // intermittent timeout) on every cold start that already had a good-enough time, and would
+    // churn the heap right before the handshake's peak allocations.
+    return true;
+  }
+
+  // Rate-limit FAILED attempts instead of latching "attempted" forever. A one-shot latch means
+  // a single call made before the radio was ready disables the sync for the rest of the
+  // session, and every later TLS connect then fails to load its trust store with no way back.
+  constexpr unsigned long RETRY_MIN_INTERVAL_MS = 30000;
+  static unsigned long lastAttemptMs = 0;
+  static bool everAttempted = false;
+  const unsigned long nowMs = millis();
+  if (everAttempted && (nowMs - lastAttemptMs) < RETRY_MIN_INTERVAL_MS) {
+    return false;
+  }
+  everAttempted = true;
+  lastAttemptMs = nowMs;
+
+  LOG_INF("CLK", "Clock unset/implausible for TLS (epoch %lld); running SNTP before the handshake",
+          static_cast<long long>(time(nullptr)));
+  char err[64] = {0};
+  if (!syncNtp(err, sizeof(err), preferredServer)) {
+    LOG_ERR("CLK", "SNTP failed (%s) — the TLS trust store will not load until the clock is set", err);
+    return false;
+  }
+  LOG_INF("CLK", "SNTP complete; epoch now %lld", static_cast<long long>(time(nullptr)));
+  return isPlausibleForTls();
+}
+
 time_t lastSyncTime() { return nvsReadSyncTime(); }
 
 uint32_t lastSleepSeconds() { return lastSleepSec; }

--- a/lib/hal/HalClock.h
+++ b/lib/hal/HalClock.h
@@ -73,6 +73,38 @@ void updatePeriodic();
 /// may have drifted.  Cleared on NTP sync.
 bool isApproximate();
 
+/// True when the system clock sits inside the window where TLS certificate
+/// date validation can succeed.
+///
+/// wolfSSL rejects a CA whose notBefore lies in the *future* of the device
+/// clock (ASN_BEFORE_DATE_E) and one that has expired (ASN_AFTER_DATE_E), and
+/// it does so when the trust store is LOADED, not just during the handshake —
+/// wolfSSL_CTX_load_verify_buffer() runs with WOLFSSL_LOAD_FLAG_NONE, so
+/// WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY is not in play. On these RTC-less C3 boards
+/// a cold boot leaves the clock at 1970 (restore() deliberately discards a
+/// stale NVS epoch rather than trusting it), which puts every curated root's
+/// notBefore in the future and makes the whole trust store fail to load.
+///
+/// "Approximate" is fine here: an NVS-restored clock that is merely a few hours
+/// off still lands inside every root's validity window, so it verifies fine.
+/// Only genuinely unset or wildly-wrong clocks matter.
+bool isPlausibleForTls();
+
+/// Make the clock usable for TLS: a no-op returning true when it already is,
+/// otherwise one SNTP attempt against `preferredServer`. Returns whether the
+/// clock ended up plausible.
+///
+/// CALL THIS AFTER WIFI IS UP AND BEFORE THE FIRST TLS CONNECT of any network
+/// flow. Skipping it does not produce a verification warning — it produces a
+/// trust store that will not load at all, which surfaces as a bare "connect
+/// failed" with no verification error to classify (and therefore no
+/// verified->insecure fallback either).
+///
+/// Failed attempts are rate-limited rather than latched, so a call made before
+/// the radio was ready does not poison the rest of the session; repeated calls
+/// on a healthy clock cost one time() comparison.
+bool ensureUsableForTls(const char* preferredServer = nullptr);
+
 /// Returns the epoch of the last successful NTP sync (from NVS), or 0 if
 /// no sync has ever been recorded.
 time_t lastSyncTime();

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -32,6 +32,11 @@ void logSyncMemSnapshot(const char* stage) {
   LOG_DBG("KOSync", "Sync mem[%s]: free=%lu contig=%lu", stage, freeHeap, contigHeap);
 }
 
+// Freshness policy, on top of HalClock::ensureUsableForTls()'s correctness floor. The floor
+// guarantees only "inside the certs' validity window", which is all TLS needs; this additionally
+// keeps the timestamp we upload to the sync server from drifting. Note the two answer different
+// questions — an unset clock reads as `now <= 0` here, but it is ensureUsableForTls() that makes
+// the handshake possible at all, so this must never be the only guard before a TLS call.
 bool shouldSyncNtpNow() {
   const time_t lastSync = HalClock::lastSyncTime();
   const time_t now = HalClock::now();
@@ -70,6 +75,11 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
   } else {
     LOG_DBG("KOSync", "Skipping NTP sync (recently synced)");
   }
+  // Independent of the freshness policy above: guarantee the clock is at least inside the
+  // certificate validity window, or the trust store will not load. Cheap when the sync above
+  // just ran (one time() comparison) and it is what makes this path's safety deliberate rather
+  // than a side effect of shouldSyncNtpNow() happening to return true on an unset clock.
+  HalClock::ensureUsableForTls(SETTINGS.ntpServer);
 
   {
     RenderLock lock(*this);

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -1,10 +1,12 @@
 #include "KOReaderAuthActivity.h"
 
 #include <GfxRenderer.h>
+#include <HalClock.h>
 #include <I18n.h>
 #include <Logging.h>
 #include <WiFi.h>
 
+#include "CrossPointSettings.h"
 #include "KOReaderCredentialStore.h"
 #include "KOReaderSyncClient.h"
 #include "MappedInputManager.h"
@@ -36,6 +38,14 @@ void KOReaderAuthActivity::onWifiSelectionComplete(const bool success) {
     }
   }
   requestUpdateAndWait();  // show status before blocking TLS call
+
+  // Set the clock before the first TLS connect. This is what was missing: unlike the sync
+  // activity (and HttpDownloader) this path went straight from "WiFi up" to a wolfSSL connect,
+  // and on these RTC-less boards a cold boot that discarded a stale NVS epoch is sitting at
+  // 1970 — which puts every curated root's notBefore in the future and makes the trust store
+  // fail to LOAD, long before any certificate is seen. Not fatal if it fails: SecureClient then
+  // waives certificate dates only, keeping chain/signature/hostname checks intact.
+  HalClock::ensureUsableForTls(SETTINGS.ntpServer);
 
   if (mode == Mode::REGISTER) {
     performRegistration();

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -32,52 +32,12 @@ std::string extractHostFromUrl(const std::string& url) {
   return url.substr(hostStart, hostEnd - hostStart);
 }
 
-// wolfSSL rejects certs whose notBefore lies in the future of the device
-// clock (ASN_BEFORE_DATE_E), and expired ones (ASN_AFTER_DATE_E). The
-// ESP32-C3 has no battery-backed RTC, so cold-boot clocks default to 1970
-// (or, if HalClock restored from NVS, a stale "last known" time that may
-// still predate the cert's notBefore). Fix it once per process before the
-// first https request by running SNTP — WiFi is already up by the time
-// runGet() is called, so this is essentially free. Subsequent calls reuse
-// whatever the first attempt produced.
-constexpr time_t MIN_PLAUSIBLE_EPOCH = 1735689600;  // 2025-01-01 00:00:00 UTC
-// Upper bound: a clock far in the future also fails cert notAfter checks. Our
-// curated roots' latest notAfter is 2038; cap at 2037 so a wildly-wrong future
-// clock still triggers SNTP rather than silently breaking verification.
-constexpr time_t MAX_PLAUSIBLE_EPOCH = 2114380800;  // 2037-01-01 00:00:00 UTC
-bool clockPlausibleForTls() {
-  const time_t now = time(nullptr);
-  return now >= MIN_PLAUSIBLE_EPOCH && now < MAX_PLAUSIBLE_EPOCH;
-}
-
-bool ensureClockForTls() {
-  static bool attempted = false;
-  if (attempted) return clockPlausibleForTls();
-  attempted = true;
-
-  // A plausible epoch is sufficient for TLS cert-date validation even if
-  // HalClock flags it "approximate" (restored from NVS on this RTC-less C3):
-  // wolfSSL's notBefore/notAfter check passes for any time within the certs'
-  // validity window, so an approximate-but-in-range clock verifies fine. This
-  // avoids a 5 s SNTP round-trip (and its intermittent timeouts) on every cold
-  // start when NVS already holds a good-enough time. Only sync when the clock
-  // is genuinely unset or out of the plausible range.
-  if (clockPlausibleForTls()) {
-    if (HalClock::isApproximate()) {
-      LOG_INF("HTTP", "Clock approximate but plausible (epoch %ld); skipping SNTP for TLS",
-              static_cast<long>(time(nullptr)));
-    }
-    return true;
-  }
-  LOG_INF("HTTP", "Clock unset/implausible (epoch %ld); running SNTP before TLS", static_cast<long>(time(nullptr)));
-  char err[64] = {0};
-  if (!HalClock::syncNtp(err, sizeof(err), SETTINGS.ntpServer)) {
-    LOG_ERR("HTTP", "SNTP sync failed: %s — TLS verification may fail until clock is set", err);
-    return false;
-  }
-  LOG_INF("HTTP", "SNTP sync complete; epoch now %ld", static_cast<long>(time(nullptr)));
-  return true;
-}
+// Clock guard for TLS. The plausibility window and the SNTP retry policy now live in
+// HalClock (isPlausibleForTls / ensureUsableForTls) so every TLS entry point shares one rule —
+// this used to be a private copy here, which is why the KOReader paths never got it. Returns
+// whether full certificate date validation is possible; false means the caller should tolerate
+// date errors (and only date errors) for this request.
+bool ensureClockForTls() { return HalClock::ensureUsableForTls(SETTINGS.ntpServer); }
 
 // Per-request timeout handed to SecureHttpClient::setTimeout(). 60s gives slow
 // servers room to send their first headers; SecureHttpClient reuses it as the
@@ -99,13 +59,15 @@ bool isRedirect(int status) {
 
 // Runs once per http call (or once per session for reused sessions): logs
 // heap stats and ensures the wall clock is set so TLS cert-date validation
-// can succeed. Shared by both TLS backends.
-void logPreCallContext(const std::string& url) {
+// can succeed. Shared by both TLS backends. Returns false when https was requested and the
+// clock could not be established — the caller then permits date errors alone.
+bool logPreCallContext(const std::string& url) {
   LOG_DBG("HTTP", "Heap free: %u, largest block: %u", esp_get_free_heap_size(),
           heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT));
   if (url.compare(0, 8, "https://") == 0) {
-    ensureClockForTls();
+    return ensureClockForTls();
   }
+  return true;
 }
 
 // One-shot streaming GET over SecureNet (wolfSSL). Fills the Sink and emits
@@ -114,7 +76,7 @@ void logPreCallContext(const std::string& url) {
 // (except where the caller disables it, e.g. OTA).
 HttpDownloader::DownloadError runGetSecure(const std::string& url, const std::string& username,
                                            const std::string& password, Sink& sink, bool allowInsecureFallback) {
-  logPreCallContext(url);
+  const bool clockReady = logPreCallContext(url);
   const unsigned long startMs = millis();
   LOG_DBG("HTTP", "Phase start @%lums heap=%u largest=%u", millis() - startMs, esp_get_free_heap_size(),
           heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT));
@@ -122,6 +84,7 @@ HttpDownloader::DownloadError runGetSecure(const std::string& url, const std::st
   crosspoint::SecureHttpClient http;
   http.setCACert(CROSSPOINT_ROOTS_PEM);
   http.setAllowInsecureFallback(allowInsecureFallback);
+  http.setAllowCertificateDateErrors(!clockReady);
   http.setTimeout(HTTP_TIMEOUT_MS);
   http.setUserAgent("WitchReader-ESP32-" CROSSPOINT_VERSION);
   if (!username.empty() && !password.empty()) {
@@ -200,14 +163,17 @@ HttpDownloader::DownloadError runGetSecureOnSession(HttpDownloader::Session& ses
                                                     const std::string& username, const std::string& password,
                                                     Sink& sink, bool allowInsecureFallback) {
   auto* impl = session.impl();
+  // Evaluated on every call, not just when the session is created: a session opened before the
+  // clock was set must not keep that verdict for the rest of its life (nor the reverse).
+  const bool clockReady = logPreCallContext(url);
   if (!impl->http) {
-    logPreCallContext(url);
     impl->http = std::make_unique<crosspoint::SecureHttpClient>();
     impl->http->setCACert(CROSSPOINT_ROOTS_PEM);
     impl->http->setTimeout(HTTP_TIMEOUT_MS);
     impl->http->setUserAgent("WitchReader-ESP32-" CROSSPOINT_VERSION);
   }
   impl->http->setAllowInsecureFallback(allowInsecureFallback);
+  impl->http->setAllowCertificateDateErrors(!clockReady);
   impl->http->clearHeaders();
   if (!username.empty() && !password.empty()) {
     impl->http->setBasicAuth(username, password);


### PR DESCRIPTION
## Problem

KOReader register/login failed on a cold-booted device:

```
[25266] [ERR] [TLS] load_verify_buffer failed for curated roots
[25308] [ERR] [TLS] load_verify_buffer failed for curated roots
[25310] [ERR] [HTTP] https connect failed: kosync.rustysoft.de:443
[25311] [DBG] [KOSync] Register response: 0 (err: ESP_ERR_HTTP_MAX_REDIRECT)
```

The X4 has **no RTC**. `HalClock::restore()` discards a stale NVS epoch *without setting the clock* ([HalClock.cpp:706-708](../blob/master/lib/hal/HalClock.cpp#L706-L708)), so a cold boot sits at 1970. The boot log says so plainly: `NVS epoch 1786250107 is stale (last NTP sync ..., 134 h ago), discarding`.

wolfSSL date-checks the **roots as it parses them**: `wolfSSL_CTX_load_verify_buffer()` passes `WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS`, which is `WOLFSSL_LOAD_FLAG_NONE`. At 1970 every curated root's `notBefore` is "in the future" → `ASN_BEFORE_DATE_E` (-150) → the whole trust store fails to load. That happens **before** the handshake, so `_lastConnectErr` stays 0, `isVerificationError(0)` is false, no fallback runs, and the surfaced error is meaningless.

`KOReaderAuthActivity` went from "WiFi up" straight to TLS with **no NTP sync at all**. `HttpDownloader` already had a correct private `ensureClockForTls()`; `KOReaderSyncActivity` was only *accidentally* safe (its `shouldSyncNtpNow()` happens to return true on an unset clock via the `age < 0` branch).

## Fix

**1. One shared clock rule.** `HalClock::isPlausibleForTls()` / `ensureUsableForTls(server)` — the plausibility window and SNTP policy promoted out of `HttpDownloader`'s anonymous namespace so every TLS entry point shares it. Server is a parameter, so no SETTINGS dependency in the HAL. Failed attempts are now **rate-limited rather than latched**: the old `static bool attempted` meant a single call made before the radio was ready disabled SNTP for the rest of the session.

Called from `KOReaderAuthActivity` (the bug), `KOReaderSyncActivity`, and `HttpDownloader`. `KOReaderSyncClient` also asks `isPlausibleForTls()` itself as a backstop, so a future caller can't reintroduce this.

**2. Degrade honestly when there is no clock.** `SecureClient::setAllowCertificateDateErrors()` waives the validity window **and nothing else** — chain, signature, trust anchor and hostname stay fatal.

The approach is adapted from @Kapfilm's fork ([aaf14fd3](https://github.com/Kapfilm/witchhunt-reader/commit/aaf14fd3df22aecfdbdd7078e53f9074fb9aed8e), "fix(ota): verify GitHub TLS without trusted clock"), whose verify callback accepts only `ASN_BEFORE_DATE_E`/`ASN_AFTER_DATE_E`. Credit where due — but that half alone does not fix this bug, because a verify callback only runs during the handshake and our failure is at trust-store load. The missing half is `wolfSSL_CTX_load_verify_buffer_ex(..., WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY)` → `VERIFY_SKIP_DATE`, which suppresses `cert->badDate` and nothing else (verified in `wolfcrypt/src/asn.c:21904` and `:24046`).

Ordering matters: **NTP first, date tolerance only as fallback.** Full date validation is preserved whenever the device can get the time.

**3. Diagnostics.** The load failure now logs the wolfSSL code *and* the epoch, with an explicit hint on -150/-151. That would have made this a ten-second read.

## Audit of every outbound HTTPS path

All six `HttpDownloader` public entry points funnel through `runGetDispatch`/`runGetOnSession` → `logPreCallContext`, so OTA, font manifest + downloads, web-server plugin relay/fetch, OPDS browse + download, weather (open-meteo) and timezone detect (ipify/timeapi) are covered without changes. `SecureNetSelfTest.cpp` was the only other direct `SecureHttpClient` user and is guarded too. Not TLS: the captive-portal probe is plain http via `NetworkClient`, Calibre is an inbound server, SNTP is UDP. No `wss://`, `WiFiClientSecure` or `esp_http_client` anywhere.
