### PR TITLE
fix: Fix/recents cover livelock and adjust grid size

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -22,19 +22,40 @@
 #include "MappedInputManager.h"
 #include "RecentBooksStore.h"
 #include "activities/reader/ReaderActivity.h"
+#include "components/CoverGridLayout.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "util/ButtonNavigator.h"
 
 namespace {
-int gridThumbWidth(int contentWidth) {
-  const int margin = RecentBooksActivity::GRID_THUMB_MARGIN;
-  const int cols = RecentBooksActivity::GRID_COLS;
-  return (contentWidth - (cols + 1) * margin) / cols;
-}
-
 std::string gridThumbPath(const std::string& coverBmpPath, int tw, int th) {
   return UITheme::getCoverThumbPath(coverBmpPath, tw, th);
+}
+
+// Where the grid lives on screen: the content rect and first-row offset from the active theme,
+// plus the cell geometry CoverGridLayout derives from that space.
+struct GridLayout {
+  Rect content;       // rect the whole screen body lives in
+  int contentTop;     // y of the first row (below the header)
+  int contentHeight;  // usable height from contentTop down
+  CoverGridLayout::Layout cells;
+};
+
+GridLayout computeGridLayout(const GfxRenderer& renderer) {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+
+  GridLayout l{};
+  l.content = UITheme::getContentRect(renderer, true, true);
+  l.contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
+  l.contentHeight = l.content.height - l.contentTop - metrics.verticalSpacing;
+
+  // The gesture-hint line sits at the bottom of the content area on X4; keep the last row's
+  // labels clear of it (the scroll arrows share that strip).
+  l.cells = CoverGridLayout::compute({.contentWidth = l.content.width,
+                                      .contentHeight = l.contentHeight,
+                                      .bottomReserve = gpio.deviceIsX3() ? 12 : 24,
+                                      .maxCellHeight = RecentBooksActivity::GRID_MAX_CELL_HEIGHT});
+  return l;
 }
 }  // namespace
 
@@ -83,12 +104,16 @@ bool RecentBooksActivity::loadNextCover() {
       return false;  // not done yet — render() will requestUpdate() and call us again
     }
     pngSessionFiles.close();
-    pngSessionFailed = (status == PngDecodeSession::Status::Error);
+    // Local, not the member: this branch resolves the book itself and advances the index, so a
+    // failure here must not leak into the NEXT book's first attempt (as wasPostFailure it would
+    // suppress that book's session ladder and record it as coverless for the whole session).
+    const bool decodeFailed = (status == PngDecodeSession::Status::Error);
+    pngSessionFailed = false;
     pngSession.reset();
 
     RecentBook& book = recentBooks[nextCoverIndex];
     const std::string placeholder = ReaderActivity::coverThumbPlaceholder(book.path);
-    if (!pngSessionFailed) {
+    if (!decodeFailed) {
       LOG_DBG("RBA", "PNG session complete for %s", book.path.c_str());
       RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, placeholder);
       book.coverBmpPath = placeholder;
@@ -123,10 +148,17 @@ bool RecentBooksActivity::loadNextCover() {
     // resolved cover — no re-opening the EPUB three times per scan to rediscover it has no cover.
     const bool valid = ReaderActivity::isCoverThumbComplete(thumbPath, tw, th);
     if (!valid) {
-      const bool ok = (ReaderActivity::ensureCoverThumb(book.path, tw, th) == ThumbResult::Ok);
+      const ThumbResult res = ReaderActivity::ensureCoverThumb(book.path, tw, th);
+      const bool ok = (res == ThumbResult::Ok);
       const bool wasPostFailure = pngSessionFailed;
       pngSessionFailed = false;  // consumed
-      if (!ok && !wasPostFailure) {
+      // Only a TRANSIENT failure may walk the session ladder. A structural absence is already
+      // permanent — generateThumbBmp() wrote the 0-byte sentinel, and re-extracting the same ZIP
+      // entry yields the same undecodable bytes. Treating it like a transient failure livelocked
+      // this scan: the sentinel keeps isCoverThumbComplete() false, so the book never resolved,
+      // nextCoverIndex never advanced, and the cover was re-inflated from the ZIP every ~1.3 s
+      // forever (observed on an EPUB whose "cover.png" is really an AVIF). Mirrors HomeActivity.
+      if (res == ThumbResult::TransientFail && !wasPostFailure) {
         pngSession = ReaderActivity::beginPngThumbSession(book.path, tw, th, pngSessionFiles);
         if (pngSession) {
           LOG_DBG("RBA", "Started PNG session for %s (%u rows)", book.path.c_str(), pngSession->totalRows());
@@ -138,19 +170,22 @@ bool RecentBooksActivity::loadNextCover() {
                   extractSession->totalBytes());
           return false;
         }
-        // No thumb produced AND no decode/extract session could start → genuinely no extractable
-        // cover. But NOT if a sidecar image exists: that is a real cover source that simply failed
-        // to convert this pass (e.g. tight heap) and should be retried, not permanently placeholdered.
-        // Otherwise write a valid placeholder BMP so future scans treat the book as resolved and stop
-        // re-opening the EPUB. (A transient post-failure retry — wasPostFailure — is skipped here too.)
-        if (ReaderActivity::sidecarCoverPath(book.path).empty() &&
-            ReaderActivity::writeCoverPlaceholderBmp(thumbPath)) {
-          LOG_DBG("RBA", "No extractable cover for %s — wrote placeholder", book.path.c_str());
-          RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, placeholder);
-          book.coverBmpPath = placeholder;
-          nextCoverIndex++;
-          return false;
-        }
+      }
+
+      // Permanent give-up: structurally absent, or no decode/extract session could be started for
+      // a transient failure. But NOT if a sidecar image exists: that is a real cover source that
+      // simply failed to convert this pass (e.g. tight heap) and should be retried, not permanently
+      // placeholdered. Otherwise write a valid placeholder BMP so future scans treat the book as
+      // resolved and stop re-opening the EPUB. (A transient post-failure retry — wasPostFailure —
+      // is skipped here too, so the next pass gets a clean attempt.)
+      const bool giveUpPermanently = (res == ThumbResult::StructurallyAbsent) || (!ok && !wasPostFailure);
+      if (giveUpPermanently && ReaderActivity::sidecarCoverPath(book.path).empty() &&
+          ReaderActivity::writeCoverPlaceholderBmp(thumbPath)) {
+        LOG_DBG("RBA", "No extractable cover for %s — wrote placeholder", book.path.c_str());
+        RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, placeholder);
+        book.coverBmpPath = placeholder;
+        nextCoverIndex++;
+        return false;
       }
       RECENT_BOOKS.updateBook(book.path, book.title, book.author, book.series, ok ? placeholder : "");
       book.coverBmpPath = ok ? placeholder : "";
@@ -292,7 +327,7 @@ void RecentBooksActivity::loop() {
     if (ev.button == MappedInputManager::Button::Up && ev.type == ButtonEventManager::PressType::Short) {
       if (!recentBooks.empty()) {
         if (gridView) {
-          selectorIndex = std::max(0, selectorIndex - GRID_COLS);
+          selectorIndex = std::max(0, selectorIndex - gridColumns());
         } else {
           selectorIndex = ButtonNavigator::previousIndex(selectorIndex, listSize);
         }
@@ -305,7 +340,7 @@ void RecentBooksActivity::loop() {
     if (ev.button == MappedInputManager::Button::Down && ev.type == ButtonEventManager::PressType::Short) {
       if (!recentBooks.empty()) {
         if (gridView) {
-          selectorIndex = std::min(listSize - 1, selectorIndex + GRID_COLS);
+          selectorIndex = std::min(listSize - 1, selectorIndex + gridColumns());
         } else {
           selectorIndex = ButtonNavigator::nextIndex(selectorIndex, listSize);
         }
@@ -460,7 +495,7 @@ void RecentBooksActivity::renderListView(RenderLock&&) {
 void RecentBooksActivity::renderGridCell(int index, bool selected, int cellX, int cellY, int tw, int th, int labelW) {
   const auto& book = recentBooks[index];
   const int labelY = cellY + th + 3;
-  const int cellFillHeight = th + GRID_LABEL_HEIGHT + 3;
+  const int cellFillHeight = th + CoverGridLayout::kLabelHeight + 3;
 
   if (selected) {
     renderer.fillRect(cellX, cellY, tw, cellFillHeight);
@@ -532,32 +567,38 @@ void RecentBooksActivity::renderGridCell(int index, bool selected, int cellX, in
   }
 }
 
+// Column count for row-wise navigation. Recomputed rather than cached: it depends on the theme
+// metrics, which the settings screen can change while this activity is on the stack.
+int RecentBooksActivity::gridColumns() const { return computeGridLayout(renderer).cells.cols; }
+
 void RecentBooksActivity::renderGridView(RenderLock&&) {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  const Rect contentRect = UITheme::getContentRect(renderer, true, true);
-  const int contentTop = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
-  const int contentHeight = contentRect.height - contentTop - metrics.verticalSpacing;
-  const int margin = GRID_THUMB_MARGIN;
-  const int tw = gridThumbWidth(contentRect.width);
-  const int th = GRID_CELL_HEIGHT;
-  const int cellHeight = th + GRID_LABEL_HEIGHT + margin;
-  const int visibleRows = std::max(1, contentHeight / cellHeight);
-  const int totalRows = (static_cast<int>(recentBooks.size()) + GRID_COLS - 1) / GRID_COLS;
-  const int selectedRow = selectorIndex / GRID_COLS;
+  const GridLayout layout = computeGridLayout(renderer);
+  const Rect contentRect = layout.content;
+  const int contentTop = layout.contentTop;
+  const int contentHeight = layout.contentHeight;
+  const int margin = CoverGridLayout::kMargin;
+  const int cols = layout.cells.cols;
+  const int tw = layout.cells.cellWidth;
+  const int th = layout.cells.cellHeight;
+  const int cellHeight = layout.cells.rowStride;
+  const int visibleRows = layout.cells.rows;
+  const int totalRows = (static_cast<int>(recentBooks.size()) + cols - 1) / cols;
+  const int selectedRow = selectorIndex / cols;
   const int pageStartRow = (selectedRow / visibleRows) * visibleRows;
-  const int startIndex = pageStartRow * GRID_COLS;
-  const int labelW = tw - 4;
+  const int startIndex = pageStartRow * cols;
+  const int labelW = layout.cells.labelWidth;
 
   auto cellPos = [&](int i, int& cx, int& cy) {
-    const int row = (i / GRID_COLS) - pageStartRow;
-    const int col = i % GRID_COLS;
+    const int row = (i / cols) - pageStartRow;
+    const int col = i % cols;
     cx = contentRect.x + margin + col * (tw + margin);
     cy = contentTop + row * cellHeight;
   };
   LOG_DBG("RBA", "Render grid: sel=%d prev=%d start=%d pageStartRow=%d visibleRows=%d totalRows=%d", selectorIndex,
           prevSelectorIndex, startIndex, pageStartRow, visibleRows, totalRows);
   // Partial fast path: only the selection changed within the same page
-  const int prevPage = prevSelectorIndex >= 0 ? (prevSelectorIndex / GRID_COLS / visibleRows) : -1;
+  const int prevPage = prevSelectorIndex >= 0 ? (prevSelectorIndex / cols / visibleRows) : -1;
   const int curPage = selectedRow / visibleRows;
   if (!fullRedrawNeeded && prevSelectorIndex >= 0 && prevSelectorIndex != selectorIndex && prevPage == curPage) {
     // The write framebuffer holds the frame from two refreshes ago (displayBuffer()
@@ -594,7 +635,7 @@ void RecentBooksActivity::renderGridView(RenderLock&&) {
     return;
   }
 
-  const int endIndex = std::min(startIndex + visibleRows * GRID_COLS, static_cast<int>(recentBooks.size()));
+  const int endIndex = std::min(startIndex + visibleRows * cols, static_cast<int>(recentBooks.size()));
   LOG_DBG("RBA", "Full grid redraw: sel=%d prev=%d", selectorIndex, prevSelectorIndex);
   for (int i = startIndex; i < endIndex; i++) {
     int cx, cy;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -14,15 +14,21 @@
 
 class RecentBooksActivity final : public Activity {
  public:
-  static constexpr int GRID_COLS = 3;
-  // Cell display size: how tall each thumbnail cell appears on screen.
-  static constexpr int GRID_CELL_HEIGHT = 160;
-  static constexpr int GRID_THUMB_MARGIN = 10;
-  static constexpr int GRID_LABEL_HEIGHT = 36;  // two small-font lines below each thumbnail
   // Stored BMP dimensions — shared with FinishedBookActivity so one file serves both.
-  // The grid scales this BMP down to the runtime cell width for display.
+  // The grid scales this BMP down to the runtime cell size for display (never up).
   static constexpr int GRID_THUMB_WIDTH = 220;
   static constexpr int GRID_THUMB_HEIGHT = 240;
+  // Largest cover box the grid will draw: the stored BMP height plus the 1 px frame on each side.
+  // A height-bound cover (the usual ~2:3 shape fills the slot's height, not its width) then draws
+  // 1:1 instead of being resampled — rescaling a dithered 1-bit image aliases its dither into a
+  // visible grid. Raising it means raising GRID_THUMB_HEIGHT, which is part of a cache filename
+  // (every cover regenerates) and is bounded by what the label block leaves free.
+  //
+  // Columns and rows are NOT constants: CoverGridLayout derives both from the panel and the theme
+  // metrics, so a higher-resolution device gets more cells instead of a handful of oversized ones.
+  // On the 480 px-wide X4/X3 panels that works out to 2x2 — at the previous hard-coded 3 columns a
+  // cell was ~136 px and covers drew at roughly 105x158, too small to recognise the artwork.
+  static constexpr int GRID_MAX_CELL_HEIGHT = GRID_THUMB_HEIGHT + 2;
 
  private:
   int selectorIndex = 0;
@@ -72,6 +78,8 @@ class RecentBooksActivity final : public Activity {
 
   void renderListView(RenderLock&&);
   void renderGridView(RenderLock&&);
+  // Columns currently on screen — derived from the panel size and theme metrics, not a constant.
+  int gridColumns() const;
 
  public:
   explicit RecentBooksActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, int focusIndex = -1)

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -128,6 +128,17 @@ std::unique_ptr<ReaderActivity::CoverExtractSession> ReaderActivity::beginCoverE
   const std::string coverImgPath = epub.getCoverImageCachePath();
   if (epub.coverImageCachedValidOnly()) return nullptr;  // already cached
 
+  // Cover bytes already on disk that no decoder recognises must NOT be re-extracted: the ZIP entry
+  // inflates to the same bytes every time, so a caller whose ladder ends in "start an extract
+  // session" would re-inflate them forever (observed at ~1.3 s per round on an EPUB whose
+  // "cover.png" is really an AVIF). generateThumbBmp() has already written the structural sentinel
+  // for this case. The >=8-byte sniff inside coverImageCachedButUnsupported() means a partially
+  // extracted PNG/JPEG never reaches this verdict, so an interrupted extraction still resumes.
+  if (epub.coverImageCachedButUnsupported()) {
+    LOG_DBG("CEX", "Cached cover.img for %s is an unsupported format — not re-extracting", bookPath.c_str());
+    return nullptr;
+  }
+
   const std::string coverHref = epub.getCoverItemHref();
   if (coverHref.empty()) {
     LOG_DBG("CEX", "No cover item href for %s", bookPath.c_str());

--- a/src/components/CoverGridLayout.cpp
+++ b/src/components/CoverGridLayout.cpp
@@ -1,0 +1,33 @@
+#include "CoverGridLayout.h"
+
+#include <algorithm>
+
+namespace CoverGridLayout {
+
+Layout compute(const Input& in) {
+  Layout l;
+
+  // Widest grid whose cells still clear kMinCellWidth: cols cells plus (cols + 1) margins have to
+  // fit. A panel too narrow for even one full-size cell still gets one column (a squeezed cover
+  // beats an empty screen).
+  const int usableWidth = std::max(0, in.contentWidth);
+  l.cols = std::max(1, (usableWidth - kMargin) / (kMinCellWidth + kMargin));
+  l.cellWidth = std::max(1, (usableWidth - (l.cols + 1) * kMargin) / l.cols);
+  l.labelWidth = std::max(0, l.cellWidth - 4);
+
+  const int maxCellHeight = std::max(kMinCellHeight, in.maxCellHeight);
+  const int usableHeight = std::max(0, in.contentHeight - std::max(0, in.bottomReserve));
+
+  // Rows are counted at full cell size, so a page never trades cover size for density.
+  const int fullStride = maxCellHeight + kLabelHeight + kMargin;
+  l.rows = std::max(1, usableHeight / fullStride);
+
+  // Whatever height is left over goes into taller cells, up to the ceiling. The lower clamp only
+  // bites on a panel too short to hold even one full-size row.
+  const int fitted = usableHeight / l.rows - kLabelHeight - kMargin;
+  l.cellHeight = std::max(kMinCellHeight, std::min(maxCellHeight, fitted));
+  l.rowStride = l.cellHeight + kLabelHeight + kMargin;
+  return l;
+}
+
+}  // namespace CoverGridLayout

--- a/src/components/CoverGridLayout.h
+++ b/src/components/CoverGridLayout.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Geometry for a paged grid of book covers (the recent-books cover view).
+//
+// Nothing here is a fixed column or row count: both fall out of the space the caller hands in, so
+// a higher-resolution panel yields MORE cells of the same comfortable size rather than the same
+// few cells blown up. The caller supplies the content area it has after the header and button
+// hints, plus the tallest cover box worth drawing — that ceiling is the cached thumbnail's own
+// height, since the draw path never upscales and a taller box would only add empty frame.
+//
+// Pure arithmetic: no renderer, no theme, no storage, so it is exercised on the host.
+namespace CoverGridLayout {
+
+// Visual constants of the grid itself. The label block holds two small-font lines (title, author).
+inline constexpr int kMargin = 10;
+inline constexpr int kLabelHeight = 36;
+// A cover much narrower than this is unrecognisable artwork, so this is what decides how many
+// columns a panel can carry.
+inline constexpr int kMinCellWidth = 200;
+inline constexpr int kMinCellHeight = 96;
+
+struct Input {
+  int contentWidth = 0;   // width available to the grid
+  int contentHeight = 0;  // height available below the header
+  int bottomReserve = 0;  // strip at the bottom left free for hints / scroll arrows
+  int maxCellHeight = 0;  // tallest cover box worth drawing (the stored thumbnail's height)
+};
+
+struct Layout {
+  int cols = 1;
+  int rows = 1;        // rows per page
+  int cellWidth = 0;   // cover box width, 1 px frame included
+  int cellHeight = 0;  // cover box height, 1 px frame included
+  int rowStride = 0;   // cellHeight + label block + margin
+  int labelWidth = 0;  // text width available under a cover
+};
+
+Layout compute(const Input& in);
+
+}  // namespace CoverGridLayout

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ add_subdirectory(${REPO_ROOT}/lib/SaxParser ${CMAKE_CURRENT_BINARY_DIR}/SaxParse
 add_subdirectory(buffered_io)
 add_subdirectory(natural_sort)
 add_subdirectory(list_layout)
+add_subdirectory(cover_grid_layout)
 add_subdirectory(differential_rounding)
 add_subdirectory(hyphenation_eval)
 add_subdirectory(url_utils)

--- a/test/cover_grid_layout/CMakeLists.txt
+++ b/test/cover_grid_layout/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(CoverGridLayoutTest
+  CoverGridLayoutTest.cpp
+  ${REPO_ROOT}/src/components/CoverGridLayout.cpp
+)
+
+target_include_directories(CoverGridLayoutTest PRIVATE
+  ${REPO_ROOT}/src
+)
+
+target_link_libraries(CoverGridLayoutTest PRIVATE
+  crosspoint_test_common
+  GTest::gtest_main
+)
+
+gtest_discover_tests(CoverGridLayoutTest)

--- a/test/cover_grid_layout/CoverGridLayoutTest.cpp
+++ b/test/cover_grid_layout/CoverGridLayoutTest.cpp
@@ -1,0 +1,100 @@
+// Cover-grid geometry: columns and rows are derived from the panel, never hard-coded, so a
+// higher-resolution device gets more cells rather than a few oversized ones. Pure arithmetic —
+// the theme metrics below are the real ones, restated here so the expectations are readable.
+
+#include <gtest/gtest.h>
+
+#include "components/CoverGridLayout.h"
+
+namespace {
+
+// Cover box ceiling used by RecentBooksActivity: the stored 220x240 thumbnail plus its 1 px frame.
+constexpr int kMaxCell = 242;
+
+// Content area left to the grid, computed the way RecentBooksActivity does it:
+//   width  = panel width - side button hints
+//   height = panel height - button hints - (topPadding + header + spacing) - spacing
+struct Theme {
+  int topPadding, header, spacing, buttonHints, sideHints;
+};
+constexpr Theme kClassic{5, 45, 10, 40, 30};
+constexpr Theme kLyra{5, 84, 16, 40, 30};  // the default theme, and the one with the tall header
+
+CoverGridLayout::Input portrait(int panelW, int panelH, const Theme& t, bool isX3) {
+  const int contentWidth = panelW - (isX3 ? 2 * t.sideHints : t.sideHints);
+  const int contentTop = t.topPadding + t.header + t.spacing;
+  const int contentHeight = (panelH - t.buttonHints) - contentTop - t.spacing;
+  return {contentWidth, contentHeight, isX3 ? 12 : 24, kMaxCell};
+}
+
+}  // namespace
+
+TEST(CoverGridLayout, X4PortraitIsTwoByTwoWithFullSizeCells) {
+  for (const auto& theme : {kClassic, kLyra}) {
+    const auto l = CoverGridLayout::compute(portrait(480, 800, theme, /*isX3=*/false));
+    EXPECT_EQ(l.cols, 2);
+    EXPECT_EQ(l.rows, 2);
+    EXPECT_EQ(l.cellWidth, 210);
+    EXPECT_EQ(l.cellHeight, kMaxCell);  // stored thumb draws 1:1, never resampled
+  }
+}
+
+TEST(CoverGridLayout, X3PortraitIsTwoByTwoWithFullSizeCells) {
+  for (const auto& theme : {kClassic, kLyra}) {
+    const auto l = CoverGridLayout::compute(portrait(528, 792, theme, /*isX3=*/true));
+    EXPECT_EQ(l.cols, 2);
+    EXPECT_EQ(l.rows, 2);
+    EXPECT_EQ(l.cellWidth, 219);
+    EXPECT_EQ(l.cellHeight, kMaxCell);
+  }
+}
+
+TEST(CoverGridLayout, EveryPageFitsTheContentArea) {
+  for (const auto& theme : {kClassic, kLyra}) {
+    for (const auto& in : {portrait(480, 800, theme, false), portrait(528, 792, theme, true)}) {
+      const auto l = CoverGridLayout::compute(in);
+      EXPECT_LE(l.rows * l.rowStride, in.contentHeight - in.bottomReserve);
+      EXPECT_LE((l.cols + 1) * CoverGridLayout::kMargin + l.cols * l.cellWidth, in.contentWidth);
+    }
+  }
+}
+
+TEST(CoverGridLayout, HigherResolutionPanelGetsMoreCellsNotBiggerOnes) {
+  // A 1072x1448 300 dpi panel: nothing changes but the numbers handed in.
+  const auto l = CoverGridLayout::compute(portrait(1072, 1448, kLyra, /*isX3=*/false));
+  EXPECT_EQ(l.cols, 4);
+  EXPECT_EQ(l.rows, 4);
+  EXPECT_EQ(l.cellHeight, kMaxCell);  // still capped by the stored thumbnail
+  EXPECT_GE(l.cellWidth, CoverGridLayout::kMinCellWidth);
+}
+
+TEST(CoverGridLayout, ColumnsNeverDropBelowTheMinimumCellWidth) {
+  for (int panelW = 300; panelW <= 2000; panelW += 7) {
+    const auto l = CoverGridLayout::compute(portrait(panelW, 1000, kClassic, /*isX3=*/false));
+    EXPECT_GE(l.cellWidth, CoverGridLayout::kMinCellWidth) << "panel width " << panelW;
+  }
+}
+
+TEST(CoverGridLayout, NarrowPanelStillYieldsOneColumn) {
+  const auto l = CoverGridLayout::compute(
+      {.contentWidth = 150, .contentHeight = 600, .bottomReserve = 24, .maxCellHeight = kMaxCell});
+  EXPECT_EQ(l.cols, 1);
+  EXPECT_EQ(l.cellWidth, 130);  // squeezed rather than nothing at all
+}
+
+TEST(CoverGridLayout, ShortPanelKeepsOneRowAndClampsTheCell) {
+  // Not even one full-size row fits: one row survives, shrunk but never below the floor.
+  const auto l = CoverGridLayout::compute(
+      {.contentWidth = 450, .contentHeight = 200, .bottomReserve = 24, .maxCellHeight = kMaxCell});
+  EXPECT_EQ(l.rows, 1);
+  EXPECT_EQ(l.cellHeight, 130);
+  EXPECT_GE(l.cellHeight, CoverGridLayout::kMinCellHeight);
+}
+
+TEST(CoverGridLayout, DegenerateInputsDoNotProduceNonsense) {
+  const auto l = CoverGridLayout::compute({0, 0, 0, 0});
+  EXPECT_EQ(l.cols, 1);
+  EXPECT_EQ(l.rows, 1);
+  EXPECT_GE(l.cellWidth, 1);
+  EXPECT_EQ(l.cellHeight, CoverGridLayout::kMinCellHeight);
+}


### PR DESCRIPTION
Changes to the recent books grid view
- An unsupported cover format prevented the recent books list view from updating covers beyond that book
- The 3x3 grid view was effectively too small to properly recognize the cover thumbnails, changed to a 2x2 grid