### PR TITLE
fix(wifi): make the cached channel/BSSID hint actually skip the scan

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -384,9 +384,10 @@ void WifiSelectionActivity::prepareForConnect() {
     WiFi.disconnect(true, true);
   }
 
-  // Scan all channels so networks with multiple APs use the strongest matching
-  // BSSID instead of the first match found by the framework's default fast scan.
-  WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+  // Sort ranks the results a full scan collected, so it is meaningful only under
+  // WIFI_ALL_CHANNEL_SCAN and can be set once here. The SCAN METHOD is deliberately NOT set
+  // here any more -- it is chosen per attempt in issueWifiBegin(), because the hinted and
+  // unhinted attempts need opposite ones. See the comment there.
   WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
 
   // Use stable base MAC so hostname suffix is deterministic across WiFi states.
@@ -440,15 +441,33 @@ void WifiSelectionActivity::issueWifiBegin(bool useHint) {
   // Reset to DHCP in case a previous attempt left a static config behind.
   WiFi.config(IPAddress(), IPAddress(), IPAddress(), IPAddress());
 
+  // The scan method is per-attempt, and it is what makes the hint mean anything at all.
+  //
+  // WIFI_ALL_CHANNEL_SCAN scans EVERY channel and collects all matching APs before connecting --
+  // that is its purpose, and it is what setSortMethod() ranks. conf.sta.channel cannot
+  // short-circuit it (Arduino folds channel, bssid and scan_method into one wifi_config_t; see
+  // STA.cpp), so under it the cached channel/BSSID saved nothing. Measured on device: hinted
+  // association 2517/2518/2535 ms vs unhinted 2569/2571 ms -- the same full scan either way,
+  // ~40 ms apart. The hint then had to finish that scan inside HINT_ATTEMPT_TIMEOUT_MS (3000 ms)
+  // with only ~480 ms to spare, and ordinary jitter tipped it into the fallback, which costs the
+  // whole timeout PLUS a fresh association (~6.6 s observed, against ~3.6 s unhinted).
+  //
+  // WIFI_FAST_SCAN stops at the first matching AP and confines the scan to conf.sta.channel,
+  // which is what the cache exists to supply. A hint that has gone stale (AP moved channel, mesh
+  // roam) now fails FAST rather than burning the timeout, and the fallback re-issues with the
+  // full scan -- so the two paths finally have the scan behaviour each was written for.
+  const bool hinted = currentAttemptChannel != 0;
+  WiFi.setScanMethod(hinted ? WIFI_FAST_SCAN : WIFI_ALL_CHANNEL_SCAN);
+
   const char* pwd = (selectedRequiresPassword && !enteredPassword.empty()) ? enteredPassword.c_str() : nullptr;
   const unsigned long preBeginMs = millis() - connectionStartTime;
-  if (currentAttemptChannel != 0) {
-    LOG_DBG("WIFI", "WiFi.begin -> %s ch=%d bssid=%02x:%02x:%02x:%02x:%02x:%02x dhcp=yes (pre-begin %lu ms)",
+  if (hinted) {
+    LOG_DBG("WIFI", "WiFi.begin -> %s ch=%d bssid=%02x:%02x:%02x:%02x:%02x:%02x scan=fast dhcp=yes (pre-begin %lu ms)",
             selectedSSID.c_str(), currentAttemptChannel, currentAttemptBssid[0], currentAttemptBssid[1],
             currentAttemptBssid[2], currentAttemptBssid[3], currentAttemptBssid[4], currentAttemptBssid[5], preBeginMs);
     WiFi.begin(selectedSSID.c_str(), pwd, currentAttemptChannel, currentAttemptBssid, true);
   } else {
-    LOG_DBG("WIFI", "WiFi.begin -> %s (no hint, pre-begin %lu ms)", selectedSSID.c_str(), preBeginMs);
+    LOG_DBG("WIFI", "WiFi.begin -> %s (no hint, scan=all-channel, pre-begin %lu ms)", selectedSSID.c_str(), preBeginMs);
     if (pwd) {
       WiFi.begin(selectedSSID.c_str(), pwd);
     } else {

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -86,10 +86,23 @@ class WifiSelectionActivity final : public Activity {
   // Connection timeouts
   static constexpr unsigned long CONNECTION_TIMEOUT_MS = 15000;
   static constexpr unsigned long AUTO_CYCLE_TIMEOUT_MS = 5000;
-  // Faster timeout for the first hint-based attempt before falling back to full scan.
-  // Hint-based connect on the correct channel usually completes in <2 s; if it doesn't,
-  // the AP has likely moved (mesh roam, channel change) so it's cheaper to bail and rescan.
-  static constexpr unsigned long HINT_ATTEMPT_TIMEOUT_MS = 3000;
+  // Backstop for the hint attempt before falling back to a full scan.
+  //
+  // The premise this was built on ("hint-based connect completes in <2 s") does not hold on real
+  // APs. Measured on an X4 across six sessions, association is 2517/2518/2535/2569/2571/2615 ms
+  // and is INDIFFERENT to the hint and to the scan method -- the scan is not what dominates it,
+  // auth/assoc is. At 3000 ms that left ~400 ms of margin over the normal case, so ordinary
+  // jitter tripped it and paid the timeout plus a full re-association (~6.6 s vs ~3.6 s).
+  //
+  // A stale hint no longer needs a timeout to be detected: since issueWifiBegin() uses
+  // WIFI_FAST_SCAN for hinted attempts, an AP that has moved off the cached channel yields
+  // NO_AP_FOUND -> WL_NO_SSID_AVAIL almost immediately and trips the hintHardFail path instead.
+  // This value now only catches an attempt that hangs without ever reporting a hard status, so
+  // it belongs well clear of normal association time rather than just above it.
+  //
+  // Safe to enlarge: the fallback resets connectionStartTime, so it gets its own full
+  // CONNECTION_TIMEOUT_MS budget and this does not eat into it.
+  static constexpr unsigned long HINT_ATTEMPT_TIMEOUT_MS = 8000;
   unsigned long connectionStartTime = 0;
 
   // BSSID/channel hint used on the current attempt (channel==0 means no hint).


### PR DESCRIPTION
## Problem

`Hint attempt did not connect (timeout after 3005 ms), retrying with full scan` fires on most connects, costing ~3 s every time. It turns out the hint was never doing anything in the first place.

`prepareForConnect()` set the scan method **once, unconditionally**:

```cpp
WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
```

and `issueWifiBegin()` then handed channel + BSSID to `WiFi.begin()`. But Arduino folds all three into one config ([`STA.cpp:387-401`](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/STA.cpp)):

```cpp
conf.sta.channel     = channel;
conf.sta.scan_method = _scanMethod;   // still WIFI_ALL_CHANNEL_SCAN
conf.sta.bssid_set   = 1;
```

`WIFI_ALL_CHANNEL_SCAN` scans **every** channel and collects all matching APs before connecting — that is its purpose, and it is what `setSortMethod()` ranks. `conf.sta.channel` cannot short-circuit it. So the cached channel bought nothing; the BSSID merely filtered which scan result was accepted.

### Measured on device (X4, five sessions)

| | associated | rssi |
|---|---|---|
| `hint=yes` | 2535, 2517, 2518 ms | −74, −70, −68 |
| `hint=no` | 2569, 2571 ms | −63, −63 |

**~40 ms apart** — the same full scan either way, inside measurement noise.

That left the hint gated behind `HINT_ATTEMPT_TIMEOUT_MS` (3000 ms) with only ~480 ms of headroom over a scan it could not shorten. Ordinary jitter tipped it into the fallback, which costs the whole timeout **plus** a fresh `WiFi.disconnect()` + association: **~6.6 s observed against ~3.6 s for the plain unhinted path.** The "optimisation" was a net 3 s penalty whenever it missed, and could not win by more than noise when it hit.

## Fix

Choose the scan method **per attempt**, in `issueWifiBegin()`:

- **Hinted attempt → `WIFI_FAST_SCAN`.** Stops at the first matching AP and confines the scan to `conf.sta.channel` — which is exactly what the cache exists to supply. This is the one-line change that makes the feature do what its name says.
- **Unhinted fallback → `WIFI_ALL_CHANNEL_SCAN`.** Still needs the full sweep so sort-by-signal can pick the strongest of several APs (multi-AP / mesh), which is why that setting was there.

A stale hint (AP moved channel, mesh roam) now fails **fast** into the fallback instead of burning the 3 s timeout — so the two paths finally have the scan behaviour each was written for.

`setSortMethod()` stays in `prepareForConnect()`: it only ranks what a full scan collected, so it is meaningful for the fallback alone and needs setting once.

Both `begin()` log lines now report the scan method (`scan=fast` / `scan=all-channel`) so a capture shows which path ran and what it cost.

## Scope

`WifiSelectionActivity` is the only place in the tree that calls `WiFi.begin()` or `setScanMethod()`, so making the setting per-attempt cannot leak into another caller.

## Device result — and a corrected prediction

Flashed and retested (X4, warm cache, same push-progress action):

```
[232904] WiFi.begin -> PYSY ch=11 bssid=f0:9f:c2:31:b8:0c scan=fast dhcp=yes (pre-begin 44 ms)
[235475] EVT associated at 2615 ms
[236987] EVT got_ip at 4127 ms
[236997] Connected to PYSY in 4135 ms (rssi=-69 ch=11 ... hint=yes)
```

The hint engages (`scan=fast`, `hint=yes`) and there is **no fallback** — the 3 s penalty is gone.

But the prediction in the first draft of this PR was **wrong**: association did not collapse. At 2615 ms it is indistinguishable from every other measurement:

| | association |
|---|---|
| ALL_CHANNEL, hinted | 2535, 2517, 2518 ms |
| ALL_CHANNEL, unhinted | 2569, 2571 ms |
| **FAST_SCAN, hinted** | **2615 ms** |

So the scan was never the bottleneck — auth/assoc is. The hint saves ~nothing in the happy path even now that it functions. Its remaining value is entirely that a *stale* hint fails fast instead of burning a timeout.

That changes what the second commit has to do. At 3000 ms the budget sat ~400 ms above a normal 2.6 s association — which is why it kept tripping, and it would have kept tripping with FAST_SCAN alone. The comment on that constant asserted "hint-based connect on the correct channel usually completes in <2 s"; six measurements say otherwise.

With FAST_SCAN in place a stale hint yields `NO_AP_FOUND` → `WL_NO_SSID_AVAIL` almost immediately and trips the existing `hintHardFail` path, so the timeout is no longer the mechanism that detects a moved AP. It is now only a backstop for an attempt that hangs without reporting a hard status, and belongs well clear of normal association time: **3000 → 8000 ms**. Safe to enlarge, because the fallback resets `connectionStartTime` and so gets its own full `CONNECTION_TIMEOUT_MS` budget.

## Worth saying plainly

Even fixed, the hint buys approximately nothing on the happy path. If you would rather simplify than maintain it, deleting the hint and its cache entirely is a defensible call and I would not argue against it — the case for keeping it is now just "a stale hint fails fast and the cache is already written", not "it makes connecting quicker".

## Validation

`pio run -e default` / `-e gh_release` clean, no new warnings. Host tests 467/468 (the `test_font_normalization` golden failure is pre-existing and unrelated).

Device-tested: `scan=fast`, `hint=yes`, no fallback, connect in 4135 ms (see above). The timeout change is not separately tested — it only matters on the runs that previously tripped, so confirming it needs a few more connects with no `Hint attempt did not connect` line.
