### PR TITLE
chore(wifi): instrument the connect phases and the post-WiFi heap

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -384,9 +384,10 @@ void WifiSelectionActivity::prepareForConnect() {
     WiFi.disconnect(true, true);
   }
 
-  // Scan all channels so networks with multiple APs use the strongest matching
-  // BSSID instead of the first match found by the framework's default fast scan.
-  WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+  // Sort ranks the results a full scan collected, so it is meaningful only under
+  // WIFI_ALL_CHANNEL_SCAN and can be set once here. The SCAN METHOD is deliberately NOT set
+  // here any more -- it is chosen per attempt in issueWifiBegin(), because the hinted and
+  // unhinted attempts need opposite ones. See the comment there.
   WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
 
   // Use stable base MAC so hostname suffix is deterministic across WiFi states.
@@ -440,15 +441,33 @@ void WifiSelectionActivity::issueWifiBegin(bool useHint) {
   // Reset to DHCP in case a previous attempt left a static config behind.
   WiFi.config(IPAddress(), IPAddress(), IPAddress(), IPAddress());
 
+  // The scan method is per-attempt, and it is what makes the hint mean anything at all.
+  //
+  // WIFI_ALL_CHANNEL_SCAN scans EVERY channel and collects all matching APs before connecting --
+  // that is its purpose, and it is what setSortMethod() ranks. conf.sta.channel cannot
+  // short-circuit it (Arduino folds channel, bssid and scan_method into one wifi_config_t; see
+  // STA.cpp), so under it the cached channel/BSSID saved nothing. Measured on device: hinted
+  // association 2517/2518/2535 ms vs unhinted 2569/2571 ms -- the same full scan either way,
+  // ~40 ms apart. The hint then had to finish that scan inside HINT_ATTEMPT_TIMEOUT_MS (3000 ms)
+  // with only ~480 ms to spare, and ordinary jitter tipped it into the fallback, which costs the
+  // whole timeout PLUS a fresh association (~6.6 s observed, against ~3.6 s unhinted).
+  //
+  // WIFI_FAST_SCAN stops at the first matching AP and confines the scan to conf.sta.channel,
+  // which is what the cache exists to supply. A hint that has gone stale (AP moved channel, mesh
+  // roam) now fails FAST rather than burning the timeout, and the fallback re-issues with the
+  // full scan -- so the two paths finally have the scan behaviour each was written for.
+  const bool hinted = currentAttemptChannel != 0;
+  WiFi.setScanMethod(hinted ? WIFI_FAST_SCAN : WIFI_ALL_CHANNEL_SCAN);
+
   const char* pwd = (selectedRequiresPassword && !enteredPassword.empty()) ? enteredPassword.c_str() : nullptr;
   const unsigned long preBeginMs = millis() - connectionStartTime;
-  if (currentAttemptChannel != 0) {
-    LOG_DBG("WIFI", "WiFi.begin -> %s ch=%d bssid=%02x:%02x:%02x:%02x:%02x:%02x dhcp=yes (pre-begin %lu ms)",
+  if (hinted) {
+    LOG_DBG("WIFI", "WiFi.begin -> %s ch=%d bssid=%02x:%02x:%02x:%02x:%02x:%02x scan=fast dhcp=yes (pre-begin %lu ms)",
             selectedSSID.c_str(), currentAttemptChannel, currentAttemptBssid[0], currentAttemptBssid[1],
             currentAttemptBssid[2], currentAttemptBssid[3], currentAttemptBssid[4], currentAttemptBssid[5], preBeginMs);
     WiFi.begin(selectedSSID.c_str(), pwd, currentAttemptChannel, currentAttemptBssid, true);
   } else {
-    LOG_DBG("WIFI", "WiFi.begin -> %s (no hint, pre-begin %lu ms)", selectedSSID.c_str(), preBeginMs);
+    LOG_DBG("WIFI", "WiFi.begin -> %s (no hint, scan=all-channel, pre-begin %lu ms)", selectedSSID.c_str(), preBeginMs);
     if (pwd) {
       WiFi.begin(selectedSSID.c_str(), pwd);
     } else {

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -491,10 +491,28 @@ void WifiSelectionActivity::issueWifiBegin(bool useHint) {
   const char* pwd = (selectedRequiresPassword && !enteredPassword.empty()) ? enteredPassword.c_str() : nullptr;
   const unsigned long preBeginMs = millis() - connectionStartTime;
   if (hinted) {
-    LOG_DBG("WIFI", "WiFi.begin -> %s ch=%d bssid=%02x:%02x:%02x:%02x:%02x:%02x scan=fast dhcp=yes (pre-begin %lu ms)",
+    // Channel only -- deliberately NOT the BSSID, even though we have one cached.
+    //
+    // Pinning conf.sta.bssid_set made the first attempt fragile for no gain. Device capture:
+    //   WiFi.begin -> PYSY ch=11 bssid=f0:9f:... scan=fast
+    //   EVT disconnected at 2462 ms: reason=201 (NO_AP_FOUND)
+    //   EVT associated at 2614 ms
+    // The AP was plainly there -- the driver's own retry associated 150 ms later -- but the
+    // BSSID-pinned probe on that channel got no answer and burned the ~2.4 s scan timeout first.
+    // It is a coin flip: the same build associated in 201 ms on a run where the pinned probe
+    // happened to hit. That is the whole of the "mysterious flat ~2.5 s association", and our
+    // HINT_ATTEMPT_TIMEOUT_MS never sees it because the driver's internal retry rescues it.
+    //
+    // The channel is the half that earns its keep: it avoids sweeping 13 channels. Matching any
+    // BSSID for this SSID on that channel is strictly more robust, costs nothing on a
+    // single-AP network, and is the correct behaviour for mesh/roaming, where the cached radio
+    // is exactly the one that may have gone away.
+    LOG_DBG("WIFI",
+            "WiFi.begin -> %s ch=%d (cached bssid %02x:%02x:%02x:%02x:%02x:%02x not pinned) scan=fast "
+            "dhcp=yes (pre-begin %lu ms)",
             selectedSSID.c_str(), currentAttemptChannel, currentAttemptBssid[0], currentAttemptBssid[1],
             currentAttemptBssid[2], currentAttemptBssid[3], currentAttemptBssid[4], currentAttemptBssid[5], preBeginMs);
-    WiFi.begin(selectedSSID.c_str(), pwd, currentAttemptChannel, currentAttemptBssid, true);
+    WiFi.begin(selectedSSID.c_str(), pwd, currentAttemptChannel, nullptr, true);
   } else {
     LOG_DBG("WIFI", "WiFi.begin -> %s (no hint, scan=all-channel, pre-begin %lu ms)", selectedSSID.c_str(), preBeginMs);
     if (pwd) {

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -9,6 +9,7 @@
 #include <NetworkClient.h>
 #include <WiFi.h>
 #include <esp_mac.h>
+#include <esp_wifi.h>
 
 #include <cstring>
 #include <ctime>
@@ -252,11 +253,10 @@ void WifiSelectionActivity::tryNextAutoCycleCandidate() {
   connectionStartTime = millis();
   connectedIP.clear();
   connectionError.clear();
-  hintFallbackDone = false;
   requestUpdate();
 
   prepareForConnect();
-  issueWifiBegin(/*useHint=*/true);
+  issueWifiBegin();
 }
 
 void WifiSelectionActivity::processWifiScanResults() {
@@ -379,11 +379,10 @@ void WifiSelectionActivity::attemptConnection() {
   connectionStartTime = millis();
   connectedIP.clear();
   connectionError.clear();
-  hintFallbackDone = false;
   requestUpdate();
 
   prepareForConnect();
-  issueWifiBegin(/*useHint=*/true);
+  issueWifiBegin();
 }
 
 void WifiSelectionActivity::prepareForConnect() {
@@ -413,10 +412,8 @@ void WifiSelectionActivity::prepareForConnect() {
     WiFi.disconnect(true, true);
   }
 
-  // Sort ranks the results a full scan collected, so it is meaningful only under
-  // WIFI_ALL_CHANNEL_SCAN and can be set once here. The SCAN METHOD is deliberately NOT set
-  // here any more -- it is chosen per attempt in issueWifiBegin(), because the hinted and
-  // unhinted attempts need opposite ones. See the comment there.
+  // Ranks what the full scan collected, so the strongest AP for the SSID wins. This is what makes
+  // dropping the channel/BSSID hint correct on a mesh -- see issueWifiBegin().
   WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
 
   // Use stable base MAC so hostname suffix is deterministic across WiFi states.
@@ -424,102 +421,81 @@ void WifiSelectionActivity::prepareForConnect() {
   readDeviceBaseMac(baseMac);
   String hostname = "CrossPoint-Reader-" + formatMacCompact(baseMac);
   WiFi.setHostname(hostname.c_str());
+
+  applyScanBudget();
 }
 
-void WifiSelectionActivity::issueWifiBegin(bool useHint) {
-  std::memset(currentAttemptBssid, 0, 6);
-  currentAttemptChannel = 0;
+// Bounds how long the connect-time scan may take.
+//
+// esp_wifi_set_scan_parameters() is explicit that "the values set using this API are also used
+// for scans used while connecting", so this is the real knob for the full sweep issueWifiBegin()
+// now always performs -- not a workaround.
+//
+// Worth being precise about what the cost actually depends on: a scan sits on each channel for a
+// fixed dwell and collects whatever answers within it, so the duration is CHANNELS x DWELL and is
+// independent of how many SSIDs are in the air. A crowded band costs driver memory for the AP
+// record list, not time. At the IDF default of 120 ms a 13-channel sweep is ~1560 ms, which is
+// most of the ~2.57 s that unhinted associations used to take (the rest being auth/assoc).
+//
+// 80 ms puts the sweep at ~1040 ms while leaving real margin for an AP that is slow to answer a
+// probe. Going lower is where it gets risky: too short a dwell misses the AP on its channel and
+// lands back in NO_AP_FOUND plus the driver's retry, which is exactly the 2.4 s failure the
+// pinned-BSSID hint used to produce. The disconnect-reason logging in onEnter() is what would
+// show that happening, so this is tunable with evidence rather than by guesswork.
+//
+// home_chan_dwell_time is set to its documented 30 ms minimum: it only matters while already
+// associated (returning to the home channel between scanned ones), which is not this path.
+void WifiSelectionActivity::applyScanBudget() {
+  wifi_scan_default_params_t params = {};
+  params.scan_time.active.min = 0;
+  params.scan_time.active.max = SCAN_ACTIVE_DWELL_MAX_MS;
+  params.scan_time.passive = SCAN_PASSIVE_DWELL_MS;
+  params.home_chan_dwell_time = SCAN_HOME_CHAN_DWELL_MS;
+
+  // Requires station mode to have been started (returns ESP_FAIL otherwise), which is why this
+  // runs at the end of prepareForConnect() rather than alongside the other WiFi.set* calls.
+  const esp_err_t err = esp_wifi_set_scan_parameters(&params);
+  if (err != ESP_OK) {
+    LOG_DBG("WIFI", "Scan budget not applied (%s); driver defaults apply (~120 ms/channel)", esp_err_to_name(err));
+    return;
+  }
+  LOG_DBG("WIFI", "Scan budget: active<=%u ms/chan, passive %u ms, home dwell %u ms", SCAN_ACTIVE_DWELL_MAX_MS,
+          SCAN_PASSIVE_DWELL_MS, SCAN_HOME_CHAN_DWELL_MS);
+}
+
+void WifiSelectionActivity::issueWifiBegin() {
   currentAttemptAssociated = false;
 
-  if (useHint) {
-    const auto* cred = WIFI_STORE.findCredential(selectedSSID);
-    if (cred && cred->channel != 0) {
-      // Discard the cached BSSID/channel hint once it ages past the TTL. The observed IP
-      // profile is cleared with it, but is never replayed. cacheTimestamp==0 predates clock
-      // sync (trust indefinitely); now==0 means the clock isn't synced right now so we
-      // can't judge age (keep it). Signed arithmetic so a future timestamp (clock corrected
-      // backwards between write and read) reads as fresh rather than ancient.
-      constexpr int64_t TTL_SECONDS = 7 * 24 * 60 * 60;
-      const time_t now = HalClock::now();
-      const int64_t elapsed = (now == 0) ? 0 : (static_cast<int64_t>(now) - static_cast<int64_t>(cred->cacheTimestamp));
-      const bool ttlExpired = (cred->cacheTimestamp != 0) && (now != 0) && (elapsed >= TTL_SECONDS);
-      if (ttlExpired) {
-        LOG_DBG("WIFI", "Connection cache aged out (ts=%u, now=%ld), discarding for full scan + DHCP",
-                cred->cacheTimestamp, (long)now);
-        RenderLock lock(*this);  // clearConnectionCache writes the SD/SPI bus shared with the display
-        WIFI_STORE.clearConnectionCache(selectedSSID);
-      } else {
-        std::memcpy(currentAttemptBssid, cred->bssid, 6);
-        currentAttemptChannel = cred->channel;
-
-        // DHCP-derived IP and DNS data can become stale long before the hint TTL.
-        // Keep it only for diagnostics; always renew the network profile through DHCP.
-        if (cred->ip[0] != 0) {
-          IPAddress ip(cred->ip[0], cred->ip[1], cred->ip[2], cred->ip[3]);
-          IPAddress gw(cred->gateway[0], cred->gateway[1], cred->gateway[2], cred->gateway[3]);
-          IPAddress mask(cred->mask[0], cred->mask[1], cred->mask[2], cred->mask[3]);
-          IPAddress dns(cred->dns[0], cred->dns[1], cred->dns[2], cred->dns[3]);
-          LOG_DBG("WIFI", "Cached network profile ignored: ip=%s gw=%s mask=%s dns=%s ts=%u age=%lld",
-                  ip.toString().c_str(), gw.toString().c_str(), mask.toString().c_str(), dns.toString().c_str(),
-                  cred->cacheTimestamp, static_cast<long long>(elapsed));
-        }
-      }
-    }
-  }
+  // Always a full, signal-sorted scan. The cached channel/BSSID hint that used to shortcut this
+  // is gone, and the device data is unambiguous about why:
+  //
+  //  - It never paid. Hinted association measured 2517/2518/2535 ms against unhinted
+  //    2569/2571 ms -- ~40 ms apart, because under WIFI_ALL_CHANNEL_SCAN conf.sta.channel cannot
+  //    short-circuit the sweep at all.
+  //  - Made to work (WIFI_FAST_SCAN), it became a coin flip: 201 ms when the pinned probe hit,
+  //    but "EVT disconnected: reason=201 (NO_AP_FOUND)" at 2462 ms when it missed, with the
+  //    driver's own retry then associating 150 ms later. That is the whole of the supposed
+  //    "flat ~2.5 s association".
+  //  - Unpinning the BSSID to fix that broke AP selection instead: WIFI_FAST_SCAN takes the
+  //    FIRST match, and setSortMethod() only ranks what a full scan collected. On a mesh SSID it
+  //    attached to a -86 dBm AP on channel 1 in place of the -63 dBm one on channel 11.
+  //
+  // A full scan sees every AP for the SSID and sort-by-signal picks the strongest, which is the
+  // only correct answer on a mesh -- and the cost is bounded by applyScanBudget(), not by how
+  // many SSIDs are in the air.
+  WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
 
   // Reset to DHCP in case a previous attempt left a static config behind.
   WiFi.config(IPAddress(), IPAddress(), IPAddress(), IPAddress());
 
-  // The scan method is per-attempt, and it is what makes the hint mean anything at all.
-  //
-  // WIFI_ALL_CHANNEL_SCAN scans EVERY channel and collects all matching APs before connecting --
-  // that is its purpose, and it is what setSortMethod() ranks. conf.sta.channel cannot
-  // short-circuit it (Arduino folds channel, bssid and scan_method into one wifi_config_t; see
-  // STA.cpp), so under it the cached channel/BSSID saved nothing. Measured on device: hinted
-  // association 2517/2518/2535 ms vs unhinted 2569/2571 ms -- the same full scan either way,
-  // ~40 ms apart. The hint then had to finish that scan inside HINT_ATTEMPT_TIMEOUT_MS (3000 ms)
-  // with only ~480 ms to spare, and ordinary jitter tipped it into the fallback, which costs the
-  // whole timeout PLUS a fresh association (~6.6 s observed, against ~3.6 s unhinted).
-  //
-  // WIFI_FAST_SCAN stops at the first matching AP and confines the scan to conf.sta.channel,
-  // which is what the cache exists to supply. A hint that has gone stale (AP moved channel, mesh
-  // roam) now fails FAST rather than burning the timeout, and the fallback re-issues with the
-  // full scan -- so the two paths finally have the scan behaviour each was written for.
-  const bool hinted = currentAttemptChannel != 0;
-  WiFi.setScanMethod(hinted ? WIFI_FAST_SCAN : WIFI_ALL_CHANNEL_SCAN);
-
   const char* pwd = (selectedRequiresPassword && !enteredPassword.empty()) ? enteredPassword.c_str() : nullptr;
   const unsigned long preBeginMs = millis() - connectionStartTime;
-  if (hinted) {
-    // Channel only -- deliberately NOT the BSSID, even though we have one cached.
-    //
-    // Pinning conf.sta.bssid_set made the first attempt fragile for no gain. Device capture:
-    //   WiFi.begin -> PYSY ch=11 bssid=f0:9f:... scan=fast
-    //   EVT disconnected at 2462 ms: reason=201 (NO_AP_FOUND)
-    //   EVT associated at 2614 ms
-    // The AP was plainly there -- the driver's own retry associated 150 ms later -- but the
-    // BSSID-pinned probe on that channel got no answer and burned the ~2.4 s scan timeout first.
-    // It is a coin flip: the same build associated in 201 ms on a run where the pinned probe
-    // happened to hit. That is the whole of the "mysterious flat ~2.5 s association", and our
-    // HINT_ATTEMPT_TIMEOUT_MS never sees it because the driver's internal retry rescues it.
-    //
-    // The channel is the half that earns its keep: it avoids sweeping 13 channels. Matching any
-    // BSSID for this SSID on that channel is strictly more robust, costs nothing on a
-    // single-AP network, and is the correct behaviour for mesh/roaming, where the cached radio
-    // is exactly the one that may have gone away.
-    LOG_DBG("WIFI",
-            "WiFi.begin -> %s ch=%d (cached bssid %02x:%02x:%02x:%02x:%02x:%02x not pinned) scan=fast "
-            "dhcp=yes (pre-begin %lu ms)",
-            selectedSSID.c_str(), currentAttemptChannel, currentAttemptBssid[0], currentAttemptBssid[1],
-            currentAttemptBssid[2], currentAttemptBssid[3], currentAttemptBssid[4], currentAttemptBssid[5], preBeginMs);
-    WiFi.begin(selectedSSID.c_str(), pwd, currentAttemptChannel, nullptr, true);
+  LOG_DBG("WIFI", "WiFi.begin -> %s (scan=all-channel sorted-by-signal, pre-begin %lu ms)", selectedSSID.c_str(),
+          preBeginMs);
+  if (pwd) {
+    WiFi.begin(selectedSSID.c_str(), pwd);
   } else {
-    LOG_DBG("WIFI", "WiFi.begin -> %s (no hint, scan=all-channel, pre-begin %lu ms)", selectedSSID.c_str(), preBeginMs);
-    if (pwd) {
-      WiFi.begin(selectedSSID.c_str(), pwd);
-    } else {
-      WiFi.begin(selectedSSID.c_str());
-    }
+    WiFi.begin(selectedSSID.c_str());
   }
 }
 
@@ -575,13 +551,17 @@ void WifiSelectionActivity::checkConnectionStatus() {
     connectedIP = ipStr;
     autoConnecting = false;
 
-    LOG_DBG("WIFI", "Connected to %s in %lu ms (rssi=%d ch=%d ip=%s gw=%s mask=%s dns=%s hint=%s)",
-            selectedSSID.c_str(), millis() - connectionStartTime, WiFi.RSSI(), WiFi.channel(), ipStr,
-            WiFi.gatewayIP().toString().c_str(), WiFi.subnetMask().toString().c_str(), WiFi.dnsIP().toString().c_str(),
-            currentAttemptChannel != 0 ? "yes" : "no");
+    LOG_DBG("WIFI", "Connected to %s in %lu ms (rssi=%d ch=%d ip=%s gw=%s mask=%s dns=%s)", selectedSSID.c_str(),
+            millis() - connectionStartTime, WiFi.RSSI(), WiFi.channel(), ipStr, WiFi.gatewayIP().toString().c_str(),
+            WiFi.subnetMask().toString().c_str(), WiFi.dnsIP().toString().c_str());
 
-    // Cache BSSID/channel to skip channel scanning. Retain the DHCP profile only for
-    // diagnostics; reconnects always renew it. SD card operations need the display lock.
+    // Records what we actually connected to. NOTHING reads the BSSID/channel back to shortcut a
+    // later connect any more -- issueWifiBegin() always does a full signal-sorted scan, for the
+    // reasons documented there. The whole record is diagnostic now (the "Reset info" prompt below
+    // clears it, and the IP profile has been diagnostic-only for a while), so the storage in
+    // WifiCredentialStore is a candidate for deletion once the full-scan path has some mileage.
+    // Kept for now rather than widening this change into the settings serialisation.
+    // SD card operations need the display lock.
     {
       RenderLock lock(*this);
       WIFI_STORE.setLastConnectedSsid(selectedSSID);
@@ -626,32 +606,6 @@ void WifiSelectionActivity::checkConnectionStatus() {
               "completing immediately");
       onComplete(true);
     }
-    return;
-  }
-
-  // If this attempt used a hint and the hint hasn't paid off (channel may have changed
-  // because the AP is part of a mesh / roamed), retry once with a full scan before
-  // surfacing failure or moving to the next candidate. Triggered on either a hard
-  // failure status or a short timeout — whichever comes first.
-  const bool usingHint = currentAttemptChannel != 0;
-  const bool hintHardFail =
-      usingHint && !hintFallbackDone && (status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL);
-  const bool hintTimedOut = usingHint && !hintFallbackDone && !currentAttemptAssociated &&
-                            (millis() - connectionStartTime > HINT_ATTEMPT_TIMEOUT_MS);
-  if (hintHardFail || hintTimedOut) {
-    LOG_DBG("WIFI", "Hint attempt did not connect (%s after %lu ms), retrying with full scan",
-            hintHardFail ? "hard fail" : "timeout", millis() - connectionStartTime);
-    hintFallbackDone = true;
-    // Wipe the stale cache before retrying. If the fallback succeeds, the success
-    // path writes a fresh cache (one extra SD write). If it fails or is interrupted,
-    // we won't carry a known-bad hint into the next session.
-    {
-      RenderLock lock(*this);
-      WIFI_STORE.clearConnectionCache(selectedSSID);
-    }
-    WiFi.disconnect(true, false);
-    connectionStartTime = millis();
-    issueWifiBegin(/*useHint=*/false);
     return;
   }
 
@@ -763,10 +717,10 @@ void WifiSelectionActivity::loop() {
     } else if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
       if (forgetPromptSelection == 1) {
         RenderLock lock(*this);
-        // User chose "Reset info" - drop the cached BSSID/channel hint + IP/gw/mask/DNS but
-        // keep the saved password, so the next connect does a full scan + DHCP and re-fetches
-        // a fresh DNS. Fixes a stale cached DNS that survives because static config never
-        // re-pulls it from DHCP.
+        // User chose "Reset info" - drop the recorded BSSID/channel + IP/gw/mask/DNS but keep
+        // the saved password. Connects already do a full scan + DHCP unconditionally, so this is
+        // now about clearing the diagnostic record rather than changing what the next connect
+        // does.
         WIFI_STORE.clearConnectionCache(selectedSSID);
       } else if (forgetPromptSelection == 2) {
         RenderLock lock(*this);

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -64,6 +64,27 @@ void WifiSelectionActivity::onEnter() {
         LOG_DBG("WIFI", "EVT got_ip at %lu ms", millis() - connectionStartTime);
       },
       ARDUINO_EVENT_WIFI_STA_GOT_IP);
+  // STA_START = the driver finished esp_wifi_start() (PHY init + RF calibration). Splits
+  // driver bring-up from the scan/auth/assoc that follows it, which the association timestamp
+  // alone cannot: measured begin->associated is a flat ~2.5 s regardless of scan method, hint,
+  // or RSSI, and that invariance is what this pair exists to explain.
+  evtIdStaStart = WiFi.onEvent(
+      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t /*info*/) {
+        LOG_DBG("WIFI", "EVT sta_start at %lu ms (driver up; scan/auth begins here)", millis() - connectionStartTime);
+      },
+      ARDUINO_EVENT_WIFI_STA_START);
+  // The one that should settle it. A cost that flat across every configuration looks like a
+  // fixed retry/backoff rather than a negotiation, and a retry means a disconnect event with a
+  // reason code. If nothing fires between begin() and STA_CONNECTED, the ~2.5 s is genuinely
+  // the AP taking that long and there is nothing here to win; if AUTH_EXPIRE / ASSOC_EXPIRE /
+  // HANDSHAKE_TIMEOUT shows up mid-connect, that names the second we are paying for.
+  evtIdDisconnected = WiFi.onEvent(
+      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t info) {
+        const uint8_t reason = info.wifi_sta_disconnected.reason;
+        LOG_DBG("WIFI", "EVT disconnected at %lu ms: reason=%u (%s) assoc=%d", millis() - connectionStartTime, reason,
+                WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(reason)), currentAttemptAssociated ? 1 : 0);
+      },
+      ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
 
   // Load saved WiFi credentials - SD card operations need lock as we use SPI
   // for both
@@ -135,6 +156,14 @@ void WifiSelectionActivity::onExit() {
   if (evtIdGotIp != 0) {
     WiFi.removeEvent(evtIdGotIp);
     evtIdGotIp = 0;
+  }
+  if (evtIdStaStart != 0) {
+    WiFi.removeEvent(evtIdStaStart);
+    evtIdStaStart = 0;
+  }
+  if (evtIdDisconnected != 0) {
+    WiFi.removeEvent(evtIdDisconnected);
+    evtIdDisconnected = 0;
   }
 
   LOG_DBG("WIFI", "Free heap at onExit start: %d bytes", ESP.getFreeHeap());

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -116,6 +116,8 @@ class WifiSelectionActivity final : public Activity {
   // WiFi event handler IDs so we can deregister on exit.
   uint16_t evtIdConnected = 0;
   uint16_t evtIdGotIp = 0;
+  uint16_t evtIdStaStart = 0;
+  uint16_t evtIdDisconnected = 0;
 
   void renderNetworkList() const;
   void renderPasswordEntry() const;

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -86,32 +86,20 @@ class WifiSelectionActivity final : public Activity {
   // Connection timeouts
   static constexpr unsigned long CONNECTION_TIMEOUT_MS = 15000;
   static constexpr unsigned long AUTO_CYCLE_TIMEOUT_MS = 5000;
-  // Backstop for the hint attempt before falling back to a full scan.
-  //
-  // The premise this was built on ("hint-based connect completes in <2 s") does not hold on real
-  // APs. Measured on an X4 across six sessions, association is 2517/2518/2535/2569/2571/2615 ms
-  // and is INDIFFERENT to the hint and to the scan method -- the scan is not what dominates it,
-  // auth/assoc is. At 3000 ms that left ~400 ms of margin over the normal case, so ordinary
-  // jitter tripped it and paid the timeout plus a full re-association (~6.6 s vs ~3.6 s).
-  //
-  // A stale hint no longer needs a timeout to be detected: since issueWifiBegin() uses
-  // WIFI_FAST_SCAN for hinted attempts, an AP that has moved off the cached channel yields
-  // NO_AP_FOUND -> WL_NO_SSID_AVAIL almost immediately and trips the hintHardFail path instead.
-  // This value now only catches an attempt that hangs without ever reporting a hard status, so
-  // it belongs well clear of normal association time rather than just above it.
-  //
-  // Safe to enlarge: the fallback resets connectionStartTime, so it gets its own full
-  // CONNECTION_TIMEOUT_MS budget and this does not eat into it.
-  static constexpr unsigned long HINT_ATTEMPT_TIMEOUT_MS = 8000;
+  // Connect-time scan budget, applied via esp_wifi_set_scan_parameters() (see applyScanBudget()).
+  // Scan duration is CHANNELS x DWELL and independent of SSID density; 80 ms puts a 13-channel
+  // sweep at ~1040 ms against ~1560 ms at the IDF default of 120 ms, while keeping margin for an
+  // AP that is slow to answer a probe. Too short lands back in NO_AP_FOUND plus a driver retry.
+  static constexpr uint32_t SCAN_ACTIVE_DWELL_MAX_MS = 80;
+  static constexpr uint32_t SCAN_PASSIVE_DWELL_MS = 200;
+  // Documented minimum; only relevant while already associated, which this path is not.
+  static constexpr uint8_t SCAN_HOME_CHAN_DWELL_MS = 30;
+
   unsigned long connectionStartTime = 0;
 
-  // BSSID/channel hint used on the current attempt (channel==0 means no hint).
-  uint8_t currentAttemptBssid[6] = {0};
-  uint8_t currentAttemptChannel = 0;
+  // Set by the STA_CONNECTED handler; read by the disconnect log to tell a mid-connect failure
+  // apart from a drop after association.
   volatile bool currentAttemptAssociated = false;
-  // Whether we've already done the silent fallback retry without the hint for this
-  // user-initiated connection. Prevents loops if the AP genuinely isn't reachable.
-  bool hintFallbackDone = false;
 
   // WiFi event handler IDs so we can deregister on exit.
   uint16_t evtIdConnected = 0;
@@ -135,10 +123,11 @@ class WifiSelectionActivity final : public Activity {
   void selectNetwork(int index);
   void attemptConnection();
   void checkConnectionStatus();
-  // Issues WiFi.begin() either with the cached BSSID/channel hint (fast path) or without
-  // (full scan fallback). `useHint=false` clears currentAttemptChannel so the success path
-  // doesn't double-store the same hint.
-  void issueWifiBegin(bool useHint);
+  // Issues WiFi.begin() with a full, signal-sorted scan. See the definition for why the cached
+  // channel/BSSID hint that used to shortcut this was removed.
+  void issueWifiBegin();
+  // Bound the connect-time scan; see the definition.
+  void applyScanBudget();
   // Prepares the WiFi stack for a connect attempt: ensures STA mode and a clean state,
   // sets a deterministic hostname. Skips the expensive disconnect(true,true) when WiFi
   // is already idle so the warm reconnect path doesn't pay an NVS-erase cost.

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -86,10 +86,23 @@ class WifiSelectionActivity final : public Activity {
   // Connection timeouts
   static constexpr unsigned long CONNECTION_TIMEOUT_MS = 15000;
   static constexpr unsigned long AUTO_CYCLE_TIMEOUT_MS = 5000;
-  // Faster timeout for the first hint-based attempt before falling back to full scan.
-  // Hint-based connect on the correct channel usually completes in <2 s; if it doesn't,
-  // the AP has likely moved (mesh roam, channel change) so it's cheaper to bail and rescan.
-  static constexpr unsigned long HINT_ATTEMPT_TIMEOUT_MS = 3000;
+  // Backstop for the hint attempt before falling back to a full scan.
+  //
+  // The premise this was built on ("hint-based connect completes in <2 s") does not hold on real
+  // APs. Measured on an X4 across six sessions, association is 2517/2518/2535/2569/2571/2615 ms
+  // and is INDIFFERENT to the hint and to the scan method -- the scan is not what dominates it,
+  // auth/assoc is. At 3000 ms that left ~400 ms of margin over the normal case, so ordinary
+  // jitter tripped it and paid the timeout plus a full re-association (~6.6 s vs ~3.6 s).
+  //
+  // A stale hint no longer needs a timeout to be detected: since issueWifiBegin() uses
+  // WIFI_FAST_SCAN for hinted attempts, an AP that has moved off the cached channel yields
+  // NO_AP_FOUND -> WL_NO_SSID_AVAIL almost immediately and trips the hintHardFail path instead.
+  // This value now only catches an attempt that hangs without ever reporting a hard status, so
+  // it belongs well clear of normal association time rather than just above it.
+  //
+  // Safe to enlarge: the fallback resets connectionStartTime, so it gets its own full
+  // CONNECTION_TIMEOUT_MS budget and this does not eat into it.
+  static constexpr unsigned long HINT_ATTEMPT_TIMEOUT_MS = 8000;
   unsigned long connectionStartTime = 0;
 
   // BSSID/channel hint used on the current attempt (channel==0 means no hint).

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -683,6 +683,29 @@ void KOReaderSyncActivity::onExit() {
   }
 }
 
+// DISPROVEN ON DEVICE 2026-08-20 -- KOSYNC_TEST_KEEP_FB does not work. Kept, with the numbers,
+// so the idea is not re-derived from the same wrong reasoning.
+//
+// The mistake was measuring FREE heap when the binding constraint is CONTIGUOUS heap. The sync
+// has two hard contiguous gates and they are both larger than what is left once WiFi is up:
+//   - the EPUB inflate ring for progress mapping: 32768 bytes
+//   - the TLS handshake:                          26624 bytes
+// With the framebuffer kept resident: free 81192 before WiFi -> 24960 after, contig 20468. Both
+// gates failed in the same run:
+//   [ERR] [ZIP]    Failed to init inflate reader
+//   [ERR] [KOX]    Failed to decompress spine=5 to temp file
+//   [ERR] [KOSync] Insufficient contiguous heap for TLS: 19444 available, 26624 required
+// The push never happened, and the progress mapping silently degraded to a coarse xpath
+// (/body/DocFragment[6]/body instead of .../div[1]/p[14]) -- the lossy percentage-only fallback
+// ensureRemotePositionMapped() warns about. So the release is load-bearing, not over-provisioning.
+//
+// What survives is the shape of the original idea: those two gates are exactly the "who would use
+// it" answer, and they are SEQUENTIAL (ensureRemotePositionMapped() tears the TLS session down
+// before mapping, precisely so the inflate can have the contiguous heap). A 48 KB region could
+// serve the 32 KB inflate ring and then the 26.6 KB handshake -- but that needs real plumbing
+// (Epub already takes an external BuildArena; wolfSSL needs WOLFSSL_STATIC_MEMORY +
+// wolfSSL_CTX_load_static_memory, not currently enabled), not merely declining to release.
+//
 // Font cache always; the secondary framebuffer only when it is actually needed gone.
 //
 // trimMemoryForNetworkSession() releases the ~48 KB framebuffer, and its header explains why:
@@ -698,10 +721,9 @@ void KOReaderSyncActivity::onExit() {
 // across the whole session, but reallocating the framebuffer afterwards leaves contig at 25588
 // against 65524 on a clean boot. That gap is what the post-sync reboot has really been covering.
 //
-// Keeping it resident is strictly better than lending it out when there is no borrower: the
-// display keeps anti-aliasing and normal differential refresh for the sync screens, there is
-// nothing to hand back, and returnSecondaryBuffer()/reallocSecondaryBuffer() never enter the
-// picture. Behind a flag until the WiFi-bring-up half of the trade is measured on device.
+// Keeping it resident LOOKED strictly better than lending it out when there is no borrower --
+// the display would keep anti-aliasing and normal refresh, and nothing would need handing back.
+// The device disagreed; see the disproof above.
 void KOReaderSyncActivity::trimForNetwork() {
 #ifdef KOSYNC_TEST_KEEP_FB
   if (auto* fontCache = renderer.getFontCacheManager()) {

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -605,6 +605,10 @@ void KOReaderSyncActivity::onEnter() {
   // reader in single-buffer mode with nothing to restore it. Every path from here does reboot.
   trimMemoryForNetworkSession(renderer, "KOSync");
   logSyncMemSnapshot("after_trim_before_wifi");
+  // Baseline for the teardown probe in onExit(). Captured here, after the trim and before the
+  // radio comes up, so the comparison isolates what the WiFi/TLS session itself did to the heap.
+  heapBeforeWifiFree_ = esp_get_free_heap_size();
+  heapBeforeWifiContig_ = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
 
   // Check if already connected (e.g. from settings page auth)
   if (WiFi.status() == WL_CONNECTED) {
@@ -630,6 +634,7 @@ void KOReaderSyncActivity::onExit() {
   if (wifiActivated) {
     WiFi.disconnect(false);
     delay(30);
+    logWifiTeardownHeapProbe();
     switch (postAction_) {
       case KOReaderSyncPostAction::Home:
       case KOReaderSyncPostAction::OpdsSearch:
@@ -652,6 +657,49 @@ void KOReaderSyncActivity::onExit() {
         break;
     }
   }
+}
+
+// Measures whether a WiFi/TLS session really does leave the heap unusable.
+//
+// The silent reboot below exists because of a learning that a network session fragments the heap
+// past the point where the reader can be rebuilt in place. That was established BEFORE the TLS
+// stack changed from mbedtls to wolfSSL, so the premise is inherited rather than measured, and it
+// is expensive: every sync costs a full reboot plus a cold book reopen.
+//
+// This does the teardown the reboot would otherwise make unnecessary -- stop and deinit the
+// driver, not just disconnect -- and reports the result against the pre-WiFi baseline. Read the
+// contig figure, not free: fragmentation is the claim under test, and the reader needs a ~48-52 KB
+// contiguous block for its secondary framebuffer. If contig comes back to roughly its
+// before-WiFi value, the reboot is buying nothing on this stack and can go.
+//
+// Measurement only: the reboot still happens immediately after, so behaviour is unchanged whatever
+// the numbers say.
+void KOReaderSyncActivity::logWifiTeardownHeapProbe() {
+#if LOG_LEVEL < 1
+  // Nothing can report the result, so don't pay for it: the teardown below costs ~150 ms and
+  // exists purely to be measured. The reboot that follows makes it redundant either way.
+  return;
+#else
+  const uint32_t freeBeforeTeardown = esp_get_free_heap_size();
+  const uint32_t contigBeforeTeardown = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
+
+  // WIFI_OFF routes through esp_wifi_stop() + esp_wifi_deinit(), which is what actually returns
+  // the driver's buffers; WiFi.disconnect() above only drops the association.
+  WiFi.mode(WIFI_OFF);
+  delay(100);  // let the driver's deferred frees land before sampling
+
+  const uint32_t freeAfter = esp_get_free_heap_size();
+  const uint32_t contigAfter = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
+
+  LOG_INF("KOSync", "WiFi teardown heap probe: free %lu -> %lu -> %lu | contig %lu -> %lu -> %lu",
+          static_cast<unsigned long>(heapBeforeWifiFree_), static_cast<unsigned long>(freeBeforeTeardown),
+          static_cast<unsigned long>(freeAfter), static_cast<unsigned long>(heapBeforeWifiContig_),
+          static_cast<unsigned long>(contigBeforeTeardown), static_cast<unsigned long>(contigAfter));
+  LOG_INF("KOSync",
+          "WiFi teardown recovery: free %+ld contig %+ld vs before-WiFi baseline (reader needs ~49152 contig)",
+          static_cast<long>(freeAfter) - static_cast<long>(heapBeforeWifiFree_),
+          static_cast<long>(contigAfter) - static_cast<long>(heapBeforeWifiContig_));
+#endif
 }
 
 void KOReaderSyncActivity::closeCancelled() {

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -89,7 +89,7 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
   requestUpdate();
 
   logSyncMemSnapshot("before_performSync");
-  trimForNetwork();
+  trimMemoryForNetworkSession(renderer, "KOSync");
   logSyncMemSnapshot("after_trim_before_performSync");
 
   performSync();
@@ -520,7 +520,7 @@ void KOReaderSyncActivity::performUpload() {
 
   // Sync UI rendering can repopulate glyph caches after the initial GET / compare
   // phase, so trim again right before the upload request.
-  trimForNetwork();
+  trimMemoryForNetworkSession(renderer, "KOSync");
   logSyncMemSnapshot("after_trim_before_updateProgress");
 
   // Capture upload-phase memory separately from fetch phase to diagnose failures
@@ -604,12 +604,8 @@ void KOReaderSyncActivity::onEnter() {
   // Deliberately below the NO_CREDENTIALS return above: that path goes back to the reader without
   // a silent reboot, and the helper has no realloc pairing, so releasing there would leave the
   // reader in single-buffer mode with nothing to restore it. Every path from here does reboot.
-  trimForNetwork();
+  trimMemoryForNetworkSession(renderer, "KOSync");
   logSyncMemSnapshot("after_trim_before_wifi");
-  // Baseline for the teardown probe in onExit(). Captured here, after the trim and before the
-  // radio comes up, so the comparison isolates what the WiFi/TLS session itself did to the heap.
-  heapBeforeWifiFree_ = esp_get_free_heap_size();
-  heapBeforeWifiContig_ = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
 
   // Check if already connected (e.g. from settings page auth)
   if (WiFi.status() == WL_CONNECTED) {
@@ -635,29 +631,23 @@ void KOReaderSyncActivity::onExit() {
   if (wifiActivated) {
     WiFi.disconnect(false);
     delay(30);
-    logWifiTeardownHeapProbe();
-#ifdef KOSYNC_TEST_NO_REBOOT
-    // Experiment: skip the post-sync reboot so a SECOND sync can run in the same boot, which is
-    // the only way to tell a one-time cost from a per-session leak. It also tests the thing the
-    // reboot exists for, directly -- resumeReader() has already queued goToReader(), so returning
-    // here rebuilds the reader in place on a heap that has just hosted a WiFi/TLS session.
+    // The reboot stays, and it is now a measured decision rather than an inherited one.
     //
-    // Restoring the secondary framebuffer is part of the experiment, not incidental:
-    // trimMemoryForNetworkSession() released it with no realloc pairing precisely because every
-    // caller reboots (see its header). Without this the reader would come back in degraded
-    // single-buffer mode and the measurement would not represent the steady state we are asking
-    // about. Whether this realloc SUCCEEDS is itself a headline result -- it is the ~48-52 KB
-    // contiguous request that the fragmentation claim was always about.
-    LOG_INF("KOSync", "TEST: skipping the post-sync reboot; rebuilding the reader in place");
-    if (!renderer.hasSecondaryBuffer()) {  // no-op when the borrow path already handed it back
-      const bool ok = renderer.reallocSecondaryBuffer();
-      renderer.setSingleBufferFastDiff(!ok);
-      LOG_INF("KOSync", "TEST: secondary framebuffer realloc -> %s (free=%lu contig=%lu)", ok ? "OK" : "FAILED",
-              static_cast<unsigned long>(esp_get_free_heap_size()),
-              static_cast<unsigned long>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT)));
-    }
-    return;
-#else
+    // The old rationale -- "a WiFi session fragments the heap past rebuilding the reader in
+    // place" -- turned out to be wrong on wolfSSL: contig runs 61428 -> 61428 -> 61428 across a
+    // push, and only ~6 KB is lost across a pull. Rebuilding in place genuinely works, and is
+    // faster (792 ms to first page against 2023 ms via the reboot).
+    //
+    // What kills it is a different number. A full esp_wifi_stop + deinit still ends
+    // ~20.5 KB below the pre-WiFi free-heap baseline, measured at -20560 / -20588 / -20644 across
+    // three sessions -- consistent enough to look like a one-time netif/event-loop cost rather
+    // than a per-session leak, but never proven so, and 20 KB is a large permanent narrowing on a
+    // 380 KB device. Reclaiming the framebuffer late also leaves contig at 25588 against 65524
+    // on a clean boot, which is below what an image decode needs.
+    //
+    // So: the reboot is not paying for fragmentation during the session, it is paying for a heap
+    // that never fully comes back. Until that ~20 KB is identified, rebooting is the cheaper
+    // trade. Do not remove this on the strength of the contig numbers alone.
     switch (postAction_) {
       case KOReaderSyncPostAction::Home:
       case KOReaderSyncPostAction::OpdsSearch:
@@ -679,114 +669,7 @@ void KOReaderSyncActivity::onExit() {
         silentRestartToReader();
         break;
     }
-#endif
   }
-}
-
-// DISPROVEN ON DEVICE 2026-08-20 -- KOSYNC_TEST_KEEP_FB does not work. Kept, with the numbers,
-// so the idea is not re-derived from the same wrong reasoning.
-//
-// The mistake was measuring FREE heap when the binding constraint is CONTIGUOUS heap. The sync
-// has two hard contiguous gates and they are both larger than what is left once WiFi is up:
-//   - the EPUB inflate ring for progress mapping: 32768 bytes
-//   - the TLS handshake:                          26624 bytes
-// With the framebuffer kept resident: free 81192 before WiFi -> 24960 after, contig 20468. Both
-// gates failed in the same run:
-//   [ERR] [ZIP]    Failed to init inflate reader
-//   [ERR] [KOX]    Failed to decompress spine=5 to temp file
-//   [ERR] [KOSync] Insufficient contiguous heap for TLS: 19444 available, 26624 required
-// The push never happened, and the progress mapping silently degraded to a coarse xpath
-// (/body/DocFragment[6]/body instead of .../div[1]/p[14]) -- the lossy percentage-only fallback
-// ensureRemotePositionMapped() warns about. So the release is load-bearing, not over-provisioning.
-//
-// What survives is the shape of the original idea: those two gates are exactly the "who would use
-// it" answer, and they are SEQUENTIAL (ensureRemotePositionMapped() tears the TLS session down
-// before mapping, precisely so the inflate can have the contiguous heap). A 48 KB region could
-// serve the 32 KB inflate ring and then the 26.6 KB handshake -- but that needs real plumbing
-// (Epub already takes an external BuildArena; wolfSSL needs WOLFSSL_STATIC_MEMORY +
-// wolfSSL_CTX_load_static_memory, not currently enabled), not merely declining to release.
-//
-// Font cache always; the secondary framebuffer only when it is actually needed gone.
-//
-// trimMemoryForNetworkSession() releases the ~48 KB framebuffer, and its header explains why:
-// WiFi bring-up is allocation-heavy and phy_init has been seen aborting on RF calibration memory
-// with the buffer resident. But that is a general contract for network activities, and this one
-// does not fit it. Measured here: 130508 free with it released against a WiFi+TLS peak of
-// ~54.5 KB, i.e. ~76 KB of headroom -- the sync is over-provisioned by roughly the size of the
-// buffer it gives up.
-//
-// And giving it up is not free. Nothing in a sync USES that memory (the web server genuinely
-// does -- it releases BOTH buffers and never draws again), so releasing only buys a reclaim
-// later, and the reclaim is what damages the heap layout: contig is 61428 -> 61428 -> 61428
-// across the whole session, but reallocating the framebuffer afterwards leaves contig at 25588
-// against 65524 on a clean boot. That gap is what the post-sync reboot has really been covering.
-//
-// Keeping it resident LOOKED strictly better than lending it out when there is no borrower --
-// the display would keep anti-aliasing and normal refresh, and nothing would need handing back.
-// The device disagreed; see the disproof above.
-void KOReaderSyncActivity::trimForNetwork() {
-#ifdef KOSYNC_TEST_KEEP_FB
-  if (auto* fontCache = renderer.getFontCacheManager()) {
-    fontCache->clearCache();
-  }
-  LOG_INF("KOSync", "TEST: keeping the secondary framebuffer resident (hasSecondary=%d free=%lu contig=%lu)",
-          renderer.hasSecondaryBuffer() ? 1 : 0, static_cast<unsigned long>(esp_get_free_heap_size()),
-          static_cast<unsigned long>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT)));
-#else
-  trimMemoryForNetworkSession(renderer, "KOSync");
-#endif
-}
-
-// Measures whether a WiFi/TLS session really does leave the heap unusable.
-//
-// The silent reboot below exists because of a learning that a network session fragments the heap
-// past the point where the reader can be rebuilt in place. That was established BEFORE the TLS
-// stack changed from mbedtls to wolfSSL, so the premise is inherited rather than measured, and it
-// is expensive: every sync costs a full reboot plus a cold book reopen.
-//
-// This does the teardown the reboot would otherwise make unnecessary -- stop and deinit the
-// driver, not just disconnect -- and reports the result against the pre-WiFi baseline. Read the
-// contig figure, not free: fragmentation is the claim under test, and the reader needs a ~48-52 KB
-// contiguous block for its secondary framebuffer. If contig comes back to roughly its
-// before-WiFi value, the reboot is buying nothing on this stack and can go.
-//
-// Measurement only: the reboot still happens immediately after, so behaviour is unchanged whatever
-// the numbers say.
-void KOReaderSyncActivity::logWifiTeardownHeapProbe() {
-#if LOG_LEVEL < 1
-  // Nothing can report the result, so don't pay for it: the teardown below costs ~150 ms and
-  // exists purely to be measured. The reboot that follows makes it redundant either way.
-  return;
-#else
-  const uint32_t freeBeforeTeardown = esp_get_free_heap_size();
-  const uint32_t contigBeforeTeardown = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
-
-  // WIFI_OFF routes through esp_wifi_stop() + esp_wifi_deinit(), which is what actually returns
-  // the driver's buffers; WiFi.disconnect() above only drops the association.
-  WiFi.mode(WIFI_OFF);
-  delay(100);  // let the driver's deferred frees land before sampling
-
-  const uint32_t freeAfter = esp_get_free_heap_size();
-  const uint32_t contigAfter = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
-
-  // Counts WiFi sessions within THIS boot. The whole point of the no-reboot experiment is
-  // whether the free-heap shortfall is paid once (netif / default event loop, created once and
-  // never destroyed) or on every session (a real leak, which would make removing the reboot a
-  // slow bleed). Session 2's delta against session 1 is the answer.
-  static uint8_t sessionInBoot = 0;
-  ++sessionInBoot;
-
-  LOG_INF("KOSync", "WiFi teardown heap probe [session %u]: free %lu -> %lu -> %lu | contig %lu -> %lu -> %lu",
-          static_cast<unsigned>(sessionInBoot), static_cast<unsigned long>(heapBeforeWifiFree_),
-          static_cast<unsigned long>(freeBeforeTeardown), static_cast<unsigned long>(freeAfter),
-          static_cast<unsigned long>(heapBeforeWifiContig_), static_cast<unsigned long>(contigBeforeTeardown),
-          static_cast<unsigned long>(contigAfter));
-  LOG_INF("KOSync",
-          "WiFi teardown recovery [session %u]: free %+ld contig %+ld vs before-WiFi baseline (reader needs ~49152 "
-          "contig)",
-          static_cast<unsigned>(sessionInBoot), static_cast<long>(freeAfter) - static_cast<long>(heapBeforeWifiFree_),
-          static_cast<long>(contigAfter) - static_cast<long>(heapBeforeWifiContig_));
-#endif
 }
 
 void KOReaderSyncActivity::closeCancelled() {

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -1,5 +1,6 @@
 #include "KOReaderSyncActivity.h"
 
+#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalClock.h>
 #include <I18n.h>
@@ -88,7 +89,7 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
   requestUpdate();
 
   logSyncMemSnapshot("before_performSync");
-  trimMemoryForNetworkSession(renderer, "KOSync");
+  trimForNetwork();
   logSyncMemSnapshot("after_trim_before_performSync");
 
   performSync();
@@ -519,7 +520,7 @@ void KOReaderSyncActivity::performUpload() {
 
   // Sync UI rendering can repopulate glyph caches after the initial GET / compare
   // phase, so trim again right before the upload request.
-  trimMemoryForNetworkSession(renderer, "KOSync");
+  trimForNetwork();
   logSyncMemSnapshot("after_trim_before_updateProgress");
 
   // Capture upload-phase memory separately from fetch phase to diagnose failures
@@ -603,7 +604,7 @@ void KOReaderSyncActivity::onEnter() {
   // Deliberately below the NO_CREDENTIALS return above: that path goes back to the reader without
   // a silent reboot, and the helper has no realloc pairing, so releasing there would leave the
   // reader in single-buffer mode with nothing to restore it. Every path from here does reboot.
-  trimMemoryForNetworkSession(renderer, "KOSync");
+  trimForNetwork();
   logSyncMemSnapshot("after_trim_before_wifi");
   // Baseline for the teardown probe in onExit(). Captured here, after the trim and before the
   // radio comes up, so the comparison isolates what the WiFi/TLS session itself did to the heap.
@@ -648,7 +649,7 @@ void KOReaderSyncActivity::onExit() {
     // about. Whether this realloc SUCCEEDS is itself a headline result -- it is the ~48-52 KB
     // contiguous request that the fragmentation claim was always about.
     LOG_INF("KOSync", "TEST: skipping the post-sync reboot; rebuilding the reader in place");
-    if (!renderer.hasSecondaryBuffer()) {
+    if (!renderer.hasSecondaryBuffer()) {  // no-op when the borrow path already handed it back
       const bool ok = renderer.reallocSecondaryBuffer();
       renderer.setSingleBufferFastDiff(!ok);
       LOG_INF("KOSync", "TEST: secondary framebuffer realloc -> %s (free=%lu contig=%lu)", ok ? "OK" : "FAILED",
@@ -680,6 +681,38 @@ void KOReaderSyncActivity::onExit() {
     }
 #endif
   }
+}
+
+// Font cache always; the secondary framebuffer only when it is actually needed gone.
+//
+// trimMemoryForNetworkSession() releases the ~48 KB framebuffer, and its header explains why:
+// WiFi bring-up is allocation-heavy and phy_init has been seen aborting on RF calibration memory
+// with the buffer resident. But that is a general contract for network activities, and this one
+// does not fit it. Measured here: 130508 free with it released against a WiFi+TLS peak of
+// ~54.5 KB, i.e. ~76 KB of headroom -- the sync is over-provisioned by roughly the size of the
+// buffer it gives up.
+//
+// And giving it up is not free. Nothing in a sync USES that memory (the web server genuinely
+// does -- it releases BOTH buffers and never draws again), so releasing only buys a reclaim
+// later, and the reclaim is what damages the heap layout: contig is 61428 -> 61428 -> 61428
+// across the whole session, but reallocating the framebuffer afterwards leaves contig at 25588
+// against 65524 on a clean boot. That gap is what the post-sync reboot has really been covering.
+//
+// Keeping it resident is strictly better than lending it out when there is no borrower: the
+// display keeps anti-aliasing and normal differential refresh for the sync screens, there is
+// nothing to hand back, and returnSecondaryBuffer()/reallocSecondaryBuffer() never enter the
+// picture. Behind a flag until the WiFi-bring-up half of the trade is measured on device.
+void KOReaderSyncActivity::trimForNetwork() {
+#ifdef KOSYNC_TEST_KEEP_FB
+  if (auto* fontCache = renderer.getFontCacheManager()) {
+    fontCache->clearCache();
+  }
+  LOG_INF("KOSync", "TEST: keeping the secondary framebuffer resident (hasSecondary=%d free=%lu contig=%lu)",
+          renderer.hasSecondaryBuffer() ? 1 : 0, static_cast<unsigned long>(esp_get_free_heap_size()),
+          static_cast<unsigned long>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT)));
+#else
+  trimMemoryForNetworkSession(renderer, "KOSync");
+#endif
 }
 
 // Measures whether a WiFi/TLS session really does leave the heap unusable.

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -635,6 +635,28 @@ void KOReaderSyncActivity::onExit() {
     WiFi.disconnect(false);
     delay(30);
     logWifiTeardownHeapProbe();
+#ifdef KOSYNC_TEST_NO_REBOOT
+    // Experiment: skip the post-sync reboot so a SECOND sync can run in the same boot, which is
+    // the only way to tell a one-time cost from a per-session leak. It also tests the thing the
+    // reboot exists for, directly -- resumeReader() has already queued goToReader(), so returning
+    // here rebuilds the reader in place on a heap that has just hosted a WiFi/TLS session.
+    //
+    // Restoring the secondary framebuffer is part of the experiment, not incidental:
+    // trimMemoryForNetworkSession() released it with no realloc pairing precisely because every
+    // caller reboots (see its header). Without this the reader would come back in degraded
+    // single-buffer mode and the measurement would not represent the steady state we are asking
+    // about. Whether this realloc SUCCEEDS is itself a headline result -- it is the ~48-52 KB
+    // contiguous request that the fragmentation claim was always about.
+    LOG_INF("KOSync", "TEST: skipping the post-sync reboot; rebuilding the reader in place");
+    if (!renderer.hasSecondaryBuffer()) {
+      const bool ok = renderer.reallocSecondaryBuffer();
+      renderer.setSingleBufferFastDiff(!ok);
+      LOG_INF("KOSync", "TEST: secondary framebuffer realloc -> %s (free=%lu contig=%lu)", ok ? "OK" : "FAILED",
+              static_cast<unsigned long>(esp_get_free_heap_size()),
+              static_cast<unsigned long>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT)));
+    }
+    return;
+#else
     switch (postAction_) {
       case KOReaderSyncPostAction::Home:
       case KOReaderSyncPostAction::OpdsSearch:
@@ -656,6 +678,7 @@ void KOReaderSyncActivity::onExit() {
         silentRestartToReader();
         break;
     }
+#endif
   }
 }
 
@@ -691,13 +714,22 @@ void KOReaderSyncActivity::logWifiTeardownHeapProbe() {
   const uint32_t freeAfter = esp_get_free_heap_size();
   const uint32_t contigAfter = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
 
-  LOG_INF("KOSync", "WiFi teardown heap probe: free %lu -> %lu -> %lu | contig %lu -> %lu -> %lu",
-          static_cast<unsigned long>(heapBeforeWifiFree_), static_cast<unsigned long>(freeBeforeTeardown),
-          static_cast<unsigned long>(freeAfter), static_cast<unsigned long>(heapBeforeWifiContig_),
-          static_cast<unsigned long>(contigBeforeTeardown), static_cast<unsigned long>(contigAfter));
+  // Counts WiFi sessions within THIS boot. The whole point of the no-reboot experiment is
+  // whether the free-heap shortfall is paid once (netif / default event loop, created once and
+  // never destroyed) or on every session (a real leak, which would make removing the reboot a
+  // slow bleed). Session 2's delta against session 1 is the answer.
+  static uint8_t sessionInBoot = 0;
+  ++sessionInBoot;
+
+  LOG_INF("KOSync", "WiFi teardown heap probe [session %u]: free %lu -> %lu -> %lu | contig %lu -> %lu -> %lu",
+          static_cast<unsigned>(sessionInBoot), static_cast<unsigned long>(heapBeforeWifiFree_),
+          static_cast<unsigned long>(freeBeforeTeardown), static_cast<unsigned long>(freeAfter),
+          static_cast<unsigned long>(heapBeforeWifiContig_), static_cast<unsigned long>(contigBeforeTeardown),
+          static_cast<unsigned long>(contigAfter));
   LOG_INF("KOSync",
-          "WiFi teardown recovery: free %+ld contig %+ld vs before-WiFi baseline (reader needs ~49152 contig)",
-          static_cast<long>(freeAfter) - static_cast<long>(heapBeforeWifiFree_),
+          "WiFi teardown recovery [session %u]: free %+ld contig %+ld vs before-WiFi baseline (reader needs ~49152 "
+          "contig)",
+          static_cast<unsigned>(sessionInBoot), static_cast<long>(freeAfter) - static_cast<long>(heapBeforeWifiFree_),
           static_cast<long>(contigAfter) - static_cast<long>(heapBeforeWifiContig_));
 #endif
 }

--- a/src/activities/reader/KOReaderSyncActivity.h
+++ b/src/activities/reader/KOReaderSyncActivity.h
@@ -122,6 +122,9 @@ class KOReaderSyncActivity final : public Activity {
   // WiFi.getMode() because intermediate paths call esp_wifi_stop() to drop the
   // radio while user reads the result, which makes WiFi.getMode() return WIFI_MODE_NULL.
   bool wifiActivated = false;
+  // Pre-WiFi heap baseline for logWifiTeardownHeapProbe(), captured in onEnter() after the trim.
+  uint32_t heapBeforeWifiFree_ = 0;
+  uint32_t heapBeforeWifiContig_ = 0;
 
   // Captured from APP_STATE.koReaderSyncSession's postAction/postActionTarget in resumeReader()
   // so onExit() can route the silent reboot even after resumeReader() has cleared the persisted
@@ -151,6 +154,8 @@ class KOReaderSyncActivity final : public Activity {
   void performFetchAndCompare();
   void performUpload();
   void closeCancelled();
+  // Diagnostic only (see the definition): does a full WiFi teardown give the heap back?
+  void logWifiTeardownHeapProbe();
   void resumeReader(KOReaderSyncOutcomeState outcome, const SyncResult* appliedResult = nullptr);
   bool ensureEpubLoadedForMapping();
   void releaseEpubForMapping();

--- a/src/activities/reader/KOReaderSyncActivity.h
+++ b/src/activities/reader/KOReaderSyncActivity.h
@@ -122,6 +122,7 @@ class KOReaderSyncActivity final : public Activity {
   // WiFi.getMode() because intermediate paths call esp_wifi_stop() to drop the
   // radio while user reads the result, which makes WiFi.getMode() return WIFI_MODE_NULL.
   bool wifiActivated = false;
+
   // Pre-WiFi heap baseline for logWifiTeardownHeapProbe(), captured in onEnter() after the trim.
   uint32_t heapBeforeWifiFree_ = 0;
   uint32_t heapBeforeWifiContig_ = 0;
@@ -156,6 +157,9 @@ class KOReaderSyncActivity final : public Activity {
   void closeCancelled();
   // Diagnostic only (see the definition): does a full WiFi teardown give the heap back?
   void logWifiTeardownHeapProbe();
+  // Pre-network memory trim for this activity (see the definition for why it is not simply
+  // trimMemoryForNetworkSession).
+  void trimForNetwork();
   void resumeReader(KOReaderSyncOutcomeState outcome, const SyncResult* appliedResult = nullptr);
   bool ensureEpubLoadedForMapping();
   void releaseEpubForMapping();

--- a/src/activities/reader/KOReaderSyncActivity.h
+++ b/src/activities/reader/KOReaderSyncActivity.h
@@ -123,10 +123,6 @@ class KOReaderSyncActivity final : public Activity {
   // radio while user reads the result, which makes WiFi.getMode() return WIFI_MODE_NULL.
   bool wifiActivated = false;
 
-  // Pre-WiFi heap baseline for logWifiTeardownHeapProbe(), captured in onEnter() after the trim.
-  uint32_t heapBeforeWifiFree_ = 0;
-  uint32_t heapBeforeWifiContig_ = 0;
-
   // Captured from APP_STATE.koReaderSyncSession's postAction/postActionTarget in resumeReader()
   // so onExit() can route the silent reboot even after resumeReader() has cleared the persisted
   // session (Reader/Home/OpenBook all resolve their destination before the reboot happens, so
@@ -155,11 +151,6 @@ class KOReaderSyncActivity final : public Activity {
   void performFetchAndCompare();
   void performUpload();
   void closeCancelled();
-  // Diagnostic only (see the definition): does a full WiFi teardown give the heap back?
-  void logWifiTeardownHeapProbe();
-  // Pre-network memory trim for this activity (see the definition for why it is not simply
-  // trimMemoryForNetworkSession).
-  void trimForNetwork();
   void resumeReader(KOReaderSyncOutcomeState outcome, const SyncResult* appliedResult = nullptr);
   bool ensureEpubLoadedForMapping();
   void releaseEpubForMapping();


### PR DESCRIPTION
Supersedes #176 (same branch stack; #176's FAST_SCAN change is undone here by removing the hint outright). Targets `master` directly.

The through-line: instrument first, then act on what the device says. Three claims got tested; two were wrong.

## What ships

**1. Connect-phase instrumentation** — `STA_START` and `STA_DISCONNECTED` with reason code. `LOG_DBG`, compiled out in release. This is what made everything else possible and it stays as the regression detector.

**2. The connect hint is gone.** Every measurement said it wasn't worth having, and the last one said it was harmful:

- It never paid: hinted association 2517/2518/2535 ms vs unhinted 2569/2571 ms — ~40 ms apart, because `conf.sta.channel` can't short-circuit `WIFI_ALL_CHANNEL_SCAN`.
- Made to work (`WIFI_FAST_SCAN`), it became a coin flip: 201 ms when the pinned probe hit, `reason=201 (NO_AP_FOUND)` at 2462 ms when it missed — with the driver's own retry associating 150 ms later. **That is the entire "mysterious flat ~2.5 s association".**
- Unpinning the BSSID to fix that broke AP selection: `WIFI_FAST_SCAN` takes the *first* match and `setSortMethod()` only ranks a full scan, so on a mesh SSID it attached to a **−86 dBm AP on channel 1** instead of the −63 dBm one on channel 11.

So `issueWifiBegin()` always does a full signal-sorted scan — the only configuration that picks the best AP on a mesh. `HINT_ATTEMPT_TIMEOUT_MS`, the fallback retry, and the per-attempt BSSID/channel state go with it.

**3. The scan is bounded instead.** `applyScanBudget()` uses `esp_wifi_set_scan_parameters()`, documented as applying to "scans used while connecting". Scan cost is **channels × dwell and independent of SSID density** — a crowded band costs driver memory for the AP list, not time. 80 ms/channel puts a sweep at ~880–1040 ms against ~1560 ms at the IDF default of 120 ms.

### Device result

```
[WIFI] Scan budget: active<=80 ms/chan, passive 200 ms, home dwell 30 ms
[WIFI] WiFi.begin -> PYSY (scan=all-channel sorted-by-signal, pre-begin 44 ms)
[WIFI] EVT associated at 1686 ms
[WIFI] Connected to PYSY in 3206 ms (rssi=-62 ch=11 ...)
```

Right AP, no `NO_AP_FOUND`, deterministic.

| config | total | AP | deterministic |
|---|---|---|---|
| original (ALL_CHANNEL + BSSID pin) | 4135 ms, 6.6 s on fallback | ch 11 | no |
| FAST_SCAN + BSSID pin | 1718 ms hit / 3629 ms miss | ch 11 | no |
| FAST_SCAN + channel only | 1403 ms | ch 1 @ −86 ❌ | wrongly |
| **this PR** | **3206 ms** | **ch 11 @ −62** ✅ | **yes** |

Stated plainly: this is **slower than a lucky hint hit** (3206 vs 1718 ms). It buys correctness and determinism, and removes the 6.6 s tail. DHCP is now 1512 ms — 47% of the total — and is the obvious next target (cached profile + gateway reachability probe + DHCP fallback), not more scan tuning.

## What was tested and reverted

Two experiments ran on device and were removed. The findings are preserved as comments at the relevant call sites.

**`KOSYNC_TEST_KEEP_FB` — disproven.** I argued the sync over-provisions by releasing the framebuffer. Wrong: I reasoned about *free* heap when the binding constraint is *contiguous* heap. Two hard gates — the EPUB inflate ring (32768) and the TLS handshake (26624) — both failed with it resident:

```
[ERR] [ZIP]    Failed to init inflate reader
[ERR] [KOSync] Insufficient contiguous heap for TLS: 19444 available, 26624 required
```

The push never happened and the mapping silently degraded to a coarse xpath. **The release is load-bearing.**

**`KOSYNC_TEST_NO_REBOOT` — the reboot stays, for a different reason than the one in the old comment.** The inherited rationale ("a WiFi session fragments the heap") is *false* on wolfSSL: contig runs 61428 → 61428 → 61428 across a push, ~6 KB lost on a pull, the framebuffer reallocs fine, and rebuilding the reader in place works and is **faster** (792 ms to first page vs 2023 ms via the reboot).

What kills it is that a full `esp_wifi_stop` + `deinit` still ends **~20.5 KB below** the pre-WiFi baseline — −20560 / −20588 / −20644 across three sessions. That consistency looks like a one-time netif/event-loop cost rather than a per-session leak, but it was never proven, and a permanent 20 KB narrowing on a 380 KB device isn't worth the reboot it saves. The reasoning now lives at the call site with the numbers, so it isn't re-derived from the old (wrong) comment.

