### PR TITLE
fix: Select whole words in the dictionary overlay (#206)

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -1225,6 +1225,10 @@ ParsedText::LineProcessResult ParsedText::extractLine(
   range.words = &words;
   range.styles = &wordStyles;
   range.sizes = &wordSizes;
+  // Carried into the block so a reader-side consumer can tell one logical word from the
+  // fragments layout split it into (bionic-reading halves, attached punctuation). Nothing on
+  // the render path reads it; the xpos above already encodes the spacing.
+  range.continues = &continuesVec;
   range.first = lastBreakAt;
   range.count = lineWordCount;
 

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -31,7 +31,13 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 70;  // bumped: a wrapper's horizontal inset reaches every
+constexpr uint8_t SECTION_FILE_VERSION = 71;  // bumped: the packed word style byte now carries a
+                                              // per-word "continues the previous word" bit, so the
+                                              // dictionary overlay can select a bionic-split or
+                                              // hyphenated word as one word. A v70 cache reads the
+                                              // bit as clear everywhere, i.e. keeps the old split
+                                              // selection, so it has to be rebuilt
+                                              // v70: a wrapper's horizontal inset reaches every
                                               // child block, and insets/hanging indents are clamped to
                                               // the panel. Layout bakes insets into word xpos (see v61),
                                               // so a v69 cache keeps the off-panel lines this fixes

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -11,6 +11,15 @@
 
 bool TextBlock::guideDotsEnabled = false;
 
+namespace {
+// Style and continuation share one arena byte: bits 0-6 are the EpdFontFamily::Style, bit 7
+// says the word is glued to its predecessor. See TextBlock::wordContinues.
+uint8_t packStyle(const EpdFontFamily::Style style, const bool continues) {
+  return static_cast<uint8_t>((static_cast<uint8_t>(style) & ~TextBlock::WORD_CONTINUES_BIT) |
+                              (continues ? TextBlock::WORD_CONTINUES_BIT : 0));
+}
+}  // namespace
+
 TextBlock::ArenaOffsets TextBlock::arenaOffsets(const uint16_t wordCount, const bool hasSizes) {
   // Layout documented in TextBlock.h: 16-bit arrays first (textOff, xpos), then
   // 8-bit arrays (styles, optional sizes), then the text blob. textOff sits at 0.
@@ -39,7 +48,7 @@ void TextBlock::bindArenaPointers() {
 
 TextBlock::TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
                      std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle,
-                     std::vector<uint8_t> word_sizes)
+                     std::vector<uint8_t> word_sizes, std::vector<bool> word_continues)
     // Narrow the parser's full BlockStyle to the render-only slice: the spacing
     // fields have already been consumed into word_xpos / the line's y by layout.
     : renderStyle{blockStyle.fontSizeMultiplier, blockStyle.headingFontId, blockStyle.alignment} {
@@ -101,7 +110,7 @@ TextBlock::TextBlock(std::vector<std::string> words, std::vector<int16_t> word_x
   for (uint16_t i = 0; i < numWords; i++) {
     textOff[i] = off;
     xpos[i] = word_xpos[i];
-    styles[i] = static_cast<uint8_t>(word_styles[i]);
+    styles[i] = packStyle(word_styles[i], i < word_continues.size() && word_continues[i]);
     memcpy(text + off, words[i].data(), words[i].size());
     off += static_cast<uint16_t>(words[i].size());
     text[off++] = '\0';
@@ -128,6 +137,10 @@ TextBlock::TextBlock(const WordRange& range, const std::vector<int16_t>& word_xp
   // Every source array must actually span [first, first + count); xpos is per line so it is
   // indexed from 0 and only needs `count` entries.
   const bool hasSizeSrc = range.sizes != nullptr && !range.sizes->empty();
+  // Optional, and only used when it actually spans the range -- a caller that does not track
+  // continuation (or hands over a short vector) just produces space-separated words.
+  const std::vector<bool>* continuesSrc =
+      (range.continues != nullptr && first + count <= range.continues->size()) ? range.continues : nullptr;
   if (count > 10000 || first + count > words.size() || first + count > styleSrc.size() || word_xpos.size() != count ||
       (hasSizeSrc && first + count > range.sizes->size())) {
     LOG_ERR("TXB", "Construction failed: range out of bounds (first=%u, count=%u, words=%u, xpos=%u)",
@@ -194,7 +207,7 @@ TextBlock::TextBlock(const WordRange& range, const std::vector<int16_t>& word_xp
   for (uint16_t i = 0; i < numWords; i++) {
     textOff[i] = off;
     xpos[i] = word_xpos[i];
-    styles[i] = static_cast<uint8_t>(styleSrc[first + i]);
+    styles[i] = packStyle(styleSrc[first + i], continuesSrc != nullptr && (*continuesSrc)[first + i]);
     // Copy the word one soft-hyphen-free run at a time.
     const std::string& w = words[first + i];
     size_t start = 0;

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -48,7 +48,7 @@ void TextBlock::bindArenaPointers() {
 
 TextBlock::TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
                      std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle,
-                     std::vector<uint8_t> word_sizes, std::vector<bool> word_continues)
+                     std::vector<uint8_t> word_sizes, const std::vector<bool>& word_continues)
     // Narrow the parser's full BlockStyle to the render-only slice: the spacing
     // fields have already been consumed into word_xpos / the line's y by layout.
     : renderStyle{blockStyle.fontSizeMultiplier, blockStyle.headingFontId, blockStyle.alignment} {

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -130,7 +130,7 @@ class TextBlock final : public Block {
   // check and drop the line instead of using it.
   explicit TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
                      std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle = BlockStyle(),
-                     std::vector<uint8_t> word_sizes = {}, std::vector<bool> word_continues = {});
+                     std::vector<uint8_t> word_sizes = {}, const std::vector<bool>& word_continues = {});
 
   // Slice of a laid-out block, addressed directly in the caller's storage.
   // Layout produces lines as [first, first + count) windows over the block's word arrays;

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -28,7 +28,7 @@
 // unaligned multi-byte access):
 //   uint16_t textOff[wordCount]   byte offset of word i's text within text[]
 //   int16_t  xpos[wordCount]
-//   uint8_t  styles[wordCount]
+//   uint8_t  styles[wordCount]    low 7 bits EpdFontFamily::Style, bit 7 = continues
 //   uint8_t  sizes[wordCount]     present only when sizesPresent
 //   char     text[textBytes]      all words back to back, each NUL-terminated
 //
@@ -121,13 +121,16 @@ class TextBlock final : public Block {
   }
 
  public:
+  // Spare high bit of the packed style byte: EpdFontFamily::Style only uses bits 0-6.
+  static constexpr uint8_t WORD_CONTINUES_BIT = 0x80;
+
   // Flatten-on-construct: copies the layout-time vectors into the arena; the
   // vectors die with the caller. An all-100% sizes vector is normalized to "no
   // sizes". On arena OOM the block is empty and valid() is false -- callers must
   // check and drop the line instead of using it.
   explicit TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
                      std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle = BlockStyle(),
-                     std::vector<uint8_t> word_sizes = {});
+                     std::vector<uint8_t> word_sizes = {}, std::vector<bool> word_continues = {});
 
   // Slice of a laid-out block, addressed directly in the caller's storage.
   // Layout produces lines as [first, first + count) windows over the block's word arrays;
@@ -140,6 +143,9 @@ class TextBlock final : public Block {
     const std::vector<std::string>* words = nullptr;
     const std::vector<EpdFontFamily::Style>* styles = nullptr;
     const std::vector<uint8_t>* sizes = nullptr;  // may be null/empty => uniform 100%
+    // Layout's per-word "attaches to the previous word with no space" flags, indexed like
+    // `words`. May be null, meaning every word is space-separated.
+    const std::vector<bool>* continues = nullptr;
     size_t first = 0;
     size_t count = 0;
   };
@@ -167,7 +173,15 @@ class TextBlock final : public Block {
     return end - textOffArr[i] - 1;  // exclude the NUL
   }
   int16_t wordXpos(const uint16_t i) const { return xposArr[i]; }
-  EpdFontFamily::Style wordStyle(const uint16_t i) const { return static_cast<EpdFontFamily::Style>(stylesArr[i]); }
+  EpdFontFamily::Style wordStyle(const uint16_t i) const {
+    return static_cast<EpdFontFamily::Style>(stylesArr[i] & ~WORD_CONTINUES_BIT);
+  }
+  // True when word i is glued to word i-1 with no space between them: the two halves of a
+  // bionic-reading word, an attached punctuation token, a styled run that changes mid-word.
+  // Word 0 carries the flag layout gave the line's first token, so it is only meaningful for
+  // i > 0. Rides in the spare high bit of the style byte, so it costs no RAM and no cache
+  // bytes; a cache written before the bit existed simply reports false everywhere.
+  bool wordContinues(const uint16_t i) const { return (stylesArr[i] & WORD_CONTINUES_BIT) != 0; }
   bool hasWordSizes() const { return sizesPresent; }
   uint8_t wordSizePct(const uint16_t i) const { return sizesPresent ? sizesArr[i] : 100; }
   // Diagnostic/test helper: materializes the per-word size vector (empty when uniform).

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -7,6 +7,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
+#include <algorithm>
 #include <cctype>
 #include <climits>
 #include <cstdlib>
@@ -24,18 +25,62 @@ constexpr unsigned long POPUP_DURATION_MS = 1500;
 // A token is selectable when it has an ASCII alphanumeric or a non-ASCII
 // codepoint outside U+2000-U+206F (dashes, bullets and other General
 // Punctuation that appear as standalone tokens are not words).
-bool isSelectableToken(const char* text) {
-  for (const auto* p = reinterpret_cast<const uint8_t*>(text); *p != 0; p++) {
-    if (*p < 0x80) {
-      if (std::isalnum(*p)) return true;
-    } else if (*p == 0xE2 && (p[1] == 0x80 || p[1] == 0x81)) {
-      if (p[2] == 0) break;  // truncated sequence: skipping would step past the NUL
-      p += 2;                // skip the 3-byte General Punctuation codepoint
+bool isSelectableToken(const char* text, const size_t length) {
+  const auto* p = reinterpret_cast<const uint8_t*>(text);
+  for (size_t i = 0; i < length; i++) {
+    if (p[i] < 0x80) {
+      if (std::isalnum(p[i])) return true;
+    } else if (p[i] == 0xE2 && i + 2 < length && (p[i + 1] == 0x80 || p[i + 1] == 0x81)) {
+      i += 2;  // skip the 3-byte General Punctuation codepoint
     } else {
       return true;
     }
   }
   return false;
+}
+
+// Word bytes for the purpose of finding a dash that joins two words.
+bool isWordByte(const uint8_t c) { return c >= 0x80 || std::isalnum(c) != 0; }
+
+// Byte offset just past the next em or en dash (U+2014 / U+2013) that has a word on both sides,
+// scanning from `from`; 0 when there is none.
+//
+// A dash written without spaces fuses two words into one layout token -- "swiftness-a",
+// "truth-that" -- and the reader looking one of them up means one of them. This is the cut. The
+// dash stays with the LEFT piece so the pieces tile the token exactly (no gap to position) and
+// the dictionary's own edge-stripping takes it off the lookup.
+// A token with no word content of its own that carries an em or en dash separates the words on
+// either side of it exactly as a space does. Bionic reading produces these: it tokenizes
+// "swiftness-a" into a word span, the dash, and another word span, so the dash arrives as its
+// own token rather than inside one.
+bool isDashSeparatorToken(const char* text, const size_t length) {
+  if (isSelectableToken(text, length)) return false;
+  const auto* b = reinterpret_cast<const uint8_t*>(text);
+  for (size_t i = 0; i + 2 < length; i++) {
+    if (b[i] == 0xE2 && b[i + 1] == 0x80 && (b[i + 2] == 0x93 || b[i + 2] == 0x94)) return true;
+  }
+  return false;
+}
+
+size_t nextDashSplit(const char* text, const size_t length, const size_t from) {
+  const auto* b = reinterpret_cast<const uint8_t*>(text);
+  for (size_t i = from; i + 3 < length; i++) {
+    if (b[i] != 0xE2 || b[i + 1] != 0x80) continue;
+    if (b[i + 2] != 0x93 && b[i + 2] != 0x94) continue;  // en dash, em dash
+    if (i == 0 || !isWordByte(b[i - 1]) || !isWordByte(b[i + 3])) continue;
+    return i + 3;
+  }
+  return 0;
+}
+
+// A word broken across two lines ends on an ASCII hyphen -- either the one layout inserted at
+// the break, or the compound's own. A token that is nothing but a dash is not a broken word.
+bool endsOnHyphen(const char* text, const size_t length) { return length >= 2 && text[length - 1] == '-'; }
+
+// The other half of a broken word starts on a word character, never on punctuation.
+bool startsOnWordByte(const char* text) {
+  const auto first = static_cast<uint8_t>(text[0]);
+  return first >= 0x80 || std::isalnum(first) != 0;
 }
 
 // Fed to the watchdog while the index pass streams a multi-megabyte .idx.
@@ -55,9 +100,52 @@ void DictionaryWordSelectActivity::onEnter() {
 // after the font cache has been prewarmed for this page: the boxes come from
 // TextBlock::wordBox, which measures the text, and measuring an SD-card font
 // before the prewarm loads every glyph from the card one overflow slot at a time.
+// Index of `geometry`'s (font, scale, line height) in the side table, adding it if new. The
+// table has one or two entries on a normal page, so the linear scan never runs long; the 255th
+// distinct style reuses the last slot rather than overflowing the one-byte index.
+uint8_t DictionaryWordSelectActivity::internDrawStyle(const TextBlock::WordBox& geometry) {
+  for (size_t i = 0; i < drawStyles.size(); i++) {
+    if (drawStyles[i].fontId == geometry.fontId && drawStyles[i].scale == geometry.scale &&
+        drawStyles[i].height == geometry.height) {
+      return static_cast<uint8_t>(i);
+    }
+  }
+  if (drawStyles.size() >= UINT8_MAX) return static_cast<uint8_t>(drawStyles.size() - 1);
+  drawStyles.push_back({geometry.scale, geometry.fontId, geometry.height});
+  return static_cast<uint8_t>(drawStyles.size() - 1);
+}
+
+size_t DictionaryWordSelectActivity::countPageTokens(size_t& wordEstimate) const {
+  size_t tokens = 0;
+  wordEstimate = 0;
+  for (const auto& element : page->elements) {
+    if (element->getTag() != TAG_PageLine) continue;
+    const auto& block = static_cast<const PageLine*>(element.get())->getBlock();
+    if (!block || !block->valid()) continue;
+    const uint16_t count = block->wordCount();
+    tokens += count;
+    // One group per token that does not continue the one before it. Reading the continuation
+    // bits costs a byte each -- no text scan, no measurement.
+    for (uint16_t i = 0; i < count; i++) {
+      if (i == 0 || !block->wordContinues(i)) wordEstimate++;
+    }
+  }
+  return tokens;
+}
+
 void DictionaryWordSelectActivity::extractWords() {
+  // Reserve once, up front, from a real count. A dense page runs to ~280 tokens and bionic
+  // reading roughly doubles that, so a fixed guess is either far too small -- and then the
+  // vector doubles repeatedly, each growth holding the old block alongside the new -- or far too
+  // large. Cutting a token at an em dash adds a piece here and there, hence the small slack.
+  size_t wordEstimate = 0;
+  const size_t tokenCount = countPageTokens(wordEstimate);
+  drawStyles.clear();
+  drawStyles.reserve(4);
+  fragments.clear();
+  fragments.reserve(tokenCount + tokenCount / 16 + 4);
   words.clear();
-  words.reserve(128);
+  words.reserve(wordEstimate + wordEstimate / 16 + 4);
   rowCount = 0;
 
   for (const auto& element : page->elements) {
@@ -67,29 +155,122 @@ void DictionaryWordSelectActivity::extractWords() {
     if (!block || !block->valid()) continue;
 
     bool rowHasWords = false;
-    for (uint16_t i = 0; i < block->wordCount(); i++) {
-      const char* text = block->wordText(i);
-      if (!isSelectableToken(text)) continue;
+    bool openGroup = false;           // words.back() is a group still being extended
+    bool openSelectable = false;      // ...and it holds at least one selectable token
+    bool previousEmitted = false;     // the previous block word produced a fragment
+    uint16_t fragmentSourceWord = 0;  // block word the piece being added came from
 
+    // A group with nothing selectable in it -- a lone dash, a run of quotes -- is dropped.
+    // Both it and its fragments are the tail of their vectors, so this is a pop, not a gap.
+    auto closeGroup = [&] {
+      if (!openGroup) return;
+      if (openSelectable) {
+        rowHasWords = true;
+      } else {
+        fragments.resize(words.back().firstFragment);
+        words.pop_back();
+      }
+      openGroup = false;
+      openSelectable = false;
+    };
+
+    // Adds one piece of a token. `mayGlue` is false for every piece after a dash cut: a dash
+    // between two words is a word boundary even though layout kept the pair in one token.
+    auto addFragment = [&](const char* text, const size_t length, const int x, const int width,
+                           const TextBlock::WordBox& geometry, const bool mayGlue) {
+      const bool glued = mayGlue && openGroup && previousEmitted && fragmentSourceWord > 0 &&
+                         block->wordContinues(fragmentSourceWord) && words.back().fragmentCount < UINT8_MAX;
+      if (!glued) closeGroup();
+
+      Fragment fragment;
+      fragment.x = static_cast<int16_t>(x);
+      fragment.y = geometry.y;
+      fragment.width = static_cast<int16_t>(width);
+      fragment.text = text;
+      fragment.length = static_cast<uint16_t>(length);
+      fragment.style = geometry.style;
+      fragment.drawStyle = internDrawStyle(geometry);
+      fragments.push_back(fragment);
+      previousEmitted = true;
+
+      if (glued) {
+        Word& word = words.back();
+        word.fragmentCount++;
+        word.width = static_cast<int16_t>(fragment.x + fragment.width - word.x);
+      } else {
+        Word word;
+        word.firstFragment = static_cast<uint16_t>(fragments.size() - 1);
+        word.fragmentCount = 1;
+        word.hyphenFragment = NO_HYPHEN;
+        word.row = rowCount;
+        word.x = fragment.x;
+        word.width = fragment.width;
+        words.push_back(word);
+        openGroup = true;
+      }
+      // Punctuation glued to a word rides along -- the dictionary strips a word's edges
+      // anyway -- but it never makes a group selectable on its own.
+      openSelectable = openSelectable || isSelectableToken(text, length);
+    };
+
+    for (uint16_t i = 0; i < block->wordCount(); i++) {
+      fragmentSourceWord = i;
+      const char* text = block->wordText(i);
+      const size_t textLength = block->wordTextLen(i);
       const TextBlock::WordBox geometry =
           block->wordBox(renderer, i, fontId, line->xPos + marginLeft, line->yPos + marginTop);
-      if (geometry.width <= 0 || geometry.height <= 0) continue;
+      // A token with no ink of its own -- the visible space that holds a no-break group
+      // together -- is not part of any word, and it separates the words on either side of it.
+      if (geometry.width <= 0 || geometry.height <= 0) {
+        previousEmitted = false;
+        continue;
+      }
+      // A bare dash between two words is a boundary, not a piece of either of them.
+      if (isDashSeparatorToken(text, textLength)) {
+        previousEmitted = false;
+        continue;
+      }
 
-      WordBox box;
-      box.x = geometry.x;
-      box.y = geometry.y;
-      box.width = geometry.width;
-      box.height = geometry.height;
-      box.row = rowCount;
-      box.text = text;
-      box.fontId = geometry.fontId;
-      box.style = geometry.style;
-      box.scale = geometry.scale;
-      words.push_back(box);
-      rowHasWords = true;
+      // The common case: one whole token, measured once by wordBox and used in place.
+      // Cutting needs a NUL-terminated copy to measure, so a token too long for the scratch
+      // buffer is left whole -- those are never the dash-joined pairs this is for.
+      if (textLength >= WORD_TEXT_CAPACITY || nextDashSplit(text, textLength, 0) == 0) {
+        addFragment(text, textLength, geometry.x, geometry.width, geometry, /*mayGlue=*/true);
+        continue;
+      }
+
+      size_t partStart = 0;
+      int partX = geometry.x;
+      bool firstPart = true;
+      while (partStart < textLength) {
+        size_t partEnd = nextDashSplit(text, textLength, partStart);
+        if (partEnd == 0) partEnd = textLength;
+        const size_t partLength = partEnd - partStart;
+
+        char part[WORD_TEXT_CAPACITY];
+        memcpy(part, text + partStart, partLength);
+        part[partLength] = '\0';
+        const int partWidth = (geometry.scale == 1.0f)
+                                  ? renderer.getTextWidth(geometry.fontId, part, geometry.style)
+                                  : renderer.getTextWidthScaled(geometry.fontId, part, geometry.style, geometry.scale);
+        if (partWidth > 0) {
+          addFragment(text + partStart, partLength, partX, partWidth, geometry, firstPart);
+          firstPart = false;
+        }
+
+        if (partEnd < textLength) {
+          // Advance, not ink width: the next piece starts where this one's pen ends.
+          const int advance = renderer.getTextAdvanceX(geometry.fontId, part, geometry.style);
+          partX += (geometry.scale == 1.0f) ? advance : static_cast<int>(advance * geometry.scale + 0.5f);
+        }
+        partStart = partEnd;
+      }
     }
+    closeGroup();
     if (rowHasWords) rowCount++;
   }
+
+  joinHyphenatedWords();
 
   wordsExtracted = true;
   // Start on the middle row's word nearest mid-screen instead of top-left: any
@@ -98,6 +279,52 @@ void DictionaryWordSelectActivity::extractWords() {
     const int initial = closestInRow(rowCount / 2, renderer.getScreenWidth() / 2);
     if (initial >= 0) selected = initial;
   }
+}
+
+void DictionaryWordSelectActivity::joinHyphenatedWords() {
+  for (size_t i = 0; i + 1 < words.size(); i++) {
+    Word& prefix = words[i];
+    const Word& suffix = words[i + 1];
+    // Words are in reading order, so a suffix one row down is by construction the last word of
+    // its line meeting the first word of the next.
+    if (suffix.row != prefix.row + 1) continue;
+    // The fragments have to be adjacent for the joined word to stay one contiguous run.
+    if (suffix.firstFragment != prefix.firstFragment + prefix.fragmentCount) continue;
+    if (prefix.fragmentCount + suffix.fragmentCount > UINT8_MAX) continue;
+    const Fragment& tail = fragments[suffix.firstFragment - 1];
+    if (!endsOnHyphen(tail.text, tail.length)) continue;
+    if (!startsOnWordByte(fragments[suffix.firstFragment].text)) continue;
+
+    prefix.hyphenFragment = static_cast<uint8_t>(prefix.fragmentCount - 1);
+    prefix.fragmentCount = static_cast<uint8_t>(prefix.fragmentCount + suffix.fragmentCount);
+    words.erase(words.begin() + static_cast<long>(i) + 1);
+  }
+}
+
+const char* DictionaryWordSelectActivity::fragmentText(const Fragment& fragment, char* buf, const size_t capacity) {
+  if (fragment.text[fragment.length] == '\0') return fragment.text;  // whole token: no copy needed
+  const size_t take = std::min(static_cast<size_t>(fragment.length), capacity - 1);
+  memcpy(buf, fragment.text, take);
+  buf[take] = '\0';
+  return buf;
+}
+
+size_t DictionaryWordSelectActivity::buildWordText(const int index, char* buf, const size_t capacity,
+                                                   const bool dropJoinHyphen) const {
+  if (capacity == 0) return 0;
+  const Word& word = words[index];
+  size_t length = 0;
+  for (uint8_t f = 0; f < word.fragmentCount && length + 1 < capacity; f++) {
+    const Fragment& piece = fragments[word.firstFragment + f];
+    const char* source = piece.text;
+    size_t take = piece.length;
+    if (dropJoinHyphen && f == word.hyphenFragment && take > 0 && source[take - 1] == '-') take--;
+    take = std::min(take, capacity - 1 - length);
+    memcpy(buf + length, source, take);
+    length += take;
+  }
+  buf[length] = '\0';
+  return length;
 }
 
 // Index of the word in `row` whose horizontal center is closest to centerX;
@@ -117,14 +344,19 @@ int DictionaryWordSelectActivity::closestInRow(const uint16_t row, const int cen
 }
 
 void DictionaryWordSelectActivity::moveVertical(const int direction) {
-  const WordBox& current = words[selected];
-  const int targetRow = static_cast<int>(current.row) + direction;
-  if (targetRow < 0 || targetRow >= static_cast<int>(rowCount)) return;
-
-  const int best = closestInRow(static_cast<uint16_t>(targetRow), current.x + current.width / 2);
-  if (best >= 0 && best != selected) {
-    selected = best;
-    requestUpdate();
+  const Word& current = words[selected];
+  const int centerX = current.x + current.width / 2;
+  // Rows can be empty: joining a hyphenated word pulls the only word off the row that carried
+  // its tail. Keep going rather than letting one such row wall the cursor in.
+  for (int row = static_cast<int>(current.row) + direction; row >= 0 && row < static_cast<int>(rowCount);
+       row += direction) {
+    const int best = closestInRow(static_cast<uint16_t>(row), centerX);
+    if (best < 0) continue;
+    if (best != selected) {
+      selected = best;
+      requestUpdate();
+    }
+    return;
   }
 }
 
@@ -154,8 +386,16 @@ void DictionaryWordSelectActivity::speculateForSelection() {
     return;
   }
 
+  char text[WORD_TEXT_CAPACITY];
+  buildWordText(selected, text, sizeof(text), true);
   Dictionary::LookupResult result = Dictionary::LookupResult::NotFound;
-  const bool found = dict.resolve(words[selected].text, speculationLocation, speculationHeadword, &result);
+  bool found = dict.resolve(text, speculationLocation, speculationHeadword, &result);
+  // A word broken at a hyphen it already had ("US-Satellitensystems") is a real headword WITH
+  // the hyphen, so the joined form gets a second chance before the word is called absent.
+  if (!found && result == Dictionary::LookupResult::NotFound && isHyphenJoined(selected)) {
+    buildWordText(selected, text, sizeof(text), false);
+    found = dict.resolve(text, speculationLocation, speculationHeadword, &result);
+  }
   speculationIdx = selected;
   if (found) {
     speculation = Speculation::Found;
@@ -248,8 +488,14 @@ void DictionaryWordSelectActivity::performLookup() {
     } else {
       result = Dictionary::LookupResult::NotFound;
     }
-  } else {
-    found = ok && dict.lookup(words[selected].text, definition, headword, &result);
+  } else if (ok) {
+    char text[WORD_TEXT_CAPACITY];
+    buildWordText(selected, text, sizeof(text), true);
+    found = dict.lookup(text, definition, headword, &result);
+    if (!found && result == Dictionary::LookupResult::NotFound && isHyphenJoined(selected)) {
+      buildWordText(selected, text, sizeof(text), false);
+      found = dict.lookup(text, definition, headword, &result);
+    }
   }
 
   if (found) {
@@ -378,52 +624,90 @@ void DictionaryWordSelectActivity::loop() {
 // buffer / oversize box) -- the highlight is drawn regardless, but the next
 // cursor move must do a full repaint.
 bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
-  const WordBox& word = words[selected];
-  // The box is the word's exact advance box, grown by 2px so the highlight has
-  // a little air around the glyphs. Clamped to the panel so save, draw and
-  // restore all use the same rectangle.
-  int hx = word.x - 2;
-  int hy = word.y - 2;
-  int hw = word.width + 4;
-  int hh = word.height + 4;
-  if (hx < 0) {
-    hw += hx;
-    hx = 0;
-  }
-  if (hy < 0) {
-    hh += hy;
-    hy = 0;
-  }
-  if (hx + hw > renderer.getScreenWidth()) hw = renderer.getScreenWidth() - hx;
-  if (hy + hh > renderer.getScreenHeight()) hh = renderer.getScreenHeight() - hy;
+  const Word& word = words[selected];
+  // Fragments up to and including the hyphenated one sit on the word's own row, the rest on
+  // the row below; each run gets its own box, so nothing between the two lines is disturbed.
+  const uint8_t runBounds[MAX_SNAPSHOT_RUNS + 1] = {
+      0, word.hyphenFragment == NO_HYPHEN ? word.fragmentCount : static_cast<uint8_t>(word.hyphenFragment + 1),
+      word.fragmentCount};
 
-  bool saved = false;
-  if (snapshot && hw > 0 && hh > 0) {
-    saved = renderer.readFramebufferRegion(hx, hy, hw, hh, snapshot.get(), SNAPSHOT_CAPACITY) > 0;
+  // A word the speculative resolve has already proved absent gets an outline instead of the
+  // inverse fill: the cursor is still obviously here, but the reader can see there is nothing
+  // to look up without pressing Confirm and waiting for a "Not found" popup. Anything not yet
+  // resolved keeps the plain highlight -- absence is only ever claimed on a verdict.
+  const bool knownMissing = speculationIdx == selected && speculation == Speculation::Missing;
+
+  snapshotRunCount = 0;
+  size_t used = 0;
+  bool saved = snapshot != nullptr;
+  for (uint8_t run = 0; run < MAX_SNAPSHOT_RUNS; run++) {
+    if (runBounds[run] >= runBounds[run + 1]) continue;
+    const Fragment& firstPiece = fragments[word.firstFragment + runBounds[run]];
+    int left = firstPiece.x;
+    int top = firstPiece.y;
+    int right = firstPiece.x + firstPiece.width;
+    int bottom = firstPiece.y + drawStyleOf(firstPiece).height;
+    for (uint8_t f = runBounds[run] + 1; f < runBounds[run + 1]; f++) {
+      const Fragment& piece = fragments[word.firstFragment + f];
+      left = std::min(left, static_cast<int>(piece.x));
+      top = std::min(top, static_cast<int>(piece.y));
+      right = std::max(right, piece.x + piece.width);
+      bottom = std::max(bottom, piece.y + drawStyleOf(piece).height);
+    }
+
+    // The box is the run's exact advance box, grown by 2px so the highlight has
+    // a little air around the glyphs. Clamped to the panel so save, draw and
+    // restore all use the same rectangle.
+    int hx = left - 2;
+    int hy = top - 2;
+    int hw = right - left + 4;
+    int hh = bottom - top + 4;
+    if (hx < 0) {
+      hw += hx;
+      hx = 0;
+    }
+    if (hy < 0) {
+      hh += hy;
+      hy = 0;
+    }
+    if (hx + hw > renderer.getScreenWidth()) hw = renderer.getScreenWidth() - hx;
+    if (hy + hh > renderer.getScreenHeight()) hh = renderer.getScreenHeight() - hy;
+    if (hw <= 0 || hh <= 0) continue;
+
+    // Runs share the one buffer back to back; a run that no longer fits gives up the
+    // differential path for the whole word rather than restoring half of it.
+    size_t written = 0;
+    if (saved) {
+      written = renderer.readFramebufferRegion(hx, hy, hw, hh, snapshot.get() + used, SNAPSHOT_CAPACITY - used);
+      saved = written > 0;
+    }
+    if (saved) {
+      snapshotRuns[snapshotRunCount] = {static_cast<int16_t>(hx), static_cast<int16_t>(hy), static_cast<int16_t>(hw),
+                                        static_cast<int16_t>(hh), static_cast<uint16_t>(used)};
+      snapshotRunCount++;
+      used += written;
+    }
+
+    if (knownMissing) {
+      renderer.drawRect(hx, hy, hw, hh, true);
+    } else {
+      renderer.fillRect(hx, hy, hw, hh, true);
+    }
+    for (uint8_t f = runBounds[run]; f < runBounds[run + 1]; f++) {
+      const Fragment& piece = fragments[word.firstFragment + f];
+      const DrawStyle& drawStyle = drawStyleOf(piece);
+      char scratch[WORD_TEXT_CAPACITY];
+      const char* text = fragmentText(piece, scratch, sizeof(scratch));
+      if (drawStyle.scale == 1.0f) {
+        renderer.drawText(drawStyle.fontId, piece.x, piece.y, text, knownMissing, piece.style);
+      } else {
+        renderer.drawTextScaled(drawStyle.fontId, piece.x, piece.y, text, knownMissing, piece.style, drawStyle.scale);
+      }
+    }
   }
-  snapshotX = static_cast<int16_t>(hx);
-  snapshotY = static_cast<int16_t>(hy);
-  snapshotW = static_cast<int16_t>(hw);
-  snapshotH = static_cast<int16_t>(hh);
+
+  if (!saved) snapshotRunCount = 0;
   snapshotIdx = saved ? selected : -1;
-
-  // A word the speculative resolve has already proved absent gets an outline
-  // instead of the inverse fill: the cursor is still obviously here, but the
-  // reader can see there is nothing to look up without pressing Confirm and
-  // waiting for a "Not found" popup. Anything not yet resolved keeps the plain
-  // highlight -- absence is only ever claimed on a verdict.
-  const bool known_missing = speculationIdx == selected && speculation == Speculation::Missing;
-  if (known_missing) {
-    renderer.drawRect(hx, hy, hw, hh, true);
-  } else {
-    renderer.fillRect(hx, hy, hw, hh, true);
-  }
-  const bool inkBlack = known_missing;
-  if (word.scale == 1.0f) {
-    renderer.drawText(word.fontId, word.x, word.y, word.text, inkBlack, word.style);
-  } else {
-    renderer.drawTextScaled(word.fontId, word.x, word.y, word.text, inkBlack, word.style, word.scale);
-  }
   return saved;
 }
 
@@ -467,7 +751,10 @@ void DictionaryWordSelectActivity::render(RenderLock&&) {
     // actually on screen first; the saved pixels below were read from that same
     // frame, so the restore only lines up after this.
     renderer.syncWriteBufferFromDisplayed();
-    renderer.writeFramebufferRegion(snapshotX, snapshotY, snapshotW, snapshotH, snapshot.get());
+    for (uint8_t run = 0; run < snapshotRunCount; run++) {
+      const SnapshotRun& saved = snapshotRuns[run];
+      renderer.writeFramebufferRegion(saved.x, saved.y, saved.width, saved.height, snapshot.get() + saved.offset);
+    }
     // Batch-load just the highlighted word's glyphs before drawing them
     // white-on-black. clearCache() FIRST: prewarmCache() appends into the page
     // slots and deliberately never clears them -- that clear normally happens
@@ -480,8 +767,13 @@ void DictionaryWordSelectActivity::render(RenderLock&&) {
     // re-render the page, only the two word boxes and the hints.
     auto* fcm = renderer.getFontCacheManager();
     fcm->clearCache();
-    fcm->prewarmCache(words[selected].fontId, words[selected].text,
-                      static_cast<uint8_t>(1u << (static_cast<uint8_t>(words[selected].style) & 0x03)));
+    const Word& word = words[selected];
+    for (uint8_t f = 0; f < word.fragmentCount; f++) {
+      const Fragment& piece = fragments[word.firstFragment + f];
+      char scratch[WORD_TEXT_CAPACITY];
+      fcm->prewarmCache(drawStyleOf(piece).fontId, fragmentText(piece, scratch, sizeof(scratch)),
+                        static_cast<uint8_t>(1u << (static_cast<uint8_t>(piece.style) & 0x03)));
+    }
     speculationRepaintPending = false;
     if (drawHighlightWithSnapshot()) {
       drawHints();

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -678,6 +678,8 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
     // differential path for the whole word rather than restoring half of it.
     size_t written = 0;
     if (saved) {
+      // cppcheck-suppress arithOperationsOnVoidPointer ; get() is uint8_t*, cppcheck
+      // mis-deduces the concept-constrained makeUniqueNoThrow<uint8_t[]> return type
       written = renderer.readFramebufferRegion(hx, hy, hw, hh, snapshot.get() + used, SNAPSHOT_CAPACITY - used);
       saved = written > 0;
     }
@@ -753,6 +755,8 @@ void DictionaryWordSelectActivity::render(RenderLock&&) {
     renderer.syncWriteBufferFromDisplayed();
     for (uint8_t run = 0; run < snapshotRunCount; run++) {
       const SnapshotRun& saved = snapshotRuns[run];
+      // cppcheck-suppress arithOperationsOnVoidPointer ; get() is uint8_t*, cppcheck
+      // mis-deduces the concept-constrained makeUniqueNoThrow<uint8_t[]> return type
       renderer.writeFramebufferRegion(saved.x, saved.y, saved.width, saved.height, snapshot.get() + saved.offset);
     }
     // Batch-load just the highlighted word's glyphs before drawing them

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -35,26 +35,88 @@ class DictionaryWordSelectActivity final : public Activity {
   void render(RenderLock&&) override;
 
  private:
-  // Screen box of one selectable word. `text` points into the owned Page's
-  // TextBlock arena (NUL-terminated), valid for this activity's lifetime.
-  struct WordBox {
+  // The font a piece was drawn with, and what follows from it. A page has one or two of these
+  // -- body text, plus a heading or an inline size change -- so they are deduplicated into a
+  // side table and a fragment stores a one-byte index instead of the fields themselves.
+  struct DrawStyle {
+    float scale;
+    // Full width, NOT narrowed: font ids are 32-bit hashes (see fontIds.h, e.g. 1883578066), so
+    // a 16-bit field truncates every one of them to a font that does not exist -- which draws
+    // the highlight box and none of the glyphs inside it.
+    int fontId;
+    int16_t height;
+  };
+
+  // Screen box of one PIECE of a selectable word. Layout hands the page words already
+  // fragmented: bionic reading splits "reading" into a bold "read" and a plain "ing",
+  // hyphenation splits it across two lines as "read-" and "ing", and attached punctuation
+  // arrives as its own token. `text` points into the owned Page's TextBlock arena, valid for
+  // this activity's lifetime.
+  //
+  // Kept to 16 bytes on purpose. A bionic page carries ~500 of these and the array has to be ONE
+  // contiguous block that stays alive until the definition has been read -- and the definition's
+  // own heap guard is a largest-contiguous-block test (Dictionary.cpp), so every byte here comes
+  // straight off the budget a lookup has to work with.
+  struct Fragment {
+    const char* text;
     int16_t x;
     int16_t y;
     int16_t width;
-    int16_t height;
-    uint16_t row;
-    const char* text;
-    // How the page drew this word, so the highlight can redraw it in white and
-    // land on the same glyphs -- a heading uses its own font, and a word may be
-    // bold, italic or scaled by the publisher's font sizes.
-    int fontId;
+    // Bytes of `text` this piece covers. Usually the whole arena token, but a token holding an
+    // em dash between two words ("swiftness-a") is cut at the dash, and those pieces are not
+    // NUL-terminated where they end -- read them through fragmentText().
+    uint16_t length;
+    uint8_t drawStyle;  // index into drawStyles
+    // Bold, italic, sub/superscript: this one really is per piece -- bionic reading alternates
+    // bold and regular within a single word.
     EpdFontFamily::Style style;
-    float scale;
   };
+  static_assert(sizeof(Fragment) <= 16, "Fragment is on the reader's contiguous-heap budget");
+
+  // One word as the reader sees it: a run of consecutive fragments. Selection, highlighting
+  // and lookup all work on these, so a bionic-split or hyphenated word behaves like any other.
+  struct Word {
+    uint16_t firstFragment;
+    uint8_t fragmentCount;
+    // Fragment offset (from firstFragment) of the piece that ends on the hyphen layout added
+    // when it broke this word across two lines, or NO_HYPHEN. Both the offset and the row span
+    // are derived from it: fragments up to and including it sit on `row`, the rest on the row
+    // below.
+    uint8_t hyphenFragment;
+    uint16_t row;
+    // Horizontal extent on `row` -- the part of the word the cursor navigates by. A
+    // hyphen-joined word's tail on the next row is highlighted but does not steer navigation.
+    int16_t x;
+    int16_t width;
+  };
+  static constexpr uint8_t NO_HYPHEN = 0xFF;
+  // Longest word handed to the dictionary, joined across fragments. Headwords far shorter
+  // than this; the buffer is a stack local, so it stays well inside the task stack budget.
+  static constexpr size_t WORD_TEXT_CAPACITY = 128;
 
   enum class Popup : uint8_t { None, Busy, NotFound, Error };
 
   void extractWords();
+  // Exact-ish capacity for the two arrays, counted before anything is allocated. Growing them
+  // mid-scan would hold the old and the new block at once, which is what actually destroys the
+  // contiguous run a definition needs. Returns tokens; sets `wordEstimate` to the group count.
+  size_t countPageTokens(size_t& wordEstimate) const;
+  uint8_t internDrawStyle(const TextBlock::WordBox& geometry);
+  // Fuse each line-final word ending in a hyphen with the first word of the line below.
+  // Layout does not record that it hyphenated (the flag never reaches the page cache), so the
+  // shape of the break is the evidence: a word that ends the line on '-' with a word starting
+  // the next line is the split of one word in every book that is not deliberately odd.
+  void joinHyphenatedWords();
+  // Concatenate word `index`'s fragments into `buf` (NUL-terminated), returning the length.
+  // dropJoinHyphen leaves out the hyphen layout inserted at a line break, which is what the
+  // dictionary should see first; a compound that legitimately breaks at its own hyphen is
+  // retried with it.
+  size_t buildWordText(int index, char* buf, size_t capacity, bool dropJoinHyphen) const;
+  // NUL-terminated view of one fragment: the arena pointer itself when the piece ends on the
+  // token's own NUL, otherwise a copy in `buf`.
+  static const char* fragmentText(const Fragment& fragment, char* buf, size_t capacity);
+  const DrawStyle& drawStyleOf(const Fragment& fragment) const { return drawStyles[fragment.drawStyle]; }
+  bool isHyphenJoined(const int index) const { return words[index].hyphenFragment != NO_HYPHEN; }
   // Open the dictionary on first use. Idempotent; false when there is none
   // configured or it will not open.
   bool ensureDictionaryOpen();
@@ -80,7 +142,9 @@ class DictionaryWordSelectActivity final : public Activity {
   const int marginLeft;
   const int marginTop;
 
-  std::vector<WordBox> words;
+  std::vector<DrawStyle> drawStyles;
+  std::vector<Fragment> fragments;
+  std::vector<Word> words;
   // Word boxes are measured once the font cache has been prewarmed for this
   // page, which only happens inside render(); onEnter() has no framebuffer to
   // scan against. Until then there is nothing to highlight.
@@ -132,11 +196,22 @@ class DictionaryWordSelectActivity final : public Activity {
   // every SD-font glyph on the page). snapshotIdx is the word whose under-pixels
   // are saved; -1 means the framebuffer no longer holds a clean page (popup
   // drawn, sub-activity shown) and the next render must be a full one.
+  //
+  // A word covers one rectangle per row it occupies -- two for a hyphen-joined word, whose
+  // halves sit at the end of one line and the start of the next. Saving their bounding box
+  // instead would mean saving both whole lines and everything between them, so the runs are
+  // packed back to back into the one buffer.
+  struct SnapshotRun {
+    int16_t x;
+    int16_t y;
+    int16_t width;
+    int16_t height;
+    uint16_t offset;  // byte offset of this run's pixels within `snapshot`
+  };
   static constexpr size_t SNAPSHOT_CAPACITY = 2048;  // packed 1bpp: 16384 pixels
+  static constexpr uint8_t MAX_SNAPSHOT_RUNS = 2;
   std::unique_ptr<uint8_t[]> snapshot;
-  int16_t snapshotX = 0;
-  int16_t snapshotY = 0;
-  int16_t snapshotW = 0;
-  int16_t snapshotH = 0;
+  SnapshotRun snapshotRuns[MAX_SNAPSHOT_RUNS] = {};
+  uint8_t snapshotRunCount = 0;
   int snapshotIdx = -1;
 };

--- a/test/text_block_range/TextBlockRangeTest.cpp
+++ b/test/text_block_range/TextBlockRangeTest.cpp
@@ -198,4 +198,75 @@ TEST(TextBlockRange, NullSizesMeansUniform) {
   EXPECT_EQ(block.wordSizePct(1), 100);
 }
 
+// The continuation flag rides in the spare high bit of the packed style byte. It is what tells
+// the dictionary overlay that "rea" and "ding" are one word rather than two, so it has to
+// survive the range copy without leaking into the style the renderer reads back.
+TEST(TextBlockContinues, RangeCtorCarriesTheFlagWithoutDisturbingStyles) {
+  const std::vector<std::string> words = {"noun", "rea", "ding", "?", "next"};
+  const std::vector<EpdFontFamily::Style> styles = {EpdFontFamily::REGULAR, EpdFontFamily::BOLD, EpdFontFamily::REGULAR,
+                                                    EpdFontFamily::REGULAR, EpdFontFamily::ITALIC};
+  const std::vector<uint8_t> sizes(words.size(), 100);
+  const std::vector<bool> continues = {false, false, true, true, false};
+  TextBlock::WordRange range = makeRange(words, styles, sizes, 0, words.size());
+  range.continues = &continues;
+
+  TextBlock block(range, {0, 40, 70, 110, 130}, BlockStyle());
+  ASSERT_TRUE(block.valid());
+  for (uint16_t i = 0; i < words.size(); i++) {
+    EXPECT_EQ(block.wordContinues(i), continues[i]) << "word " << i;
+    EXPECT_EQ(block.wordStyle(i), styles[i]) << "word " << i;
+  }
+}
+
+// A style that uses the top of the 7-bit range must not be mistaken for a continuation, and a
+// continuation must not smuggle a bit into the style.
+TEST(TextBlockContinues, HighStyleBitsSurviveAlongsideTheFlag) {
+  const std::vector<std::string> words = {"small", "caps"};
+  const auto smallCapsBold = static_cast<EpdFontFamily::Style>(EpdFontFamily::SMALL_CAPS | EpdFontFamily::BOLD |
+                                                               EpdFontFamily::SUP | EpdFontFamily::UNDERLINE);
+  const std::vector<EpdFontFamily::Style> styles = {smallCapsBold, smallCapsBold};
+  const std::vector<uint8_t> sizes(words.size(), 100);
+  const std::vector<bool> continues = {false, true};
+  TextBlock::WordRange range = makeRange(words, styles, sizes, 0, words.size());
+  range.continues = &continues;
+
+  TextBlock block(range, {0, 50}, BlockStyle());
+  ASSERT_TRUE(block.valid());
+  EXPECT_EQ(block.wordStyle(0), smallCapsBold);
+  EXPECT_EQ(block.wordStyle(1), smallCapsBold);
+  EXPECT_FALSE(block.wordContinues(0));
+  EXPECT_TRUE(block.wordContinues(1));
+}
+
+// The flags are indexed like the source words, not from 0 -- an interior line must report the
+// flags of the words it actually holds.
+TEST(TextBlockContinues, FlagsFollowTheRangeWindow) {
+  const Fixture f = uniformFixture();
+  const std::vector<bool> continues = {false, false, true, true, false};
+  TextBlock::WordRange range = makeRange(f.words, f.styles, f.sizes, 2, 2);
+  range.continues = &continues;
+
+  TextBlock block(range, {0, 40}, BlockStyle());
+  ASSERT_TRUE(block.valid());
+  EXPECT_TRUE(block.wordContinues(0));  // source word 2
+  EXPECT_TRUE(block.wordContinues(1));  // source word 3
+}
+
+// A caller that does not track continuation (and a cache written before the bit existed) must
+// read as "every word is space-separated".
+TEST(TextBlockContinues, AbsentFlagsMeanNoContinuation) {
+  const Fixture f = uniformFixture();
+  TextBlock block(makeRange(f.words, f.styles, f.sizes, 0, 3), {0, 40, 90}, BlockStyle());
+  ASSERT_TRUE(block.valid());
+  for (uint16_t i = 0; i < 3; i++) EXPECT_FALSE(block.wordContinues(i));
+
+  // A short vector is ignored rather than read out of bounds.
+  const std::vector<bool> tooShort = {true};
+  TextBlock::WordRange range = makeRange(f.words, f.styles, f.sizes, 0, 3);
+  range.continues = &tooShort;
+  TextBlock guarded(range, {0, 40, 90}, BlockStyle());
+  ASSERT_TRUE(guarded.valid());
+  for (uint16_t i = 0; i < 3; i++) EXPECT_FALSE(guarded.wordContinues(i));
+}
+
 }  // namespace

--- a/test/word_size_layout/WordSizeLayoutTest.cpp
+++ b/test/word_size_layout/WordSizeLayoutTest.cpp
@@ -238,6 +238,93 @@ TEST(WordSizeSerialization, ArenaRoundTripPreservesPerWordFields) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Word continuation (issue #206: bionic reading and hyphenation split one word)
+// ---------------------------------------------------------------------------
+
+// Bionic reading rewrites "reading" into a bold "rea" plus a plain "ding". The pieces have to
+// reach the line marked as one word, or the dictionary overlay selects half of it.
+TEST(WordContinuation, BionicHalvesAreMarkedAsOneWord) {
+  GfxRenderer renderer;
+  ParsedText text(false, false, noIndentStyle(), /*bionicReadingEnabled=*/true);
+  text.addWord("reading", EpdFontFamily::REGULAR);
+  text.addWord("here", EpdFontFamily::REGULAR);
+
+  const auto result = layout(text, renderer, 400);
+  ASSERT_EQ(result.lines.size(), 1u);
+  const TextBlock& line = *result.lines[0];
+  ASSERT_EQ(line.wordCount(), 4);
+  EXPECT_STREQ(line.wordText(0), "read");
+  EXPECT_STREQ(line.wordText(1), "ing");
+  EXPECT_STREQ(line.wordText(2), "he");
+  EXPECT_STREQ(line.wordText(3), "re");
+  EXPECT_FALSE(line.wordContinues(0));
+  EXPECT_TRUE(line.wordContinues(1));
+  EXPECT_FALSE(line.wordContinues(2));
+  EXPECT_TRUE(line.wordContinues(3));
+  // The bold prefix is what makes the two pieces look like separate words on screen; the flag
+  // has to survive alongside it.
+  EXPECT_EQ(line.wordStyle(0), EpdFontFamily::BOLD);
+  EXPECT_EQ(line.wordStyle(1), EpdFontFamily::REGULAR);
+}
+
+// Punctuation the parser attaches to a word arrives as its own token with the same flag, so it
+// travels with the word instead of becoming a selectable "word" of its own.
+TEST(WordContinuation, AttachedPunctuationIsMarkedAsContinuation) {
+  GfxRenderer renderer;
+  ParsedText text(false, false, noIndentStyle());
+  text.addWord("question", EpdFontFamily::REGULAR);
+  text.addWord("?", EpdFontFamily::REGULAR, /*underline=*/false, /*attachToPrevious=*/true);
+
+  const auto result = layout(text, renderer, 400);
+  ASSERT_EQ(result.lines.size(), 1u);
+  EXPECT_FALSE(result.lines[0]->wordContinues(0));
+  EXPECT_TRUE(result.lines[0]->wordContinues(1));
+}
+
+// Hyphenation splits the word ACROSS lines, so the halves land in different blocks and no flag
+// can join them. What survives is the shape the overlay keys on: the first line ends on the
+// inserted hyphen and the next starts with the rest of the word.
+TEST(WordContinuation, HyphenationLeavesTheHyphenOnTheFirstLine) {
+  GfxRenderer renderer;
+  ParsedText text(false, /*hyphenationEnabled=*/true, noIndentStyle());
+  text.addWord("Quadratkilometer", EpdFontFamily::REGULAR);
+
+  // Narrow enough that the single word cannot fit, so the breaker has to split it.
+  const auto result = layout(text, renderer, 120);
+  ASSERT_GE(result.lines.size(), 2u);
+  const TextBlock& first = *result.lines[0];
+  const std::string prefix = first.wordText(first.wordCount() - 1);
+  ASSERT_FALSE(prefix.empty());
+  EXPECT_EQ(prefix.back(), '-');
+  EXPECT_FALSE(result.lines[1]->wordContinues(0));  // a new line always starts a new run
+  const std::string suffix = result.lines[1]->wordText(0);
+  ASSERT_FALSE(suffix.empty());
+  // Dropping the inserted hyphen and joining is what reconstructs the word.
+  EXPECT_EQ(prefix.substr(0, prefix.size() - 1) + suffix, "Quadratkilometer");
+}
+
+// The continuation flag shares the style byte with EpdFontFamily::Style, and the arena is
+// written to the section cache verbatim, so the flag has to come back off disk intact.
+TEST(WordSizeSerialization, ContinuationFlagRoundTrips) {
+  const std::vector<std::string> words = {"rea", "ding", "next"};
+  const std::vector<EpdFontFamily::Style> styles = {EpdFontFamily::BOLD, EpdFontFamily::REGULAR, EpdFontFamily::ITALIC};
+  TextBlock original(words, {0, 30, 80}, styles, BlockStyle(), {}, {false, true, false});
+  ASSERT_TRUE(original.valid());
+
+  FsFile file = HalFile::forReadWrite();
+  ASSERT_TRUE(original.serialize(file));
+  ASSERT_TRUE(file.seek(0));
+
+  const auto restored = TextBlock::deserialize(file);
+  ASSERT_NE(restored, nullptr);
+  ASSERT_EQ(restored->wordCount(), words.size());
+  EXPECT_FALSE(restored->wordContinues(0));
+  EXPECT_TRUE(restored->wordContinues(1));
+  EXPECT_FALSE(restored->wordContinues(2));
+  for (uint16_t i = 0; i < words.size(); ++i) EXPECT_EQ(restored->wordStyle(i), styles[i]);
+}
+
 // An empty word ("") is stored as a bare NUL; the offset table must still be
 // strictly increasing and validation must accept it.
 TEST(WordSizeSerialization, EmptyStringWordRoundTrips) {


### PR DESCRIPTION
Fixes #206.

Word selection worked on layout fragments rather than words. With bionic reading on, "reading" offered **read** and **ing** as two separate selections; hyphenation offered **read-** and **ing** on two lines. Neither looked up.

## The data model

Layout already knows which pieces belong together — `ParsedText` sets `wordContinues` on a bionic suffix and on attached punctuation — but `TextBlock` didn't store it, so a consumer walking `wordText()` saw fragments.

The flag now rides in **bit 7 of the packed style byte**. `EpdFontFamily::Style` only uses bits 0–6, the arena is serialized to the section cache verbatim, and `wordStyle()` masks it off — no RAM, no cache bytes, no format change. A pre-existing cache reads the bit as clear, i.e. keeps the old behaviour, so `SECTION_FILE_VERSION` goes 70 → 71 and books re-index once.

## The overlay

`Fragment` (one drawn piece) + `Word` (a run of them). Highlighting, glyph prewarm and the differential snapshot all iterate fragments; the lookup text is joined into a stack buffer, so a word costs no allocation of its own.

Three things needed handling beyond the flag:

**Hyphenation** splits a word across lines into different blocks, and `lineEndsWithHyphenatedWord` never reaches the page cache — so the shape is the evidence instead: a line ending on `-` meeting a word starting the next. The lookup tries the de-hyphenated join first and the hyphenated form second, so a compound broken at its own hyphen (`US-Satellitensystems`) still resolves.

**Spaceless dashes** fuse two words into one layout token — `swiftness—a`, and 274 more in one test book (0.28% of all words). Rebuilt after hyphenation that gave `swiftness—a`, which is no headword, and the retry then handed `swift-ness—a` to a lookup whose compound fallback splits on the hyphen and resolved **swift**. Tokens are now cut at an internal em/en dash, the dash staying with the left piece so the pieces tile the token and the dictionary's own edge-stripping removes it. `isDashSeparatorToken` covers the bionic case, where the dash arrives as its own token instead.

**Two-row words** mean the snapshot holds one packed run per row. Saving their bounding box would cover both whole lines and everything between them — far past the 2 KB cap.

## Heap

The definition guard in `Dictionary.cpp` is a **largest-contiguous-block** test, so these arrays compete directly with the definition being read. Looking up a common word on a bionic page failed with "low memory" while a rare one succeeded.

Capacity is now counted before anything is allocated (a bionic page runs to ~570 fragments; a fixed guess doubled repeatedly, each growth holding the old block alongside the new), and `Fragment` is packed to 16 bytes by deduplicating `(font, scale, line height)` into a side table.

| | contiguous held | peak during extraction |
|---|---|---|
| before this branch | ~28.7 KB | ~43 KB |
| after | **~12.6 KB** | ~12.6 KB |

## Testing

- 612 host tests pass; the pipeline goldens are byte-identical, which is what proves the style mask is clean.
- New coverage: bionic halves, attached punctuation and the hyphen shape in `test/word_size_layout`; bit packing, range windowing, absent/short flag vectors and a serialize round-trip in `test/text_block_range`.
- Dash splitting validated against the full 98k-token stream of a real book: all 271 distinct dash tokens split, every resulting lookup resolves to the bare word.
- Device-validated on X4 across several rounds.

Note the overlay's own text predicates are file-local statics with no unit test — happy to lift them into a testable unit in a follow-up if that's wanted.
