### PR TITLE
fix: crash closing a HalFile that was never opened

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -563,7 +563,11 @@ bool Section::loadSectionFile(const BuildParams& p) {
 }
 
 bool Section::clearCache() {
-  file.close();  // Must be closed before removal on FAT32
+  // Only close a handle we actually opened: a Section whose cache is cleared before it ever
+  // loaded or built (settings change on a freshly constructed Section) still holds the default
+  // handle, and HalFile::close() asserts on those. Same reason as the guards in runBuildSetup
+  // and abortBuild.
+  if (file) file.close();  // Must be closed before removal on FAT32
   lut.clear();
   tocBoundaries.clear();
   pageCount = 0;
@@ -806,7 +810,9 @@ Section::BuildPhaseResult Section::runBuildSetup(BuildState& st) {
   // Reset build state — createSectionFile may be called on a Section that previously
   // loaded a cache (e.g. fallback no-CSS file). pageCount must start at 0 so that
   // onPageComplete() numbering and paragraphLutPerPage stay in lockstep.
-  file.close();
+  // "Previously loaded" is the exception, not the rule: on a first build this handle has never
+  // been opened, and closing one of those asserts inside the HAL.
+  if (file) file.close();
   pageCount = 0;
   this->lut.clear();
   cssLowHeapDegraded_ = false;
@@ -1656,7 +1662,9 @@ void Section::abortSectionBuild() {
   }
   // During a live build, `file` is the build's write handle and filePath its cache path
   // (both set by runBuildSetup). The header was never patched, so remove the file.
-  file.close();
+  // An abort before runBuildSetup got as far as opening it leaves the handle untouched, and
+  // closing an unopened handle asserts.
+  if (file) file.close();
   Storage.remove(filePath.c_str());
   if (buildState_->cssParser) {
     buildState_->cssParser->clear();

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -254,10 +254,17 @@ bool ContentOpfParser::setup() {
   return true;
 }
 
-ContentOpfParser::~ContentOpfParser() {
+// The item store is only opened when there is a cache to serve (see the manifest/spine branches in
+// startElement), so a null-cache parse reaches the manifest/spine/guide end tags with a handle that
+// was never opened. One place to ask that question, instead of four.
+void ContentOpfParser::closeItemStore() {
   if (tempItemStore) {
     tempItemStore.close();
   }
+}
+
+ContentOpfParser::~ContentOpfParser() {
+  closeItemStore();
   const auto itemCachePath = cachePath + itemCacheFile;
   if (Storage.exists(itemCachePath.c_str())) {
     Storage.remove(itemCachePath.c_str());
@@ -400,19 +407,31 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
 
   if (self->state == IN_PACKAGE && isManifestTag(name)) {
     self->state = IN_MANIFEST;
-    if (!Storage.openFileForWrite("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
-      LOG_ERR("COF", "Couldn't open temp items file for writing. This is probably going to be a fatal error.");
+    // The item store exists for ONE job: resolving spine idrefs to hrefs, which only happens when
+    // there is a cache to write spine entries into. A cover/metadata load (OpfCacheMode::Disabled)
+    // passes a null cache and skips spine parsing entirely, so building the store there wrote the
+    // whole manifest to SD for nothing — and, because those load paths never call setupCacheDir(),
+    // usually failed to open at all and logged three "probably going to be a fatal error" lines per
+    // book per pass. coverItemHref does not come from here; it is matched inline as items stream by.
+    if (self->cache) {
+      if (!Storage.openFileForWrite("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
+        LOG_ERR("COF", "Couldn't open temp items file for writing. This is probably going to be a fatal error.");
+      }
+      self->itemWriter_.emplace(self->tempItemStore);
     }
-    self->itemWriter_.emplace(self->tempItemStore);
     return;
   }
 
   if (self->state == IN_PACKAGE && isSpineTag(name)) {
     self->state = IN_SPINE;
-    if (!Storage.openFileForRead("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
-      LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
+    // No cache => no spine parsing (see the isItemRefTag branch), so nothing will read this.
+    // resolveSpineItemRefHref() already treats an absent reader as "cannot resolve".
+    if (self->cache) {
+      if (!Storage.openFileForRead("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
+        LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
+      }
+      self->itemReader_.emplace(self->tempItemStore);
     }
-    self->itemReader_.emplace(self->tempItemStore);
 
     // Sort item index for binary search if we have enough items
     if (self->itemIndex.size() >= LARGE_SPINE_THRESHOLD) {
@@ -448,8 +467,12 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
     self->state = IN_GUIDE;
     // TODO Remove print
     LOG_DBG("COF", "Entering guide state.");
-    if (!Storage.openFileForRead("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
-      LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
+    // Guide references carry their own href attribute and never consult the item store, so this
+    // open only has to keep the (cached) reader pointing at a valid handle.
+    if (self->cache) {
+      if (!Storage.openFileForRead("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
+        LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
+      }
     }
     return;
   }
@@ -550,7 +573,7 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
     // Write items down to SD card (buffered — thousands of tiny field writes otherwise cost a
     // full FsFile call each). The index entry records the position AFTER the id string:
     // hash-trusted lookups seek straight to the href and never re-read the id.
-    self->itemWriter_->writeString(itemId);
+    if (self->itemWriter_.has_value()) self->itemWriter_->writeString(itemId);
     if (self->tempItemStore && !self->indexDisabled_) {
       ItemIndexEntry entry;
       entry.idHash = fnvHash(itemId);
@@ -568,7 +591,7 @@ void ContentOpfParser::startElement(void* userData, const char* name, const char
         self->itemIndex.clear();  // free the partial index; lookups use the linear scan
       }
     }
-    self->itemWriter_->writeString(href);
+    if (self->itemWriter_.has_value()) self->itemWriter_->writeString(href);
 
     if (itemId == self->coverItemId) {
       // Some EPUBs set meta name="cover" to an XHTML wrapper item.
@@ -704,13 +727,13 @@ void ContentOpfParser::endElement(void* userData, const char* name) {
   if (self->state == IN_SPINE && isSpineTag(name)) {
     self->state = IN_PACKAGE;
     self->itemReader_.reset();
-    self->tempItemStore.close();
+    self->closeItemStore();
     return;
   }
 
   if (self->state == IN_GUIDE && isGuideTag(name)) {
     self->state = IN_PACKAGE;
-    self->tempItemStore.close();
+    self->closeItemStore();
     return;
   }
 
@@ -721,7 +744,7 @@ void ContentOpfParser::endElement(void* userData, const char* name) {
       self->itemWriter_->flush();
       self->itemWriter_.reset();
     }
-    self->tempItemStore.close();
+    self->closeItemStore();
     return;
   }
 

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -124,6 +124,8 @@ class ContentOpfParser final : public Print {
   bool resolveItemRefHrefWithIndex(const std::string& idref, std::string& href);
   bool resolveItemRefHrefLinearScan(const std::string& idref, std::string& href);
   bool resolveSpineItemRefHref(const std::string& idref, std::string& href);
+  // Closes tempItemStore if it was ever opened — a null-cache parse never opens it.
+  void closeItemStore();
   void handleSpineItemRefElement(const char** atts);
 
  public:

--- a/test/epub_opf/ContentOpfParserTest.cpp
+++ b/test/epub_opf/ContentOpfParserTest.cpp
@@ -145,6 +145,47 @@ TEST(ContentOpfParser, ExtractsMetadataManifestAndGuideFields) {
   EXPECT_EQ(parser.guideCoverPageHref, "book/OEBPS/text/cover.xhtml");
 }
 
+// A cover/metadata load (Epub::loadForCover / loadForMetadata) passes a null cache. It must still
+// resolve the EPUB2 <meta name="cover"> -> manifest image item, and it must NOT build the .items.bin
+// item store: that store exists only to resolve spine idrefs, which a null cache skips entirely.
+// Building it there wrote the whole manifest to SD per cover pass and — since those load paths never
+// call setupCacheDir() — usually failed to open and logged three "probably fatal" errors per book.
+TEST(ContentOpfParser, ResolvesMetaCoverWithoutCacheAndWritesNoItemStore) {
+  const std::string cacheDir = makeTempDir();
+  ASSERT_FALSE(cacheDir.empty());
+  TempDirGuard dirGuard(cacheDir);
+
+  const std::string base = "/book/OEBPS/";
+  const std::string xml =
+      "<?xml version='1.0' encoding='utf-8'?>"
+      "<package xmlns:opf='http://www.idpf.org/2007/opf' xmlns:dc='http://purl.org/dc/elements/1.1/'>"
+      "<metadata>"
+      "<dc:title>Cover By Meta</dc:title>"
+      "<meta name='cover' content='cover-img'/>"
+      "</metadata>"
+      "<manifest>"
+      "<item id='chap1' href='text/chapter-1.xhtml' media-type='application/xhtml+xml'/>"
+      "<item id='cover-img' href='images/front.jpeg' media-type='image/jpeg'/>"
+      "</manifest>"
+      "<spine>"
+      "<itemref idref='chap1'/>"
+      "</spine>"
+      "</package>";
+
+  ContentOpfParser parser(cacheDir, base, xml.size(), nullptr);
+  ASSERT_TRUE(parseOpfXml(parser, xml));
+
+  // The cover href is matched inline as manifest items stream past — never read back from the
+  // item store — so dropping the store cannot break it.
+  EXPECT_EQ(parser.coverItemHref, "book/OEBPS/images/front.jpeg");
+  EXPECT_EQ(parser.title, "Cover By Meta");
+
+  // The store must never have been created. (The destructor removes it, so check while the
+  // parser is still alive.)
+  EXPECT_FALSE(std::filesystem::exists(cacheDir + "/.items.bin"))
+      << "null-cache parse built an item store it will never read";
+}
+
 TEST(ContentOpfParser, DecodesNumericCharacterReferencesInDescription) {
   const std::string cacheDir = makeTempDir();
   ASSERT_FALSE(cacheDir.empty());

--- a/test/shims/HalStorage.h
+++ b/test/shims/HalStorage.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -30,6 +31,7 @@ class HalFile : public Print {
     HalFile f;
     f.backing_ = std::move(content);
     f.hasData_ = true;
+    f.hasImpl_ = true;
     return f;
   }
 
@@ -40,6 +42,16 @@ class HalFile : public Print {
     HalFile f;
     f.hasData_ = true;
     f.writable_ = true;
+    f.hasImpl_ = true;
+    return f;
+  }
+
+  // A handle HalStorage tried to open. Device parity: HalStorage hands out an Impl even when the
+  // open FAILED, so close() is legal on it — unlike a handle nobody ever opened. The stubs below
+  // return one from every open call for exactly that reason.
+  static HalFile opened() {
+    HalFile f;
+    f.hasImpl_ = true;
     return f;
   }
 
@@ -90,8 +102,17 @@ class HalFile : public Print {
   bool getModifyDateTime(uint16_t*, uint16_t*) { return false; }
   bool isDirectory() const { return false; }
   void rewindDirectory() {}
-  bool close() { return false; }
-  HalFile openNextFile() { return HalFile{}; }
+  // Device parity, deliberately fatal: HalFile::close() asserts on a handle that was never opened
+  // (impl == nullptr), so closing one must fail here too — otherwise the bug is invisible on the
+  // host and aborts in the reader's hands. Not assert(): host tests build with NDEBUG.
+  bool close() {
+    if (!hasImpl_) {
+      std::fprintf(stderr, "HalFile::close() on a handle that was never opened — this aborts on device\n");
+      std::abort();
+    }
+    return false;
+  }
+  HalFile openNextFile() { return opened(); }
   bool isOpen() const { return hasData_; }
   operator bool() const { return hasData_; }
 
@@ -100,6 +121,7 @@ class HalFile : public Print {
   size_t pos_ = 0;
   bool hasData_ = false;
   bool writable_ = false;
+  bool hasImpl_ = false;
 };
 
 using FsFile = HalFile;
@@ -114,20 +136,44 @@ class HalStorage {
   size_t readFileToBuffer(const char*, char*, size_t, size_t = 0) { return 0; }
   bool writeFile(const char*, const String&) { return false; }
   bool ensureDirectoryExists(const char*) { return false; }
-  HalFile open(const char*, int = 0) { return HalFile{}; }
+  HalFile open(const char*, int = 0) { return HalFile::opened(); }
   bool mkdir(const char*, bool = true) { return false; }
   bool exists(const char*) { return false; }
   bool remove(const char*) { return false; }
   bool rename(const char*, const char*) { return false; }
   bool rmdir(const char*) { return false; }
-  bool openFileForRead(const char*, const char*, HalFile&) { return false; }
-  bool openFileForRead(const char*, const std::string&, HalFile&) { return false; }
-  bool openFileForRead(const char*, const String&, HalFile&) { return false; }
-  bool openFileForUpdate(const char*, const char*, HalFile&) { return false; }
-  bool openFileForUpdate(const char*, const std::string&, HalFile&) { return false; }
-  bool openFileForWrite(const char*, const char*, HalFile&) { return false; }
-  bool openFileForWrite(const char*, const std::string&, HalFile&) { return false; }
-  bool openFileForWrite(const char*, const String&, HalFile&) { return false; }
+  bool openFileForRead(const char*, const char*, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
+  bool openFileForRead(const char*, const std::string&, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
+  bool openFileForRead(const char*, const String&, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
+  bool openFileForUpdate(const char*, const char*, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
+  bool openFileForUpdate(const char*, const std::string&, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
+  bool openFileForWrite(const char*, const char*, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
+  bool openFileForWrite(const char*, const std::string&, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
+  bool openFileForWrite(const char*, const String&, HalFile& file) {
+    file = HalFile::opened();
+    return false;
+  }
   bool removeDir(const char*) { return false; }
   bool copyFile(const char*, const std::string&, const char*) { return false; }
   uint64_t sdTotalBytes() const { return 0; }

--- a/test/zip_entry_reader/HalStorage.h
+++ b/test/zip_entry_reader/HalStorage.h
@@ -22,14 +22,19 @@
 class HalFile : public Print {
  public:
   HalFile() = default;
-  ~HalFile() { close(); }
+  ~HalFile() { closeQuiet(); }
 
-  HalFile(HalFile&& o) noexcept : fp_(o.fp_) { o.fp_ = nullptr; }
+  HalFile(HalFile&& o) noexcept : fp_(o.fp_), hasImpl_(o.hasImpl_) {
+    o.fp_ = nullptr;
+    o.hasImpl_ = false;
+  }
   HalFile& operator=(HalFile&& o) noexcept {
     if (this != &o) {
-      close();
+      closeQuiet();
       fp_ = o.fp_;
+      hasImpl_ = o.hasImpl_;
       o.fp_ = nullptr;
+      o.hasImpl_ = false;
     }
     return *this;
   }
@@ -37,13 +42,15 @@ class HalFile : public Print {
   HalFile& operator=(const HalFile&) = delete;
 
   bool openForRead(const std::string& path) {
-    close();
+    closeQuiet();
+    hasImpl_ = true;
     fp_ = fopen(path.c_str(), "rb");
     return fp_ != nullptr;
   }
 
   bool openForWrite(const std::string& path) {
-    close();
+    closeQuiet();
+    hasImpl_ = true;
     const auto parent = std::filesystem::path(path).parent_path();
     if (!parent.empty()) {
       std::error_code ec;
@@ -56,17 +63,23 @@ class HalFile : public Print {
 
   // Mirrors HalStorage::openFileForUpdate: existing file, read+write, no truncation.
   bool openForUpdate(const std::string& path) {
-    close();
+    closeQuiet();
+    hasImpl_ = true;
     fp_ = fopen(path.c_str(), "r+b");
     return fp_ != nullptr;
   }
 
+  // Device parity, deliberately fatal. HalStorage gives every handle it opens an Impl — even when
+  // the open FAILED — so on device close() is fine on an opened-and-failed handle but asserts on
+  // one that was never opened at all (or was moved from). stdio cannot tell those apart, so
+  // hasImpl_ models it: without this, closing a never-opened handle is silently fine on the host
+  // and aborts in the reader's hands. Not assert(): host tests build with NDEBUG.
   bool close() {
-    if (fp_) {
-      fclose(fp_);
-      fp_ = nullptr;
+    if (!hasImpl_) {
+      std::fprintf(stderr, "HalFile::close() on a handle that was never opened — this aborts on device\n");
+      std::abort();
     }
-    return true;
+    return closeQuiet();
   }
 
   bool isOpen() const { return fp_ != nullptr; }
@@ -128,7 +141,18 @@ class HalFile : public Print {
   HalFile openNextFile() { return HalFile{}; }
 
  private:
+  // close() without the device-parity check: for the destructor and the open helpers, which must
+  // both tolerate a handle that was never opened.
+  bool closeQuiet() {
+    if (fp_) {
+      fclose(fp_);
+      fp_ = nullptr;
+    }
+    return true;
+  }
+
   FILE* fp_ = nullptr;
+  bool hasImpl_ = false;
 };
 
 using FsFile = HalFile;


### PR DESCRIPTION
## The crash

Entering **RecentBooks in cover mode** aborts on device, right after the first book whose cover has to be extracted:

```
[COF] Found EPUB 3 nav document: OEBPS/nav.xhtml
assert failed: bool HalFile::close() HalStorage.cpp:285 (impl != nullptr)
```

A default-constructed `FsFile` has `impl == nullptr`, and every `HalFile` method asserts on that. `HalStorage` installs an `Impl` on every open it performs — *including one that failed* — so `close()` after a failed open is legal; `close()` on a handle nobody ever opened is not.

## What went wrong

`ContentOpfParser` stopped opening its `.items.bin` store for a null-cache parse (a cover/metadata load), but the manifest/spine/guide **end** tags still closed it unconditionally. The abort is the `</manifest>` of that first cover parse.

Skipping the store there is right on its own merits — it exists only to resolve spine idrefs, which a null cache never does, and those load paths never call `setupCacheDir()`, so the open usually failed and logged three "probably going to be a fatal error" lines per book per cover pass. `coverItemHref` is matched inline as items stream by, so cover resolution is unaffected; the new test pins that, and that no `.items.bin` appears.

## A second instance, already latent on master

`Section` closes its `file` member in three cleanup paths that can all run before any open: `runBuildSetup` (first build), `clearCache` (cache dropped before the Section ever loaded), and `abortBuild` (abort before setup reached `openFileForWrite`). The first survives today only because some earlier path usually attempted an open on that handle — an accident, not an invariant.

## Why the tests did not catch either

Both host shims treated "close a never-opened handle" as fine. They now model the device contract, using `abort()` rather than `assert()` because host tests build Release with `NDEBUG`. Verified by reverting each fix in turn: without the parser guard the new null-cache OPF test aborts with the shim message; without the Section guards, 107 pipeline/footnote tests do.

I also swept by hand the member `FsFile` handles in code the suite does not execute — `SerialTransferDevice`, `WebDAVHandler`, `CrossPointWebServer`, `FileIndex`, `ZipFile`, `XtcParser`, `CssParser`, `PageListSink`, `FootnotePreviews`, `BookMetadataCache`, `ReaderActivity::CoverExtractSession`. Every close there is guarded or reached only after an open attempt.

## Testing

- 506/506 host tests pass
- `pio run` builds clean (flash 92.7%)
- **Device validation pending**: the reproduction is entering RecentBooks in cover mode with a book whose cover is not yet extracted