### PR TITLE
fix(serial): X3 could stay mute on the serial wire for a whole session

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -5,8 +5,8 @@
 #include <SPI.h>
 #include <Wire.h>
 #include <XteinkDetect.h>
+#include <driver/usb_serial_jtag.h>
 #include <esp_sleep.h>
-#include <soc/usb_serial_jtag_struct.h>
 
 // Global HalGPIO instance
 HalGPIO gpio;
@@ -301,26 +301,21 @@ void HalGPIO::update() {
 }
 
 void HalGPIO::updateUsbState(const unsigned long now) {
-  // SOF-based host-link sampling (see the member comment). A cheap register
-  // read, so it runs at its own short cadence on both devices and is never
-  // behind the I2C throttle below — a fresh enumeration must cancel light
+  // Host-link check (see the member comment). A single volatile read of a flag
+  // the IDF tick hook maintains, so it runs on every call on both devices and is
+  // never behind the I2C throttle below — a fresh enumeration must cancel light
   // sleep within a poll or two, or the next slice kills the CDC link again.
-  if (sofLastSampleMs == 0 || now - sofLastSampleMs >= SOF_SAMPLE_MS) {
-    const auto sof = static_cast<uint16_t>(USB_SERIAL_JTAG.fram_num.sof_frame_index);
-    usbSofActive = (sof != lastSofFrameIndex);
-    lastSofFrameIndex = sof;
-    sofLastSampleMs = now;
-  }
+  usbHostLinkActive = isUsbHostLinkActive();
 
   // Throttle the X3's I2C-based USB detection; see USB_POLL_X3_MS. First call
   // (usbLastPollMs == 0) always polls so boot state is correct. The combined
-  // verdict below is still recomputed every call so a SOF-detected attach is
-  // not held back by the throttle window.
+  // verdict below is still recomputed every call so a host-link-detected attach
+  // is not held back by the throttle window.
   if (usbLastPollMs == 0 || !deviceIsX3() || now - usbLastPollMs >= USB_POLL_X3_MS) {
     usbLastPollMs = now;
     usbElectricalConnected = isUsbElectricalConnected();
   }
-  const bool connected = usbSofActive || usbElectricalConnected;
+  const bool connected = usbHostLinkActive || usbElectricalConnected;
   usbStateChanged = (connected != lastUsbConnected);
   lastUsbConnected = connected;
 }
@@ -514,10 +509,14 @@ HalGPIO::WakeCheck HalGPIO::verifyPowerButtonWakeup(WakeGestures gestures, uint1
   }
 }
 
+bool HalGPIO::isUsbHostLinkActive() const { return usb_serial_jtag_is_connected(); }
+
 bool HalGPIO::isUsbConnected() const {
-  // Recent SOF activity means an enumerated host regardless of what the
-  // electrical check says (false at boot until update() has sampled twice).
-  return usbSofActive || isUsbElectricalConnected();
+  // An enumerated host counts regardless of what the electrical check says. Read
+  // the IDF monitor directly rather than the cached member: callers can reach
+  // this before the first update() (main.cpp opens the serial log right after
+  // gpio.begin()), and the cached value would still be its false initializer.
+  return isUsbHostLinkActive() || isUsbElectricalConnected();
 }
 
 bool HalGPIO::isUsbElectricalConnected() const {
@@ -525,8 +524,8 @@ bool HalGPIO::isUsbElectricalConnected() const {
     // X3: GPIO20 is repurposed as I2C SDA, so the X4 pin-level USB detect is
     // unusable here — the I2C pull-ups would always report HIGH. Probe the
     // BQ27220 fuel gauge instead. Charge inference misses a data-only cable and
-    // any cable once the battery is full; the SOF check in updateUsbState()
-    // covers those.
+    // any cable once the battery is full; the host-link check in
+    // updateUsbState() covers those.
     //
     // Current() is the ONLY signal trusted here: it is signed, and current
     // flowing INTO the battery (positive, above a noise floor) only happens on a
@@ -544,9 +543,9 @@ bool HalGPIO::isUsbElectricalConnected() const {
     // device-observed on an X3 at 100% with no cable attached.
     //
     // The case FC was meant to catch — a cable to a computer with the battery
-    // already full — is now covered properly by the SOF check in
-    // updateUsbState(), which sees the host link itself rather than inferring it
-    // from charge state. The one remaining gap is a dumb wall charger with a
+    // already full — is now covered properly by the host-link check in
+    // updateUsbState(), which sees the enumerated link itself rather than
+    // inferring it from charge state. The one remaining gap is a dumb wall charger with a
     // full battery: no charge current and no SOF, so no charging indication.
     // That is the honest reading ("charged", not "charging"), and light sleep is
     // safe there because there is no CDC link to lose.

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -65,18 +65,21 @@ class HalGPIO {
   // X4 detection is a single digitalRead and stays per-loop.
   static constexpr unsigned long USB_POLL_X3_MS = 1000;
 
-  // USB-Serial-JTAG SOF activity, sampled by update(): the host sends a SOF
-  // frame every 1 ms while the bus is enumerated, so a frame index that moved
-  // between two samples means a live host link. Catches what the charge-based
-  // X3 check misses: a data-only cable, and any cable once the battery is full
-  // (charge current ~0). Both matter for HalPowerManager::lightSleep(), which
-  // must not halt the chip out from under an enumerated CDC link. Samples must
-  // be >SOF_SAMPLE_MS apart — update() can be called back-to-back (inner input
-  // loops), and adjacent reads would compare equal and flicker the verdict.
-  uint16_t lastSofFrameIndex = 0;
-  unsigned long sofLastSampleMs = 0;
-  bool usbSofActive = false;
-  static constexpr unsigned long SOF_SAMPLE_MS = 10;
+  // Live USB host link, straight from the IDF's SOF monitor
+  // (usb_serial_jtag_is_connected(), maintained by a FreeRTOS tick hook that
+  // watches the SOF interrupt bit with a 3 ms no-SOF tolerance). Catches what
+  // the charge-based X3 check misses: a data-only cable, and any cable once the
+  // battery is full (charge current ~0). Both matter for
+  // HalPowerManager::lightSleep(), which must not halt the chip out from under
+  // an enumerated CDC link — and for main.cpp, which only opens the serial log
+  // when a host is present.
+  //
+  // This used to be sampled here by diffing USB_SERIAL_JTAG.fram_num: that index
+  // is 11 bits and wraps every 2.048 s, so any sampling cadence landing on a
+  // multiple of that read two equal values and reported "no host" while a
+  // monitor was attached. The IDF hook has no such blind spot and costs nothing
+  // to read.
+  bool usbHostLinkActive = false;
 
   // Per-device electrical/charge-inference USB check (fresh read; X3 = BQ27220
   // charge current over I2C, X4 = VBUS-driven level on GPIO20).
@@ -256,6 +259,12 @@ class HalGPIO {
 
   // Check if USB is connected
   bool isUsbConnected() const;
+
+  // Enumerated USB host link only (SOF activity), with no charge-state
+  // inference mixed in. Separated out so a caller that needs to know *why* the
+  // verdict came out the way it did — the serial-log gate's diagnostic — can
+  // report the two terms apart.
+  bool isUsbHostLinkActive() const;
 
   // USB state as sampled by the last update() call. Prefer this in per-loop
   // polling: isUsbConnected() performs a fresh I2C read on X3.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -706,6 +706,66 @@ static HalGPIO::WakeGestures wakeGestureFromSettings() {
   return gestures;
 }
 
+#ifdef ENABLE_SERIAL_LOG
+// Open the USB-CDC log wire when a host is actually on the other end.
+//
+// This is the ONLY HWCDC::begin() in the firmware. -DARDUINO_USB_MODE=1 compiles
+// out the core's CDC-on-boot begin() (cores/esp32/main.cpp guards it with
+// !ARDUINO_USB_MODE; HWCDC.cpp only instantiates the object), so skipping this
+// call leaves HWCDC with no TX ring buffer and no ISR — nothing can ever set its
+// "connected" flag, `if (logSerial)` in logPrintf() stays false, and every LOG_*
+// line is dropped for the rest of the session while still filling the RTC ring.
+//
+// Gated rather than unconditional because begin() allocates the 4 KB RX + 8 KB TX
+// buffers below, which are pure waste on a device running from battery.
+//
+// The gate has to be the enumerated host link, not the charge state. X3 has no
+// pin-level USB detect (GPIO20 is I2C SDA there), so its electrical check infers
+// a cable from BQ27220 charge current — which reads false on a full battery or a
+// data-only cable. That is how an X3 with a serial monitor attached could stay
+// mute for a whole session while X4, which reads VBUS off a pin, never did.
+// isUsbConnected() now leads with the IDF's SOF-based host-link flag, and the
+// call is retried on USB state changes so a cable plugged after boot still gets
+// a log.
+static bool serialLogOpen = false;
+
+static bool openSerialLogIfHostPresent() {
+  if (serialLogOpen) return false;
+
+  // The host link is the signal that matters; the charge inference behind
+  // isUsbConnected() is only consulted when there is none, since on X3 it costs
+  // an I2C read and can only add a (harmless) false positive here.
+  const bool hostLink = gpio.isUsbHostLinkActive();
+  if (!hostLink && !gpio.isUsbConnected()) {
+    // Ring-buffer only — the wire is closed by definition. Surfaces in the crash
+    // report's "Last logs", so a session that produced no serial output at all
+    // can still be explained after the fact.
+    LOG_INF("MAIN", "Serial log not opened: no USB host link, no charge-inferred cable");
+    return false;
+  }
+
+  // Enlarge the USB-CDC RX buffer from the 256-byte default before begin().
+  // The serial file-transfer protocol receives 2048-byte chunks in bursts; a
+  // 256-byte ring drops bytes whenever the byte-by-byte drain stalls briefly,
+  // which surfaces as "Timeout waiting for ACK" / failed uploads. 4096 matches
+  // MicroReader's usb_serial_jtag rx_buffer_size.
+  logSerial.setRxBufferSize(4096);
+  // Enlarge the TX buffer too (default 256) so file downloads stream out in
+  // larger bursts without the device having to block mid-chunk on a full ring
+  // (a full ring that doesn't drain within HWCDC's tx timeout flips the link
+  // to "disconnected" and silently drops TX).
+  logSerial.setTxBufferSize(8192);
+  Serial.begin(115200);
+  const unsigned long start = millis();
+  while (!Serial && (millis() - start) < 500) {
+    delay(10);
+  }
+  serialLogOpen = true;
+  LOG_INF("MAIN", "Serial log opened (%s)", hostLink ? "enumerated host link" : "charge-inferred cable");
+  return true;
+}
+#endif
+
 void setup() {
   markBootPhase(BootPhase::SetupEntry);
   // Load just the settings we need before any other init, so the wake gesture mirrors
@@ -799,24 +859,7 @@ void setup() {
   }
 
 #ifdef ENABLE_SERIAL_LOG
-  if (gpio.isUsbConnected()) {
-    // Enlarge the USB-CDC RX buffer from the 256-byte default before begin().
-    // The serial file-transfer protocol receives 2048-byte chunks in bursts; a
-    // 256-byte ring drops bytes whenever the byte-by-byte drain stalls briefly,
-    // which surfaces as "Timeout waiting for ACK" / failed uploads. 4096 matches
-    // MicroReader's usb_serial_jtag rx_buffer_size. setRxBufferSize() recreates
-    // the queue, so it takes effect even though CDC_ON_BOOT already ran begin().
-    logSerial.setRxBufferSize(4096);
-    // Enlarge the TX buffer too (default 256) so file downloads stream out in
-    // larger bursts without the device having to block mid-chunk on a full ring
-    // (a full ring that doesn't drain within HWCDC's tx timeout flips the link
-    // to "disconnected" and silently drops TX).
-    logSerial.setTxBufferSize(8192);
-    Serial.begin(115200);
-    const unsigned long start = millis();
-    while (!Serial && (millis() - start) < 500) {
-      delay(10);
-    }
+  if (openSerialLogIfHostPresent()) {
     markBootPhase(BootPhase::SerialUp);
   }
 #endif
@@ -1296,6 +1339,11 @@ void loop() {
   // Refresh the battery icon when USB is plugged or unplugged.
   // Placed after sleep guards so we never queue a render that won't be processed.
   if (gpio.wasUsbStateChanged()) {
+#ifdef ENABLE_SERIAL_LOG
+    // A cable (or a host) that arrived after boot: open the log wire now rather
+    // than staying mute until the next reboot. No-op once it is open.
+    openSerialLogIfHostPresent();
+#endif
     activityManager.requestUpdate();
   }
 


### PR DESCRIPTION
## Problem

An X3 with a serial monitor attached produced no log output at all, for the whole session, while X4 never failed. Two independent causes, both rooted in the same thing: **X3 has no pin-level USB detect** (GPIO20 is I2C SDA there), so it infers a cable from BQ27220 charge current — which reads false on a full battery, on a data-only cable, or if the I2C read fails.

**1. `Serial.begin()` never ran.** [main.cpp](src/main.cpp) opened the log once, behind `if (gpio.isUsbConnected())`. That is the *only* `HWCDC::begin()` in the firmware: `-DARDUINO_USB_MODE=1` compiles out the core's CDC-on-boot begin (`cores/esp32/main.cpp:99` is guarded by `!ARDUINO_USB_MODE`; `HWCDC.cpp:617` only instantiates the object). The comment claiming CDC-on-boot had already begun it was wrong.

Skipping the call leaves HWCDC with no TX ring buffer and no ISR. The ISR is the only thing that sets HWCDC's `connected` flag, so `operator bool()` returns false forever and `if (logSerial && !serialWireMuted)` in `logPrintf()` drops every line — silently, for the rest of the session. And nothing retried: a cable plugged after boot could not open it either.

At that call site `gpio.update()` has never run (`HalGPIO::begin()` doesn't call it), so `usbSofActive` was still its `false` initializer and the verdict collapsed to the charge-current read.

**2. The host-link check itself had a blind spot.** `updateUsbState()` sampled `USB_SERIAL_JTAG.fram_num` and called the link live if the frame index moved between two reads. That index is 11 bits and wraps every 2.048 s, so a sampling cadence landing on a multiple of it reads two equal values and reports "no host". That same verdict gates `HalPowerManager::lightSleep()`, which the code notes "kills an enumerated USB-CDC link" — one 40 ms slice tears down the link, after which SOFs never return, the verdict stays false, and the device keeps sleeping.

## Fix

Take the host link from the IDF instead of hand-rolling it. `usb_serial_jtag_is_connected()` is maintained by a FreeRTOS tick hook that watches the SOF interrupt bit with a 3 ms no-SOF tolerance (`usb_serial_jtag_connection_monitor.c`), has no wrap blind spot, and is a single volatile read.

- `HalGPIO::isUsbConnected()` now leads with the host link, exposed separately as `isUsbHostLinkActive()` so the two terms can be reported apart. This closes the light-sleep hole at the same time.
- The serial open is gated on the host link, with the charge inference consulted only when there is none (on X3 it costs an I2C read and can only add a harmless false positive there).
- The open is retried from the USB-state-change branch in `loop()`, so a cable plugged after boot opens the log instead of waiting for a reboot.
- The decision is logged either way. A refusal still reaches the RTC ring buffer, so it shows up in the crash report's "Last logs" and a session with no serial output at all is explainable after the fact.

Net removal of state: three members (`lastSofFrameIndex`, `sofLastSampleMs`, `SOF_SAMPLE_MS`) go away.

## Behaviour change worth knowing

X3's `getWakeupReason()` uses the same verdict to decide `AfterUSBPower`. With detection now correct on a full battery, plugging USB into a powered-off, fully charged X3 goes back to sleep instead of booting to Home — which is the documented intent and what X4 already does. A reset from a host (esptool / opening the port) is unaffected: that arrives as a non-POWERON reset reason and boots normally, as the device log below shows.

## Testing

**Device-validated on X3 at 100% battery** — the exact state that reproduced the mute:

```
[190 07:55:00] [INF] [MAIN] Serial log opened (enumerated host link)
[191 07:55:00] [INF] [MAIN] Hardware detect: X3
[191 07:55:00] [INF] [BOOT] Wake gate: not-pressed (decided at 30 ms, ...)
[421 09:55:00] [DBG] [GPIO] getWakeupReason: wakeupCause=0, resetReason=11, usbConnected=1
```

Logs then ran continuously through 80 s of idle, including the CPU-downclock cycles that precede the light-sleep path.

- `pio run` clean, flash 93.9%, RAM 17.0%
- 581/581 host tests pass (`cd test/build_test && ctest -j4`)
