### PR TITLE
fix(activities): protect activity lifetime across the mid-render unlock

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -166,6 +166,7 @@ void HalDisplay::releaseBuffers() { einkDisplay.releaseBuffers(); }
 static uint32_t fbufContig() { return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT); }
 
 bool HalDisplay::releaseSecondaryBuffer() {
+  HalSpiBus::Lock spiLock;  // see the note above borrowSecondaryBuffer()
   // Double-release guard. releaseSecondaryBuffer() returning false means the
   // secondary buffer was already gone — i.e. a caller released it without
   // tracking that it had, then released again. The release windows here are
@@ -186,6 +187,7 @@ bool HalDisplay::releaseSecondaryBuffer() {
 }
 
 bool HalDisplay::reallocSecondaryBuffer() {
+  HalSpiBus::Lock spiLock;  // see the note above borrowSecondaryBuffer()
   const bool ok = einkDisplay.reallocSecondaryBuffer();
   LOG_INF("FBUF", "reallocSecondary -> %d (hasSecondary=%d redSynced=%d contig=%lu)", ok ? 1 : 0,
           einkDisplay.hasSecondaryBuffer() ? 1 : 0, einkDisplay.isRedRamSynced() ? 1 : 0,
@@ -195,7 +197,22 @@ bool HalDisplay::reallocSecondaryBuffer() {
 
 bool HalDisplay::hasSecondaryBuffer() const { return einkDisplay.hasSecondaryBuffer(); }
 
+// The four buffer-ownership transitions below all take the SPI bus lock, for two reasons that
+// both trace back to them running on the LOOP task (reader background builds) while the render
+// task drives the panel:
+//
+//  - borrowSecondaryBuffer() is not a pointer swap. It calls syncPendingAsync(), which runs the
+//    driver's displayFinish() — real SPI traffic plus a BUSY wait. Unlocked, that collides with
+//    the render task's own refresh and with SD transfers, which is precisely the unsynchronised
+//    SdSpiCard failure this lock exists to prevent (see HalSpiBus.h).
+//  - all four reassign frameBufferActive, which a deferred refresh still reads (X3's
+//    post-waveform DTM1 sync). Serialising them behind the same lock the display paths take
+//    means the swap cannot land mid-refresh.
+//
+// The mutex is recursive, so a caller that already holds it is unaffected, and the lock is
+// uncontended on the normal path — this costs nothing when nothing else is on the bus.
 uint8_t* HalDisplay::borrowSecondaryBuffer(size_t* size) {
+  HalSpiBus::Lock spiLock;
   uint8_t* buf = einkDisplay.borrowSecondaryBuffer(size);
   LOG_INF("FBUF", "borrowSecondary -> %d (size=%lu hasSecondary=%d)", buf ? 1 : 0,
           static_cast<unsigned long>(buf && size ? *size : 0), einkDisplay.hasSecondaryBuffer() ? 1 : 0);
@@ -203,6 +220,7 @@ uint8_t* HalDisplay::borrowSecondaryBuffer(size_t* size) {
 }
 
 bool HalDisplay::returnSecondaryBuffer() {
+  HalSpiBus::Lock spiLock;
   const bool ok = einkDisplay.returnSecondaryBuffer();
   LOG_INF("FBUF", "returnSecondary -> %d (hasSecondary=%d)", ok ? 1 : 0, einkDisplay.hasSecondaryBuffer() ? 1 : 0);
   return ok;

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -93,7 +93,15 @@ void ActivityManager::renderTaskLoop() {
     RenderLock lock;
     if (currentActivity) {
       HalPowerManager::Lock powerLock;  // Ensure we don't go into low-power mode while rendering
+      // Publish "a pass is in flight" from INSIDE the lock, so a transition holding the mutex
+      // can read it as proof that no pass can begin behind its back. It stays set across the
+      // window where render() drops the mutex (renderContents' pre-waveform unlock), which is
+      // exactly the window a plain RenderLock cannot see — see RenderLock(ExclusiveActivityAccess).
+      renderPassActive.store(true, std::memory_order_release);
       currentActivity->render(std::move(lock));
+      // Cleared unconditionally on every exit path of render(): the call cannot throw
+      // (-fno-exceptions) and every `return` inside it lands here.
+      renderPassActive.store(false, std::memory_order_release);
       // Always-on guard (cheap; one read): warn once if the render task's stack high-water gets
       // dangerously thin. The render task's stack abuts the heap top — an overflow spills into
       // the heap and shows up as an unrelated corruption assert. Tracks the running minimum so
@@ -184,7 +192,9 @@ void ActivityManager::loop() {
 
   while (pendingAction != PendingAction::None) {
     if (pendingAction == PendingAction::Pop) {
-      RenderLock lock;
+      // Exclusive: this branch destroys currentActivity, so it must also outwait an
+      // in-flight render pass, not just the mutex.
+      RenderLock lock{RenderLock::ExclusiveActivityAccess{}};
 
       if (!currentActivity) {
         // Should never happen in practice
@@ -243,7 +253,10 @@ void ActivityManager::loop() {
 
     } else if (pendingActivity) {
       // Current activity has requested a new activity to be launched
-      RenderLock lock;
+      // Exclusive: the Replace path destroys currentActivity (and the Push path hands it to the
+      // stack while the render task may still hold a pointer to it), so both need the render
+      // pass to have finished, not merely the mutex to be free.
+      RenderLock lock{RenderLock::ExclusiveActivityAccess{}};
 
       const bool enteringReader = pendingActivity->isReaderActivity();
       const bool exitingReader = currentActivity && currentActivity->isReaderActivity();
@@ -586,6 +599,52 @@ RenderLock::RenderLock([[maybe_unused]] Activity&) {
   isLocked = true;
 }
 
+RenderLock::RenderLock(ExclusiveActivityAccess) {
+  // This waits for the render task to leave render(). Called FROM the render task it would wait
+  // on itself forever, so state the invariant rather than leaving a future misuse to present as
+  // an unexplained freeze — which is the exact class of bug this constructor exists to remove.
+  assert(xTaskGetCurrentTaskHandle() != activityManager.renderTaskHandle &&
+         "RenderLock(ExclusiveActivityAccess) must not be taken on the render task");
+
+  // See the header for why the mutex alone is not enough. Take it, and only keep it if no
+  // render pass is in flight; otherwise hand it straight back so the render task can finish.
+  constexpr TickType_t RETRY_DELAY_TICKS = 1;
+  constexpr unsigned long SLOW_WAIT_WARN_MS = 5000;
+  const unsigned long start = millis();
+  bool warned = false;
+  bool waited = false;
+  while (true) {
+    xSemaphoreTake(activityManager.renderingMutex, portMAX_DELAY);
+    if (!activityManager.renderPassActive.load(std::memory_order_acquire)) {
+      isLocked = true;
+      // Only ever logged when we actually had to wait, so it is silent on the common path and
+      // one line per genuinely-overlapping transition otherwise. That line IS the evidence this
+      // guard exists for: it marks a transition that arrived while the render task was inside
+      // render() — the interleaving that used to run the activity's destructor (or race
+      // endBackgroundBorrow()) out from under a pass still using the object. Compiled out at
+      // LOG_LEVEL=0, so it costs nothing in a release build.
+      if (waited) {
+        LOG_DBG("ACT", "Transition waited %lums for an in-flight render pass (activity teardown deferred)",
+                millis() - start);
+      }
+      return;
+    }
+    waited = true;
+    // The render task is in its mid-pass unlocked window and wants the mutex back. Give it up
+    // and yield: a plain retry at equal priority could re-win the mutex before the render task
+    // is scheduled, so the vTaskDelay is load-bearing, not a politeness.
+    xSemaphoreGive(activityManager.renderingMutex);
+    vTaskDelay(RETRY_DELAY_TICKS);
+    // A pass that never ends means a wedged panel or a stuck build slice, not lock contention.
+    // Say so once rather than looking like an unexplained freeze — this wait blocks activity
+    // transitions, so it is the first thing a "device hung on Back" report would land on.
+    if (!warned && millis() - start > SLOW_WAIT_WARN_MS) {
+      warned = true;
+      LOG_ERR("ACT", "Activity transition waiting >%lums for the in-flight render pass to finish", SLOW_WAIT_WARN_MS);
+    }
+  }
+}
+
 RenderLock::~RenderLock() {
   if (isLocked) {
     xSemaphoreGive(activityManager.renderingMutex);
@@ -606,5 +665,11 @@ void RenderLock::unlock() {
  *
  * @return true if renderingMutex is busy, otherwise false.
  *
+ * Asks the mutex for its holder rather than peeking it as a queue. xQueuePeek() is not defined
+ * for mutex-type queues: it reinterprets the holder/recursion union as queue pointers, and on a
+ * free mutex it also pops a task off xTasksWaitingToReceive — waking a waiter that then finds
+ * the mutex still unavailable. It happened to be harmless for a plain (non-recursive) mutex,
+ * but it is unsupported API use in the reader's hottest polling path, and the holder query
+ * answers exactly the same question legally.
  */
-bool RenderLock::peek() { return xQueuePeek(activityManager.renderingMutex, NULL, 0) != pdTRUE; };
+bool RenderLock::peek() { return xSemaphoreGetMutexHolder(activityManager.renderingMutex) != nullptr; };

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -4,6 +4,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
+#include <atomic>
 #include <cassert>
 #include <memory>
 #include <string>
@@ -77,6 +78,18 @@ class ActivityManager {
   // Mutex to protect rendering operations from race conditions
   // Must only be used via RenderLock
   SemaphoreHandle_t renderingMutex = nullptr;
+
+  // True while the render task is inside currentActivity->render(). Set and cleared by the
+  // render task WHILE HOLDING renderingMutex, which is what makes it usable as a lifetime
+  // guard: a task that holds the mutex and reads this false knows no pass can start until it
+  // releases, because starting one requires the same mutex.
+  //
+  // It exists because holding renderingMutex is not sufficient to prove the render task is
+  // done with the activity — render() drops the mutex mid-pass (see the comment on
+  // RenderLock(ExclusiveActivityAccess)) and then keeps using the object. Destroying the
+  // activity in that window is a use-after-free, so every transition that can destroy
+  // currentActivity acquires its lock through that constructor.
+  std::atomic<bool> renderPassActive{false};
 
   // Whether to trigger a render after the current loop()
   // This variable must only be set by the main loop, to avoid race conditions

--- a/src/activities/RenderLock.h
+++ b/src/activities/RenderLock.h
@@ -7,8 +7,26 @@ class RenderLock {
   bool isLocked = false;
 
  public:
+  // Tag type selecting the constructor below. Named rather than a bool so call sites
+  // read as a statement of intent instead of `RenderLock lock(true)`.
+  struct ExclusiveActivityAccess {};
+
   explicit RenderLock();
   explicit RenderLock(Activity&);  // unused for now, but keep for compatibility
+
+  // Acquire the rendering mutex AND guarantee the render task is not inside
+  // currentActivity->render(). Use this — never the plain constructor — before
+  // destroying or replacing the current activity.
+  //
+  // Holding the mutex alone is NOT enough: the render task deliberately drops it in the
+  // middle of a pass (renderContents() releases it before the waveform wait so the loop
+  // task can service input and schedule a pre-render) and then re-acquires it and keeps
+  // dereferencing the activity. A transition that took the plain lock in that window
+  // could run the activity's destructor while the render task was still using it.
+  //
+  // Blocks until both conditions hold. See ActivityManager::renderPassActive.
+  explicit RenderLock(ExclusiveActivityAccess);
+
   RenderLock(const RenderLock&) = delete;
   RenderLock& operator=(const RenderLock&) = delete;
   ~RenderLock();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -655,10 +655,13 @@ void EpubReaderActivity::onExit() {
     secondaryBorrowed_ = false;
     secondaryBufferDegraded_ = false;
     LOG_INF("ERS", "onExit: returned secondary buffer borrowed by Background-C");
-  }
-  // Background-C may instead have RELEASED the secondary buffer for headroom; the build is now
-  // aborted, so restore the global "buffer resident" invariant before the next activity renders.
-  if (secondaryBufferDegraded_ && !renderer.hasSecondaryBuffer()) {
+  } else if (secondaryBufferDegraded_ && !renderer.hasSecondaryBuffer()) {
+    // Background-C may INSTEAD have RELEASED the secondary buffer for headroom; the build is now
+    // aborted, so restore the global "buffer resident" invariant before the next activity renders.
+    // `else if` because borrowed and released are alternatives, never both: returning a borrow
+    // above already makes the buffer resident. That used to be expressed by the borrow branch
+    // clearing secondaryBufferDegraded_, which left this branch's reachability depending on a
+    // flag write two lines up rather than on the state it actually tests.
     if (reallocSecondaryEvictingCaches()) {
       LOG_INF("ERS", "onExit: restored secondary buffer released by Background-C");
     }
@@ -690,6 +693,15 @@ void EpubReaderActivity::loop() {
   if (pendingProgressSave.pending.load(std::memory_order_acquire)) {
     pendingProgressSave.pending.store(false, std::memory_order_relaxed);
     saveProgress(pendingProgressSave.spineIndex, pendingProgressSave.page, pendingProgressSave.pageCount);
+  }
+
+  // Deferred by the render task (renderFinishedBookPass) because it ends in pushActivity().
+  // After the progress flush and before input handling: this is the reader's LAST loop() pass —
+  // the launch pushes it onto the activity stack, which stops loop() being called — so anything
+  // still owed must be flushed above, and nothing below it will run again.
+  if (finishedBookLaunchPending_) {
+    serviceFinishedBookLaunch();
+    return;
   }
 
   if (inputDrainGuard.shouldDrain(mappedInput)) {
@@ -1011,19 +1023,30 @@ void EpubReaderActivity::startActivityForResult(std::unique_ptr<Activity>&& acti
   // that is still live, and keeps a COMPLETED one for buildSection() to adopt. Resetting would
   // throw that finished section away and make the next page turn rebuild it — paying for the
   // refresh fix with a page-turn stall.
-  if (backgroundBorrowActive_) {
-    LOG_INF("ERS", "Overlay '%s' opening; returning Background-B's borrowed buffer so its refreshes stay fast",
-            activity ? activity->getName().c_str() : "<null>");
+  //
+  // Under the render lock, like every other endBackgroundBorrow() call site. This runs on the
+  // loop task, and the render task calls the same function from recoverSecondaryBufferIfNeeded()
+  // at the top of every render(). Its `if (!backgroundBorrowActive_) return;` is a plain bool,
+  // not a guard against concurrency: unlocked, both tasks pass it and both run the teardown —
+  // double-destroying backgroundSection_ and buildScratch_ (two frees into TLSF, which corrupts
+  // the free list and hangs a later malloc) while returnSecondaryBuffer() memcpy's 48 KB into a
+  // framebuffer the render task is using.
+  {
+    RenderLock lock(*this);
+    if (backgroundBorrowActive_) {
+      LOG_INF("ERS", "Overlay '%s' opening; returning Background-B's borrowed buffer so its refreshes stay fast",
+              activity ? activity->getName().c_str() : "<null>");
+    }
+    // Not a preemption. backgroundPreemptCount_ measures one specific thing — a build that keeps
+    // losing the race against page turns — and BG_BUILD_MAX_PREEMPTIONS (2) makes B abandon the
+    // spine to the foreground once it is hit. An overlay opening says nothing about whether the
+    // parse fits between two turns, so letting it burn that budget would mean two visits to the
+    // reader menu permanently demote the next section to a blocking Background-C build with its
+    // popup. Restore the count so B resumes with exactly the budget it had.
+    const uint8_t preemptionsBeforeOverlay = backgroundPreemptCount_;
+    endBackgroundBorrow();
+    backgroundPreemptCount_ = preemptionsBeforeOverlay;
   }
-  // Not a preemption. backgroundPreemptCount_ measures one specific thing — a build that keeps
-  // losing the race against page turns — and BG_BUILD_MAX_PREEMPTIONS (2) makes B abandon the
-  // spine to the foreground once it is hit. An overlay opening says nothing about whether the
-  // parse fits between two turns, so letting it burn that budget would mean two visits to the
-  // reader menu permanently demote the next section to a blocking Background-C build with its
-  // popup. Restore the count so B resumes with exactly the budget it had.
-  const uint8_t preemptionsBeforeOverlay = backgroundPreemptCount_;
-  endBackgroundBorrow();
-  backgroundPreemptCount_ = preemptionsBeforeOverlay;
   Activity::startActivityForResult(std::move(activity), std::move(resultHandler));
 }
 
@@ -2941,7 +2964,7 @@ EpubReaderActivity::RenderPass EpubReaderActivity::classifyRenderPass() const {
   return RenderPass::Normal;
 }
 
-void EpubReaderActivity::renderFinishedBookPass(RenderLock& lock, const int spineCount) {
+void EpubReaderActivity::renderFinishedBookPass(const int spineCount) {
   // Immediately transition to finished-book flow instead of showing an end-of-book screen
   if (finishedBookActivityStarted_) {
     return;
@@ -2952,7 +2975,19 @@ void EpubReaderActivity::renderFinishedBookPass(RenderLock& lock, const int spin
   finishedBookSyncSpineIndex_ = lastSpineIndex;
   finishedBookSyncPage_ = 0;
   finishedBookSyncPageCount_ = 0;
-  lock.unlock();
+  // Arm only; loop() performs the launch on the loop task (see finishedBookLaunchPending_).
+  // This pass used to drop the render lock and call launchFinishedBookFlow() from here, which
+  // both mutated ActivityManager's pending-activity state from the wrong task and did SD work
+  // (findNextBookInDirectory) on the render task's stack. The lock is now simply kept: nothing
+  // below it is long-running any more.
+  finishedBookLaunchPending_ = true;
+}
+
+void EpubReaderActivity::serviceFinishedBookLaunch() {
+  if (!finishedBookLaunchPending_ || !epub) {
+    return;
+  }
+  finishedBookLaunchPending_ = false;
   BookFinished::launchFinishedBookFlow(
       *this, renderer, mappedInput, epub->getPath(), epub->getSeries(), epub->getSeriesIndex(), epub->getAuthor(),
       [](void* ctx) { static_cast<EpubReaderActivity*>(ctx)->finishedBookActivityStarted_ = false; }, this,
@@ -3835,9 +3870,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   clampSpineIndex(spineCount);
 
-  // The finished-book pass needs no layout/stats setup and consumes the lock itself.
+  // The finished-book pass needs no layout/stats setup, and only arms a flag — the lock stays
+  // held for the rest of this call and is released by the render task as usual.
   if (currentSpineIndex == spineCount) {
-    renderFinishedBookPass(lock, spineCount);
+    renderFinishedBookPass(spineCount);
     return;
   }
 
@@ -4381,6 +4417,19 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   // frameBuffer is already swapped. The loop task gets full CPU during the
   // waveform for input handling and pre-render scheduling.
   lock.unlock();
+
+#ifdef ERS_TEST_WIDEN_RENDER_WINDOW_MS
+  // TEST HOOK — never defined by any environment in platformio.ini. Holds the mid-render
+  // unlocked window open so a transition requested during it deterministically overlaps a live
+  // render pass, which is otherwise a ~1-2 s target that has to be hit by hand. Validates
+  // RenderLock(ExclusiveActivityAccess): with the guard, the transition logs
+  // "Transition waited Nms" and proceeds safely; swap the two ExclusiveActivityAccess call
+  // sites in ActivityManager::loop() back to the plain constructor and the same gesture runs
+  // the activity's destructor while this pass is still using `this`.
+  // Build with: PLATFORMIO_BUILD_FLAGS=-DERS_TEST_WIDEN_RENDER_WINDOW_MS=4000 pio run
+  LOG_INF("ERS", "TEST: holding the mid-render unlocked window open for %d ms", ERS_TEST_WIDEN_RENDER_WINDOW_MS);
+  delay(ERS_TEST_WIDEN_RENDER_WINDOW_MS);
+#endif
 
   // Sleep until BUSY deasserts, then do post-waveform SPI work (DTM1 resync
   // on X3, conditioning passes, flag updates). SPI ownership transfers back

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -510,6 +510,13 @@ class EpubReaderActivity final : public Activity {
   bool pendingScreenshot = false;
   bool skipNextButtonCheck = false;  // Skip button processing for one frame after subactivity exit
   bool finishedBookActivityStarted_ = false;
+  // Armed by renderFinishedBookPass() (render task), consumed by loop() (loop task). The launch
+  // itself must not run on the render task: it ends in pushActivity(), which writes
+  // ActivityManager's pendingActivity/pendingAction — and loop() reads and std::move()s those
+  // with no lock at all, because the invariant they rely on is "only the loop task touches
+  // them", not "the render lock covers them". A unique_ptr assigned from one task while another
+  // moves it is a double-free waiting to happen.
+  bool finishedBookLaunchPending_ = false;
   // Last valid spine/page/pageCount at book-finish time, stashed for onFinishedBookSyncRequested()
   // — see the SyncPositionOverride comment for why currentSpineIndex/section can't be used there.
   int finishedBookSyncSpineIndex_ = 0;
@@ -581,8 +588,11 @@ class EpubReaderActivity final : public Activity {
   RenderLayout computeRenderLayout() const;
   // Select which pass this render() invocation should run, from pending flags + reader state.
   RenderPass classifyRenderPass() const;
-  // FinishedBook pass: transition to the finished-book flow. Consumes the lock.
-  void renderFinishedBookPass(RenderLock& lock, int spineCount);
+  // FinishedBook pass: arm the transition to the finished-book flow. Runs under the render
+  // lock and keeps it; the launch itself is deferred to the loop task (see the pair below).
+  void renderFinishedBookPass(int spineCount);
+  // Loop-task half of renderFinishedBookPass(): performs the launch it armed.
+  void serviceFinishedBookLaunch();
   // PreRender pass (Background A): render the next page's content into the framebuffer only.
   void renderPreRenderPass(const RenderLayout& layout);
   // BufferDisplay pass: framebuffer already holds the next page; add status bar + flush.


### PR DESCRIPTION
Audit of how the foreground (loop task) and the render task are actually serialised, prompted by #165. The `RenderLock` design is sound — one non-recursive mutex, render task in `renderTaskLoop()`, loop-side code taking it around shared-state mutation — but there are five places where the discipline isn't applied.

## 1. The framebuffer borrow was returned without the lock

[`EpubReaderActivity::startActivityForResult()`](../blob/master/src/activities/reader/EpubReaderActivity.cpp#L1005) called `endBackgroundBorrow()` unlocked — the only one of ~10 call sites that did (`onExit`, `stepBackgroundSectionBuild` ×4, `buildSection`, `renderNormalPass` all hold it).

Its concurrent counterpart is the render task, which calls the *same function* first thing in `render()` via `recoverSecondaryBufferIfNeeded()`. The guard is a plain bool:

```cpp
if (!backgroundBorrowActive_) return;
...
backgroundSection_.reset();   // ~Section
buildScratch_.reset();        // ~BuildArena
renderer.returnSecondaryBuffer();
```

Both tasks pass it, both run the teardown: two frees into TLSF, plus `returnSecondaryBuffer()`'s 48 KB `memcpy` into a framebuffer the render task is using. A TLSF double-free corrupts the free list and a later `malloc` can walk it forever — a hang with **no panic**, which matches #165's "had to press reset".

Reached by the reader menu, TOC, footnotes, bookmarks and quick overrides. Step 1 of #165's repro is "press the menu button".

## 2. Activity lifetime was unprotected across the mid-render unlock

`renderContents()` releases the lock before the waveform wait so the loop task can service input — then `renderNormalPass()` re-acquires it and keeps writing `this` state (`pendingProgressSave`, `lastRenderStats`, `section`). Same shape in `displayBuildPage()` and `renderFinishedBookPass()`.

Nothing stopped `ActivityManager::loop()` taking the lock in that window and running `exitActivity()` → the destructor. The only guard was a null check on `section`, which is itself a read through a freed `this`.

Fixed with `ActivityManager::renderPassActive`, set and cleared by the render task **inside** the mutex, plus a new `RenderLock(ExclusiveActivityAccess)` that keeps the lock only when no pass is in flight, used by the Pop and Replace branches. Two details worth review: the `vTaskDelay` in its retry loop is load-bearing (equal priorities — a bare retry could re-win the mutex before the render task is scheduled), and there's an `assert` against taking it on the render task, since that would be a self-wait.

## 3. The render task was pushing activities

`renderFinishedBookPass()` dropped the lock and called `launchFinishedBookFlow()`, which ends in `pushActivity()`. But `pendingActivity`/`pendingAction` are guarded by "only the loop task touches them", **not** by the render lock — `ActivityManager::loop()` reads and `std::move`s them with no lock at all. A `unique_ptr` assigned from one task while another moves it is a double-free waiting to happen. Deferred to `loop()` via `finishedBookLaunchPending_`, placed after the progress flush since that pass is the reader's last before it goes on the stack.

## 4. Framebuffer ownership transitions bypassed the SPI bus lock

Every display entry point in `HalDisplay.cpp` takes `HalSpiBus::Lock` except the four secondary-buffer transitions. `borrowSecondaryBuffer()` is not a pointer swap — it calls `syncPendingAsync()` → `displayFinish()`, real SPI traffic plus a BUSY wait, from the loop task. That is precisely the unsynchronised `SdSpiCard` failure [HalSpiBus.h](../blob/master/lib/hal/HalSpiBus.h) was written to prevent ("easily misfiled as heap corruption").

## 5. Smaller

- `RenderLock::peek()` used `xQueuePeek()` on a mutex, which isn't defined for mutex-type queues — it reinterprets the holder/recursion union and can pop a waiter off `xTasksWaitingToReceive`. Harmless in practice for a non-recursive mutex, but it's unsupported API use in the reader's hottest polling path. Now `xSemaphoreGetMutexHolder()`.
- `onExit()`'s borrowed/released recovery branches are a proper `else if` instead of depending on a flag write two lines up, which made the second branch's reachability an accident of ordering.

## Validation — please read before merging

`pio run -e default` / `-e gh_release` clean, no new warnings. Host tests 467/468 (the `test_font_normalization` golden failure is pre-existing, in a harness that stubs `HalDisplay` and compiles none of these files).

**The overlapping window IS reproduced on device** (X4, ordinary use, no test hook):

```
[35275] [ERS] Rendered page in 2023ms
[35276] [ACT] Transition waited 2ms for an in-flight render pass (activity teardown deferred)
[35276] [ACT] Pushed to activity stack, new size = 1
[35276] [ACT] Entering activity: EpubReaderMenu
```

Opening the reader menu right after a page render landed inside the render task's mid-pass unlocked window. On master that transition would have reassigned `currentActivity` while the render task still held a pointer into it and was about to re-acquire the lock and keep writing through it. Here it deferred 2 ms and proceeded safely.

What that proves: the interleaving is real and reachable in normal use, and the guard fires. What it does not prove: that the unguarded version would have crashed on this particular pass — 2 ms is a narrow miss, and the consequences depend on what the render task touched next. Treat this as "closes a demonstrated race", not "fixes a demonstrated crash".

Two aids remain for anyone wanting to widen it:

- The exclusive lock logs `[ACT] Transition waited Nms for an in-flight render pass` **only when it actually had to wait** — silent on the common path, compiled out at `LOG_LEVEL=0`. Every occurrence is one interleaving that previously ran the destructor under a live pass.
- `ERS_TEST_WIDEN_RENDER_WINDOW_MS` (defined by no environment) holds the mid-render window open so it can be hit deliberately:

  ```
  PLATFORMIO_BUILD_FLAGS="-DERS_TEST_WIDEN_RENDER_WINDOW_MS=4000" pio run -e default -t upload
  ```

  Turn a page, wait for `TEST: holding the mid-render unlocked window open`, then press Confirm or long-press Back within 4 s.

A device log already shows the window is genuinely reachable — one millisecond into that hold, the loop task took the mutex and ran `pageTurn()` while the render task was still inside `render()`. A page turn is a *designed* overlap (plain `RenderLock`); swap the button for a transition and it becomes a teardown.

Honest framing: this closes real but narrow races. It is **not** confirmed as the cause of #165 — the long-press hang in that report turned out to be a CPU-clock problem (#173). #165's own repro (menu -> Push progress) now completes end to end on this build, but via the 3 s auto-close rather than the Back press the reporter used, so that exact step is still untested.
