### PR TITLE
fix(sax): ignore trailing non-XML data after the root element closes

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -2766,15 +2766,16 @@ bool ChapterHtmlSlimParser::finalize() {
   // truncated (dropped) the excess. Surface it so out-of-bounds documents are
   // diagnosable rather than failing invisibly (e.g. XPath/anchor drift). Also
   // surfaces voidTag: the source had an HTML-style unclosed void element
-  // (<br>, <hr>, ...) that the parser auto-closed rather than failing on.
+  // (<br>, <hr>, ...) that the parser auto-closed rather than failing on, and
+  // trailingData: the file had padding bytes after </html> that were ignored.
   if (const uint32_t trunc = saxParser_.truncationFlags()) {
     LOG_DBG("EHP",
             "SaxParser hit fixed-capacity limits (flags=0x%lx): elemName=%d attrName=%d attrVal=%d maxAttrs=%d "
-            "maxDepth=%d voidTag=%d",
+            "maxDepth=%d voidTag=%d trailingData=%d",
             static_cast<unsigned long>(trunc), (trunc & SaxParser::kTruncElemName) != 0,
             (trunc & SaxParser::kTruncAttrName) != 0, (trunc & SaxParser::kTruncAttrValue) != 0,
             (trunc & SaxParser::kTruncMaxAttrs) != 0, (trunc & SaxParser::kTruncMaxDepth) != 0,
-            (trunc & SaxParser::kVoidTagRepaired) != 0);
+            (trunc & SaxParser::kVoidTagRepaired) != 0, (trunc & SaxParser::kTrailingDataIgnored) != 0);
   }
 
   // Process last page if there is still text. Done unconditionally so that a partial

--- a/lib/SaxParser/SaxParser/SaxParser.h
+++ b/lib/SaxParser/SaxParser/SaxParser.h
@@ -58,12 +58,13 @@ class SaxParser {
   // result is lossy. Callers with logging should surface a non-zero value so
   // field cases that exceed the bounds are diagnosable. Always 0 for expat.
   enum TruncationFlag : uint32_t {
-    kTruncElemName = 1u << 0,    // element name longer than kElemNameLen
-    kTruncAttrName = 1u << 1,    // attribute name longer than kElemNameLen
-    kTruncAttrValue = 1u << 2,   // attribute value longer than kAttrValueLen
-    kTruncMaxAttrs = 1u << 3,    // more than kMaxAttrs attributes on one element
-    kTruncMaxDepth = 1u << 4,    // nesting deeper than kMaxDepth
-    kVoidTagRepaired = 1u << 5,  // HTML-style unclosed void tag (<br>, <hr>, ...) auto-closed
+    kTruncElemName = 1u << 0,        // element name longer than kElemNameLen
+    kTruncAttrName = 1u << 1,        // attribute name longer than kElemNameLen
+    kTruncAttrValue = 1u << 2,       // attribute value longer than kAttrValueLen
+    kTruncMaxAttrs = 1u << 3,        // more than kMaxAttrs attributes on one element
+    kTruncMaxDepth = 1u << 4,        // nesting deeper than kMaxDepth
+    kVoidTagRepaired = 1u << 5,      // HTML-style unclosed void tag (<br>, <hr>, ...) auto-closed
+    kTrailingDataIgnored = 1u << 6,  // bytes after the root element's end tag; parse stopped there
   };
   uint32_t truncationFlags() const;
 

--- a/lib/SaxParser/SaxParserYxml.cpp
+++ b/lib/SaxParser/SaxParserYxml.cpp
@@ -85,6 +85,14 @@ struct SaxParserImpl {
   char elemStack[kMaxDepth][kElemNameLen];
   size_t elemDepth = 0;
 
+  // Open-element count and root-closed latch, for the trailing-data tolerance in
+  // dispatchToken(). Deliberately NOT elemDepth: that one stops growing at
+  // kMaxDepth (the name stack is fixed-capacity) while still counting every
+  // close, so an over-deep document would drive it to zero -- and latch the root
+  // as closed -- with real elements still open. This counter has no capacity.
+  size_t openElems = 0;
+  bool rootClosed = false;
+
   // Running byte offset (updated once per yxml_parse call).
   uint32_t byteOffset = 0;
 
@@ -264,6 +272,31 @@ bool SaxParser::feed(const uint8_t* buf, size_t len) {
     }
     impl->byteOffset = static_cast<uint32_t>(impl->x.total);
     if (r < 0) {
+      // ---------------------------------------------------------------------------
+      // Trailing non-XML data after the root element
+      //
+      // Real EPUBs turn up with padding bytes (\x05\x05..., \x02\x02, \x10\x10...)
+      // appended after </html>. Browsers and HTML parsers ignore anything past the
+      // root close; yxml is a strict XML engine and reports a syntax error, which
+      // fails the whole chapter parse even though every byte of content was already
+      // delivered. On this firmware that lands as a section cache marked
+      // truncatedCache, so the finished build is discarded, rebuilt on the released
+      // path and the reading position resets -- for every spine of the book.
+      //
+      // Once the root element has closed the document is complete, so treat any
+      // error past that point as end-of-input: stop (no further callbacks, and
+      // finalize() reports success) and record the repair for the caller's log.
+      //
+      // Ported from crosspoint-reader#3134 by Yo'av Moshe (@bjesus), which fixed the
+      // same failure in their expat backend by latching on </html>. The latch here
+      // is the root element close instead of a tag name, so it covers the OPF, NCX,
+      // nav and page-map parsers too.
+      // ---------------------------------------------------------------------------
+      if (impl->rootClosed) {
+        impl->truncFlags |= SaxParser::kTrailingDataIgnored;
+        stopped_ = true;
+        return true;
+      }
       errorLine_ = static_cast<int>(impl->x.line);
       errorString_ = "yxml parse error";
       return false;
@@ -272,6 +305,7 @@ bool SaxParser::feed(const uint8_t* buf, size_t len) {
       case YXML_ELEMSTART:
         if (impl->inOpeningTag) fireStart(impl);
         flushChar(impl);
+        ++impl->openElems;
         if (strlen(impl->x.elem) > kElemNameLen - 1) impl->truncFlags |= SaxParser::kTruncElemName;
         strncpy(impl->pendingElem, impl->x.elem, kElemNameLen - 1);
         impl->pendingElem[kElemNameLen - 1] = '\0';
@@ -311,6 +345,7 @@ bool SaxParser::feed(const uint8_t* buf, size_t len) {
           impl->endCb(impl->userData, impl->elemStack[impl->elemDepth - 1]);
         }
         if (impl->elemDepth > 0) --impl->elemDepth;
+        if (impl->openElems > 0 && --impl->openElems == 0) impl->rootClosed = true;
         break;
       case YXML_PISTART:
       case YXML_PICONTENT:

--- a/test/sax_parser/SaxParserTest.cpp
+++ b/test/sax_parser/SaxParserTest.cpp
@@ -667,3 +667,123 @@ TEST(SaxParser, PairedBrAndImgInBodyAreDropped) {
   EXPECT_TRUE(sawTwo);
   EXPECT_TRUE(sawAfter);
 }
+
+// ---------------------------------------------------------------------------
+// Trailing data after the root element (crosspoint-reader#3134)
+// ---------------------------------------------------------------------------
+
+TEST(SaxParser, TrailingPaddingBytesAfterRootAreIgnored) {
+  // Real EPUBs carry padding bytes after </html>. Every callback must still fire,
+  // the parse must succeed, and the repair must be reported.
+  const std::string xml = std::string("<html><body>hello</body></html>") + std::string(3, '\x05');
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml.data());
+  EXPECT_TRUE(p.feed(bytes, xml.size()));
+  EXPECT_TRUE(p.finalize());
+  EXPECT_TRUE(p.truncationFlags() & SaxParser::kTrailingDataIgnored);
+
+  ASSERT_EQ(c.events.size(), 5u);
+  EXPECT_EQ(c.events[2].text, "hello");
+  EXPECT_EQ(c.events[4].type, Event::Type::End);
+  EXPECT_EQ(c.events[4].name, "html");
+}
+
+TEST(SaxParser, TrailingDataToleranceAppliesToStrictParsers) {
+  // The latch is the root element close, not a tag name, so the strict-XML
+  // parsers (OPF, NCX, container, page-map, OPDS) get the same tolerance.
+  const std::string xml = std::string("<package><metadata/></package>") + std::string(2, '\x02');
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar));
+
+  const auto* bytes = reinterpret_cast<const uint8_t*>(xml.data());
+  EXPECT_TRUE(p.feed(bytes, xml.size()));
+  EXPECT_TRUE(p.finalize());
+  EXPECT_TRUE(p.truncationFlags() & SaxParser::kTrailingDataIgnored);
+  EXPECT_TRUE(p.isStopped());
+}
+
+TEST(SaxParser, TrailingDataInASeparateFeedIsIgnored) {
+  // The padding usually arrives in the last chunk of the streamed spine, after
+  // the chunk that closed the root — and every later chunk must be a no-op too.
+  const char* doc = "<html><body>hi</body></html>";
+  const char* pad = "\x10\x10\x10";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  ASSERT_TRUE(p.feed(reinterpret_cast<const uint8_t*>(doc), strlen(doc)));
+  const size_t eventsAtRootClose = c.events.size();
+  EXPECT_TRUE(p.feed(reinterpret_cast<const uint8_t*>(pad), strlen(pad)));
+  EXPECT_TRUE(p.feed(reinterpret_cast<const uint8_t*>(pad), strlen(pad)));
+  EXPECT_TRUE(p.finalize());
+
+  EXPECT_EQ(c.events.size(), eventsAtRootClose);  // no callbacks after the root closed
+}
+
+TEST(SaxParser, MalformedMarkupBeforeRootCloseStillFails) {
+  // The tolerance must not swallow a real error inside the document: the same
+  // class of syntax error one tag earlier is corruption, not trailing junk.
+  const char* xml = "<html><body>hello</body></wrong></html>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  EXPECT_FALSE(p.feed(reinterpret_cast<const uint8_t*>(xml), strlen(xml)));
+  EXPECT_STRNE(p.errorString(), "");
+}
+
+TEST(SaxParser, SiblingAfterRootCloseIsIgnoredNotParsed) {
+  // A well-formed-looking second root is still past the end of the document.
+  // yxml rejects it; we stop there rather than failing the whole parse.
+  const char* xml = "<html><body>hi</body></html><html><body>ignored</body></html>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  EXPECT_TRUE(p.feed(reinterpret_cast<const uint8_t*>(xml), strlen(xml)));
+  EXPECT_TRUE(p.finalize());
+  for (const auto& e : c.events) {
+    EXPECT_NE(e.text, "ignored");
+  }
+}
+
+TEST(SaxParser, TrailingWhitespaceKeepsFlagsClear) {
+  // Whitespace after the root is legal XML: no error, and nothing to report.
+  const char* xml = "<html><body>hi</body></html>\n\n";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar, nullptr, /*htmlVoidTagRepair=*/true));
+
+  EXPECT_TRUE(p.feed(reinterpret_cast<const uint8_t*>(xml), strlen(xml)));
+  EXPECT_TRUE(p.finalize());
+  EXPECT_EQ(p.truncationFlags(), 0u);
+  EXPECT_FALSE(p.isStopped());
+}
+
+TEST(SaxParser, DeepNestingDoesNotLatchRootClosedEarly) {
+  // The latch counts opens/closes without a capacity limit, unlike the fixed
+  // kMaxDepth name stack: a document nested past that stack must NOT look like
+  // it closed its root partway through, or later corruption would be ignored.
+  std::string xml = "<r>";
+  constexpr int kDeep = 64;  // <r> plus this many: deeper than the element-name stack
+  for (int i = 0; i < kDeep; ++i) xml += "<d>";
+  for (int i = 0; i < kDeep; ++i) xml += "</d>";
+  xml += "</wrong>";  // corruption INSIDE <r>, must still fail
+  xml += "</r>";
+
+  Collector c;
+  SaxParser p;
+  ASSERT_TRUE(p.init(&c, Collector::onStart, Collector::onEnd, Collector::onChar));
+
+  EXPECT_FALSE(p.feed(reinterpret_cast<const uint8_t*>(xml.data()), xml.size()));
+}


### PR DESCRIPTION
Ported from [crosspoint-reader#3134](https://github.com/crosspoint-reader/crosspoint-reader/pull/3134) by Yo'av Moshe ([@bjesus](https://github.com/bjesus)), who found and fixed this on the expat backend.

## Problem

Real EPUBs turn up with padding bytes appended after `</html>` (`\x05\x05...`, `\x02\x02`, `\x10\x10...`). Browsers ignore anything past the root close; yxml is a strict XML engine and reports a syntax error — so the chapter parse fails after every byte of content has already been delivered.

Confirmed on the host before writing anything: feeding `<html><body>hello</body></html>\x05\x05\x05` fires all callbacks, then `feed()` returns false. Trailing whitespace is fine; any non-whitespace byte past the root close fails.

On this firmware the fallout is worse than a lost parse. `write()` returns short → the build ends with `parserStreamOk=false` → `runBuildFinalize` keeps the pages but writes `parseComplete=false`, which becomes `truncatedCache`. Every consumer of that flag reads it as memory-pressure damage:

- `EpubReaderActivity.cpp:1429` — Background-B discards the finished build and forces a foreground rebuild
- `EpubReaderActivity.cpp:1597` — Background-C calls `fallbackToReleasedRebuild("incomplete")`, which is where the reported reset to page 0 comes from
- `EpubReaderActivity.cpp:3524` — the reader shows the truncated-section mitigation hint

For such a book that happens on every spine, every time: builds thrown away and redone on the slow released path, forever, plus a misleading low-memory hint.

## Fix

Latch the root element close in the yxml backend and treat any error past it as end of input: `stop()` (no further callbacks, `finalize()` reports success), and set a new `kTrailingDataIgnored` truncation flag so the EHP log still names the repair.

Upstream latches on seeing `</html>` in `endElement()`, which is chapter-specific. Latching on the root close instead of a tag name extends the tolerance to the OPF, NCX, container, nav, page-map and OPDS parsers, which share this backend.

The latch counts opens/closes in its own unbounded counter rather than reusing `elemDepth`. `elemDepth` saturates at the fixed-capacity `kMaxDepth` (64) name stack but still decrements on every close, so a document nested deeper than that would drive it to zero with real elements still open — and from there start swallowing genuine corruption. `DeepNestingDoesNotLatchRootClosedEarly` covers that case; I checked it actually fails against the `elemDepth` version before keeping the counter.

## Testing

- 500/500 host tests pass (`ctest -j4`), including 7 new ones: padding bytes after the root, padding arriving in a later feed, the strict-parser path, a second root element, trailing whitespace keeping flags clear, malformed markup *before* the root close still failing, and the deep-nesting guard.
- `pio run` builds clean (flash 92.8%).
- **Not device-validated.** The host tests prove the parser behaviour; the payoff — a padded book no longer marking every section `truncatedCache` — is only observable on hardware with such an EPUB.