### PR TITLE
fix: repair mistyped http/https scheme in user-entered server URLs

### DIFF
--- a/lib/KOReaderSync/KOReaderCredentialStore.cpp
+++ b/lib/KOReaderSync/KOReaderCredentialStore.cpp
@@ -6,6 +6,7 @@
 #include <ObfuscationUtils.h>
 
 #include "../../src/JsonSettingsIO.h"
+#include "../../src/util/UrlUtils.h"
 
 // Initialize the static instance
 KOReaderCredentialStore KOReaderCredentialStore::instance;
@@ -70,19 +71,28 @@ void KOReaderCredentialStore::clearCredentials() {
 }
 
 void KOReaderCredentialStore::setServerUrl(const std::string& url) {
-  serverUrl = url;
-  LOG_DBG("KRS", "Set server URL: %s", url.empty() ? "(default)" : url.c_str());
+  // Repair a typo'd scheme here as well as in getBaseUrl(), so the settings
+  // screen shows -- and the file keeps -- the URL that will actually be used.
+  serverUrl = UrlUtils::repairSchemeSeparator(url);
+  LOG_DBG("KRS", "Set server URL: %s", serverUrl.empty() ? "(default)" : serverUrl.c_str());
 }
 
 std::string KOReaderCredentialStore::getBaseUrl() const {
   std::string url;
   if (serverUrl.empty()) {
     url = DEFAULT_SERVER_URL;
-  } else if (serverUrl.find("://") == std::string::npos) {
-    // Normalize URL: add http:// if no protocol specified (local servers typically don't have SSL)
-    url = "http://" + serverUrl;
   } else {
-    url = serverUrl;
+    // A URL entered as "https:/host" (one slash) carries a scheme no "://" test can
+    // see; without the repair it becomes "http://https:/host", which resolves to the
+    // host "https:" and fails every connect.
+    const std::string repaired = UrlUtils::repairSchemeSeparator(serverUrl);
+    if (repaired != serverUrl) {
+      // Quoted so a missing slash is unmistakable in a log; on screen "https:/host"
+      // and "https://host" look almost identical.
+      LOG_INF("KRS", "Repaired malformed sync URL: '%s' -> '%s'", serverUrl.c_str(), repaired.c_str());
+    }
+    // Falls back to http:// when no protocol was given (local servers typically don't have SSL).
+    url = UrlUtils::ensureProtocol(repaired);
   }
 
   // Strip trailing slashes to avoid double-slash in API paths

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -17,6 +17,7 @@
 #include "RecentBooksStore.h"
 #include "SettingsList.h"
 #include "WifiCredentialStore.h"
+#include "util/UrlUtils.h"
 
 namespace {
 // Upper bound on any stored credential we will decode from JSON. A WPA passphrase
@@ -454,7 +455,9 @@ bool JsonSettingsIO::loadKOReader(KOReaderCredentialStore& store, const char* js
       *needsResave = true;
     }
   }
-  store.serverUrl = doc["serverUrl"] | std::string("");
+  // Repair a scheme typo saved by an older build, so the settings screen shows the
+  // same URL getBaseUrl() will connect to.
+  store.serverUrl = UrlUtils::repairSchemeSeparator(doc["serverUrl"] | std::string(""));
   uint8_t method = doc["matchMethod"] | (uint8_t)0;
   store.matchMethod = static_cast<DocumentMatchMethod>(method);
   store.sendMetadata = doc["sendMetadata"] | false;

--- a/src/OpdsServerStore.cpp
+++ b/src/OpdsServerStore.cpp
@@ -28,7 +28,9 @@ std::optional<std::string> normalizeUrl(const std::string& url) {
     return std::nullopt;
   }
 
-  std::string normalized = url;
+  // Repair a mistyped scheme before the check below: "https:/host" has no "://",
+  // so it would otherwise be treated as scheme-less and become "https://https:/host".
+  std::string normalized = UrlUtils::repairSchemeSeparator(url);
   if (normalized.find("://") == std::string::npos) {
     normalized = "https://" + normalized;
   }

--- a/src/util/UrlUtils.cpp
+++ b/src/util/UrlUtils.cpp
@@ -1,6 +1,7 @@
 #include "UrlUtils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <string_view>
 
 namespace UrlUtils {
@@ -152,6 +153,17 @@ std::string_view extractHostView(const std::string_view url) {
   return authorityEnd == std::string::npos ? url : url.substr(0, authorityEnd);
 }
 
+bool startsWithHttpScheme(const std::string& url) {
+  const size_t colon = url.find(':');
+  if (colon == 0 || colon == std::string::npos) {
+    return false;
+  }
+  std::string scheme = url.substr(0, colon);
+  std::transform(scheme.begin(), scheme.end(), scheme.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return scheme == "http" || scheme == "https";
+}
+
 void appendView(std::string& out, const std::string_view view) { out.append(view.data(), view.size()); }
 
 std::string buildResolvedUrl(const std::string_view host, const std::string_view path, const std::string_view query,
@@ -175,10 +187,54 @@ std::string normalizeJoinedPath(const std::string_view baseDir, const std::strin
 }  // namespace
 
 std::string ensureProtocol(const std::string& url) {
-  if (url.find("://") == std::string::npos) {
-    return "http://" + url;
+  // Repair first: "https:/host" carries a scheme the "://" test cannot see, and
+  // prepending on top of it yields the unconnectable "http://https:/host".
+  const std::string repaired = repairSchemeSeparator(url);
+  if (repaired.find("://") == std::string::npos) {
+    return "http://" + repaired;
   }
-  return url;
+  return repaired;
+}
+
+std::string repairSchemeSeparator(const std::string& url) {
+  std::string repaired = url;
+
+  // Loop so a doubled scheme ("http://https://host") collapses in one pass too.
+  for (int guard = 0; guard < 2; guard++) {
+    const size_t colon = repaired.find(':');
+    if (colon == 0 || colon == std::string::npos) {
+      break;
+    }
+
+    std::string scheme = repaired.substr(0, colon);
+    std::transform(scheme.begin(), scheme.end(), scheme.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (scheme != "http" && scheme != "https") {
+      break;
+    }
+
+    size_t restStart = colon + 1;
+    size_t slashCount = 0;
+    while (restStart < repaired.size() && repaired[restStart] == '/') {
+      restStart++;
+      slashCount++;
+    }
+    if (restStart >= repaired.size()) {
+      break;  // bare scheme, nothing to repair
+    }
+
+    const std::string rest = repaired.substr(restStart);
+    const bool restCarriesItsOwnScheme = startsWithHttpScheme(rest);
+    if (slashCount == 2 && !restCarriesItsOwnScheme) {
+      break;  // already well formed
+    }
+
+    // A second scheme inside the URL means the outer one was prepended by mistake;
+    // keep the inner one and let the next pass fix its own separator.
+    repaired = restCarriesItsOwnScheme ? rest : scheme + "://" + rest;
+  }
+
+  return repaired;
 }
 
 std::string extractHost(const std::string& url) { return std::string(extractHostView(url)); }

--- a/src/util/UrlUtils.h
+++ b/src/util/UrlUtils.h
@@ -9,6 +9,16 @@ namespace UrlUtils {
 std::string ensureProtocol(const std::string& url);
 
 /**
+ * Repair a mistyped http/https scheme, e.g. "https:/example.com" or
+ * "https:example.com" -> "https://example.com", and drop a doubled scheme
+ * ("http://https://example.com" -> "https://example.com"). A well-formed URL,
+ * or one with any other scheme, is returned unchanged. Hand-typed server URLs
+ * lose a slash easily, and the result then looks scheme-less to every "://"
+ * check, which prepends a second scheme on top.
+ */
+std::string repairSchemeSeparator(const std::string& url);
+
+/**
  * Extract host with protocol from URL (e.g., "http://example.com" from "http://example.com/path")
  */
 std::string extractHost(const std::string& url);

--- a/test/url_utils/UrlUtilsTest.cpp
+++ b/test/url_utils/UrlUtilsTest.cpp
@@ -96,3 +96,38 @@ TEST(UrlUtils, ExtractHostnameRejectsMalformedInputs) {
   ASSERT_EQ(UrlUtils::extractHostname("mailto:user@example.com"), "");
   ASSERT_EQ(UrlUtils::extractHostname("urn:isbn:1234567890"), "");
 }
+
+TEST(UrlUtils, RepairsMistypedSchemeSeparator) {
+  // The failure this guards: a hand-typed "https:/host" has no "://", so every
+  // scheme check treats it as scheme-less and prepends a second scheme.
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("https:/kosync.example.com"), "https://kosync.example.com");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("http:/example.com:8080/path"), "http://example.com:8080/path");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("https:example.com"), "https://example.com");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("https:///example.com"), "https://example.com");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("HTTPS:/example.com"), "https://example.com");
+}
+
+TEST(UrlUtils, CollapsesDoubledScheme) {
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("http://https://example.com"), "https://example.com");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("http://https:/example.com/path"), "https://example.com/path");
+}
+
+TEST(UrlUtils, LeavesWellFormedAndUnrelatedUrlsUnchanged) {
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("https://example.com/path"), "https://example.com/path");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("http://192.168.0.5:8080"), "http://192.168.0.5:8080");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("example.com"), "example.com");
+  // host:port without a scheme must not be mistaken for a scheme separator
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("localhost:8080"), "localhost:8080");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("ftp:/example.com"), "ftp:/example.com");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("https://"), "https://");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator("https:"), "https:");
+  ASSERT_EQ(UrlUtils::repairSchemeSeparator(""), "");
+}
+
+TEST(UrlUtils, EnsureProtocolRepairsBeforeItPrepends) {
+  ASSERT_EQ(UrlUtils::ensureProtocol("example.com/feed"), "http://example.com/feed");
+  // A mistyped scheme must be repaired, never treated as scheme-less.
+  ASSERT_EQ(UrlUtils::ensureProtocol("https:/example.com"), "https://example.com");
+  ASSERT_EQ(UrlUtils::ensureProtocol("http:/example.com"), "http://example.com");
+  ASSERT_EQ(UrlUtils::ensureProtocol("https://example.com"), "https://example.com");
+}


### PR DESCRIPTION
## Problem

KOReader sync failed on an X3 with every request dying at connect:

```
[KOSync] Getting progress: http://https:/kosync.example.com/syncs/progress/...
[HTTP] http connect failed: https:0
[KOSync] GET ... -> 0 (err: ESP_ERR_HTTP_MAX_REDIRECT) [attempt 3 body_len=0]
```

WiFi was fine (IP and NTP both fine). The sync server URL had been saved with a single slash — `https:/kosync.example.com`. Every scheme check in the firmware asks whether the URL contains `"://"`; that string answers *no*, so `getBaseUrl()` concluded the URL was scheme-less and prepended `http://` on top of the scheme that was already there. The result parses as host `https:`, port `0`, and can never connect — after three 3 s timeouts, reported as the meaningless `ESP_ERR_HTTP_MAX_REDIRECT`.

On e-ink the setting reads as correct: one slash and two are very hard to tell apart, so this is neither an obvious mistake to make nor to spot.

## Fix

`UrlUtils::repairSchemeSeparator()` normalizes a mistyped http/https scheme (missing, single, or extra slashes) and collapses an already-doubled scheme. A well-formed URL, a scheme-less host, `localhost:8080`, or a non-http scheme is returned untouched, so it is safe to run over user input ahead of any other normalization.

Applied at every user-entered URL path:

| Site | Effect |
| --- | --- |
| `UrlUtils::ensureProtocol` | repairs before it prepends — it is the `"://"` test that the bad input defeats |
| `KOReaderCredentialStore::setServerUrl` | settings screen and saved file show the URL that will be used |
| `KOReaderCredentialStore::getBaseUrl` | repairs before the `http://` fallback; logs the repair with both forms quoted |
| `JsonSettingsIO::loadKOReader` | fixes an already-affected device on the next boot, no retyping |
| `OpdsServerValidation::normalizeUrl` | covers the OPDS settings activity and the web UI add-server endpoint, which had the identical hole (`https:/host` -> `https://https:/host`) |

**Deliberately unchanged:** `handleRelay` / `handleFetchToSd` keep their strict `rfind("http://", 0)` check. That one fences plugin-supplied URLs before an allowlist match, where repairing input could reshape the host being matched — a malformed URL there should keep getting its 400. The URL *parsers* (`SecureHttpClient`, `HttpDownloader`, `WebDAVHandler`, `buildUrl`) are also untouched: they consume URLs that already passed an entry point, or come from feeds and protocol headers where a repair would be a guess.

## Memory / flash

No new allocations: `repairSchemeSeparator` works on a single `std::string` copy of a URL that is at most 128 chars (the keyboard entry cap), and is called only on settings entry, settings load, and once per sync request. Flash 93.9%.

## Testing

- 4 new cases in `test/url_utils` covering repair, doubled-scheme collapse, `ensureProtocol` ordering, and the leave-alone set (`localhost:8080`, `ftp:/…`, bare `https:`, empty)
- 581/581 host tests pass (`cd test/build_test && ctest -j4`)
- `pio run` clean
- **Device-validated on X3**: KOReader sync completes with the previously broken URL
