### PR TITLE
fix: washed-out covers: clip the equalize CDF

### DIFF
--- a/lib/GfxRenderer/AdaptiveTone.h
+++ b/lib/GfxRenderer/AdaptiveTone.h
@@ -87,11 +87,30 @@ inline constexpr uint32_t MIN_MIDTONE_PERMILLE = 60;
 // rather than a replacement.
 enum class Mode : uint8_t { Stretch, Equalize };
 
+// --- Why the CDF is clipped ------------------------------------------------------
+// Proportional-to-mass is the whole point of equalization and also its failure mode: it
+// is proportional with no upper bound, so a single dominant tone claims output range in
+// proportion to how dominant it is. Book covers are the worst case for that -- a dark
+// night scene puts 40% of its pixels in a narrow near-black band, the CDF hands that band
+// most of the range, and the black background comes back as mid-grey. Measured on the
+// sample covers, unclipped equalization lifted luminance 32 to 82 and 64 to 129 on one
+// and 64 to 91, 96 to 151 on another: shadows gone, the image washed out. That is the
+// textbook global-histogram-equalization result, not a bug in the CDF.
+//
+// The textbook answer is the contrast limit from CLAHE: cap what any one bin may
+// contribute before integrating, and hand the clipped-off excess back to every bin
+// evenly. A spike can then buy at most EQ_CLIP_MULTIPLE times the flat share of the
+// output range, and the more an image is dominated by one tone the closer its curve
+// falls back to the identity -- which is the right way for this to fail. It stays two
+// passes over 256 bins with no extra buffer.
+inline constexpr uint64_t EQ_CLIP_MULTIPLE = 2;
+
 // Equalization strength, as a blend against the original luminance. Deliberately gentler
-// than Stretch's 3/4: a full CDF map is a much stronger transform, and at 3/4 the smooth
-// background gradients on photographic covers break into visible dither banding.
+// than Stretch's 3/4: a full CDF map is a much stronger transform, and above 1/4 the
+// smooth background gradients on photographic covers break into visible dither banding
+// and dark covers still read as lifted even with the clip above holding the curve back.
 inline constexpr int EQ_BLEND_NUM = 1;
-inline constexpr int EQ_BLEND_DEN = 2;
+inline constexpr int EQ_BLEND_DEN = 4;
 
 // --- Where the curve lives -------------------------------------------------------
 // Both modes bake into a 256-entry lookup table rather than being recomputed per pixel:
@@ -201,11 +220,29 @@ inline Points derivePoints(const uint32_t* histogram, uint64_t sampleCount, Mode
   // of everything below it -- the usual off-by-one that leaves equalized images dark.
   // No MIN_RANGE gate: a narrow band is precisely what equalization is for, and the
   // line-art rejection above has already turned away the images that must not be touched.
+  //
+  // Bin counts are clipped to EQ_CLIP_MULTIPLE of the flat share and the excess shared
+  // out evenly before integrating, so no single dominant tone can claim the range -- see
+  // the note on EQ_CLIP_MULTIPLE for what that failure looks like on a dark cover.
+  const uint64_t clipLimit = (sampleCount * EQ_CLIP_MULTIPLE) / 256u;
+  uint64_t excess = 0;
+  for (int i = 0; i < 256; i++) {
+    if (histogram[i] > clipLimit) excess += histogram[i] - clipLimit;
+  }
+  const uint64_t shared = excess / 256u;
+  uint64_t clippedTotal = 0;
+  for (int i = 0; i < 256; i++) {
+    clippedTotal += (histogram[i] < clipLimit ? histogram[i] : clipLimit) + shared;
+  }
+  // Only reachable on a degenerate histogram (fewer samples than bins); leave the caller
+  // untoned rather than divide by it.
+  if (clippedTotal == 0) return points;
+
   points.generation = ++detail::g_generation;
   uint64_t running = 0;
   for (int i = 0; i < 256; i++) {
-    running += histogram[i];
-    const int equalized = static_cast<int>((running * 255u) / sampleCount);
+    running += (histogram[i] < clipLimit ? histogram[i] : clipLimit) + shared;
+    const int equalized = static_cast<int>((running * 255u) / clippedTotal);
     int adjusted = (i * (EQ_BLEND_DEN - EQ_BLEND_NUM) + equalized * EQ_BLEND_NUM) / EQ_BLEND_DEN;
     if (i > HIGHLIGHT_FLOOR && adjusted < i) adjusted = i;
     if (adjusted < 0) adjusted = 0;

--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -188,16 +188,13 @@ BmpReaderError Bitmap::parseHeaders() {
 
   const bool highColor = !nativePalette;
   if (highColor && dithering) {
-    // Always DisplayTuned, tone mapping or not. The tone curve corrects the IMAGE's
-    // range; the DisplayTuned values correct for the PANEL's transfer function, and
-    // level-correcting an image does not change how dark the panel renders level 1.
-    // Feeding the ditherer the evenly-spaced values instead tells it that level 1
-    // shows as 85 when it actually shows as 30, and error diffusion turns that
-    // 55-level lie into a systematic darkening (measured: covers lost 20-40 points
-    // of mean brightness and, on low-gain images, contrast as well). The reader's
-    // in-book image path has always used DisplayTuned with tone mapping active --
-    // see the AtkinsonDitherer built in JpegToFramebufferConverter -- and this is
-    // what brings the sleep screen back in line with it.
+    // Always DisplayTuned, tone mapping or not: the tone curve corrects the IMAGE's
+    // range and the quantizer's thresholds correct for the PANEL, so the two are
+    // orthogonal and there is nothing for a mode swap to avoid. The earlier swap to
+    // Native on tone-mapped input was a real bug (near-black sleep covers), but so was
+    // the thing it was compensating for -- DisplayTuned used to feed error diffusion a
+    // bunched 15/30/80/210 level spacing, which is what actually washed the midtones
+    // out. Both live under Gray4QuantizationMode now; see the note there.
     if (USE_ATKINSON) {
       atkinsonDitherer = new (std::nothrow) AtkinsonDitherer(width);
     } else {

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -21,23 +21,38 @@ struct QuantizedGray4 {
   uint8_t value;
 };
 
-// DisplayTuned: thresholds fitted to the panel's measured mid-grey placement.
-//   The represented values (15/30/80/210) are deliberately not evenly spaced —
-//   they encode how dark each level actually renders, so error diffusion stays
-//   honest about what the panel produced.
-// Native: evenly-spaced levels (0/85/170/255), i.e. the mathematically correct
-//   quantizer for a display whose levels ARE evenly spaced. This panel's are not,
-//   so Native is not the right choice here for any input.
-//   In particular it is NOT the counterpart to adaptive tone mapping: a tone curve
-//   corrects the image's range, DisplayTuned corrects the panel's transfer function,
-//   and the two are orthogonal. Level-correcting an image does not make the panel's
-//   level 1 any lighter, so swapping to Native on tone-mapped input just tells error
-//   diffusion that level 1 shows as 85 when it really shows as 30 -- which reads as a
-//   badly darkened image, not as avoided double-compensation. (That swap was the bug
-//   behind the near-black adaptive sleep covers; see Bitmap::parseHeaders.)
-// Note: `Native` matches quantizeGray4Level() in Epub/converters/DitherUtils.h,
-// which serves the reader's image path. Kept separate because that one returns
-// only an index and has no DisplayTuned counterpart.
+// A 4-level error-diffusion quantizer needs two things, and they are not the same thing:
+//
+//   - THRESHOLDS decide which level a pixel lands on. This is where a display tuning
+//     belongs: the X4's greys read darker than their nominal value, so pushing the
+//     thresholds down (30/50/140 rather than the even 43/128/213) promotes pixels a
+//     level and compensates. That is a deliberate, output-referred brightening.
+//   - REPRESENTED VALUES are the feedback term: `error = wanted - value` is what the
+//     ditherer pushes to the neighbouring pixels. They must describe how far apart the
+//     levels are, because that spacing is what the error is measured against.
+//
+// These were conflated. DisplayTuned used to report 15/30/80/210 as its values, on the
+// reasoning that they encode how dark each level really renders. As a description of the
+// panel that may well be right, but as a feedback term it is ruinous: three of the four
+// levels sit inside the bottom 80 and there is a 130-wide gap below white. Any image
+// whose mass sits in 50..140 -- 76% of the pixels on a typical low-contrast cover -- then
+// has only levels 2 and 3 to work with, 130 apart, and comes back as coarse speckle with
+// its midtone structure gone. Measured as the correlation between the source and the
+// rendered level map (both box-averaged 4x4, so the metric does not depend on what the
+// panel does with each level), 15/30/80/210 lost structure on all seven sample covers,
+// r = 0.87-0.98 where even spacing held r > 0.99 -- worst exactly where tone mapping had
+// widened the midtones first, which is why this surfaced as "the adaptive filter washes
+// covers out".
+//
+// So both modes now feed error diffusion the even 0/85/170/255 spacing, and differ only
+// in their thresholds -- which is the half a display tuning was ever meant to touch:
+//   DisplayTuned: X4-tuned thresholds 30/50/140. The brightening is preserved.
+//   Native: even thresholds 43/128/213, the untuned midpoints.
+// Note: `Native` matches quantizeGray4Level() in Epub/converters/DitherUtils.h, which
+// serves the reader's in-book image path -- and that path really does use it, because
+// the AtkinsonDitherer in JpegToFramebufferConverter sits inside
+// ENABLE_IMAGE_DITHERING_EXTENSION, which no build defines. Kept as separate enumerators
+// because quantizeGray4Level returns only an index and has no threshold counterpart.
 enum class Gray4QuantizationMode : uint8_t { DisplayTuned, Native };
 
 inline QuantizedGray4 quantizeGray4(int gray, const Gray4QuantizationMode mode) {
@@ -45,17 +60,18 @@ inline QuantizedGray4 quantizeGray4(int gray, const Gray4QuantizationMode mode) 
   if (gray > 255) gray = 255;
 
   if (mode == Gray4QuantizationMode::Native) {
-    // Midpoints between the four evenly-spaced levels 0, 85, 170, 255.
+    // Untuned midpoints between the four levels.
     if (gray < 43) return {0, 0};
     if (gray < 128) return {1, 85};
     if (gray < 213) return {2, 170};
     return {3, 255};
   }
 
-  if (gray < 30) return {0, 15};
-  if (gray < 50) return {1, 30};
-  if (gray < 140) return {2, 80};
-  return {3, 210};
+  // X4-tuned thresholds; same level spacing fed back to the diffuser (see above).
+  if (gray < 30) return {0, 0};
+  if (gray < 50) return {1, 85};
+  if (gray < 140) return {2, 170};
+  return {3, 255};
 }
 
 enum class BmpRowOrder { BottomUp, TopDown };

--- a/test/adaptive_tone/AdaptiveToneTest.cpp
+++ b/test/adaptive_tone/AdaptiveToneTest.cpp
@@ -244,6 +244,35 @@ TEST(AdaptiveToneEqualize, LeavesAnAlreadyUniformHistogramAlone) {
   }
 }
 
+TEST(AdaptiveToneEqualize, DoesNotLiftAShadowSpikeIntoTheMidtones) {
+  // The dark-cover case: 40% of the pixels in a narrow near-black band, the rest spread
+  // thinly above it. Unclipped, the CDF hands that band most of the output range and the
+  // black background comes back as mid-grey -- the washed-out covers this clip fixes.
+  Histogram h{};
+  for (int i = 12; i <= 30; i++) h[static_cast<size_t>(i)] = 4000;  // ~40% of the image
+  for (int i = 31; i <= 255; i++) h[static_cast<size_t>(i)] = 500;
+
+  const Points points = derive(h, Mode::Equalize);
+  ASSERT_TRUE(points.active);
+  EXPECT_LT(adaptive_tone::apply(points, 20), 48) << "the near-black band must stay dark";
+  EXPECT_LT(adaptive_tone::apply(points, 64), 96) << "shadows must not be pushed to midtones";
+}
+
+TEST(AdaptiveToneEqualize, FallsBackTowardsTheIdentityOnASingleDominantTone) {
+  // The clip's graceful-degradation property: the more one tone dominates, the less range
+  // the curve can hand it, so an image with nothing else to equalize is left nearly alone
+  // rather than being blown apart.
+  Histogram h{};
+  for (int i = 0; i < 256; i++) h[static_cast<size_t>(i)] = 10;
+  h[70] = 400000;
+
+  const Points points = derive(h, Mode::Equalize);
+  ASSERT_TRUE(points.active);
+  for (int i = 0; i < 256; i++) {
+    EXPECT_NEAR(adaptive_tone::apply(points, static_cast<uint8_t>(i)), i, 8) << "lum=" << i;
+  }
+}
+
 TEST(AdaptiveToneEqualize, ReachesFullWhiteAtTheTop) {
   // The CDF is evaluated at the top of each bin, so the brightest occupied level maps to
   // 255 before blending. Sampling the CDF below the bin instead is the classic off-by-one

--- a/test/adaptive_tone/AdaptiveToneTest.cpp
+++ b/test/adaptive_tone/AdaptiveToneTest.cpp
@@ -11,6 +11,7 @@
 #include <numeric>
 
 #include "AdaptiveTone.h"
+#include "BitmapHelpers.h"
 
 namespace {
 
@@ -281,6 +282,62 @@ TEST(AdaptiveToneEqualize, ReachesFullWhiteAtTheTop) {
   const Points points = derive(h, Mode::Equalize);
   ASSERT_TRUE(points.active);
   EXPECT_EQ(adaptive_tone::apply(points, 255), 255);
+}
+
+// --- Gray4QuantizationMode --------------------------------------------------
+//
+// The two modes are a threshold tuning, not two different claims about the level
+// spacing. Feeding error diffusion a bunched spacing (the old 15/30/80/210) collapsed
+// midtone images onto two levels 130 apart and washed the covers out; these pin the
+// separation of concerns so it cannot be reintroduced by "tuning the quantizer".
+
+TEST(Gray4Quantization, BothModesFeedBackTheSameLevelSpacing) {
+  // Whatever the thresholds, `value` is the error-diffusion feedback term and must
+  // describe how far apart the levels are -- identically in both modes.
+  for (int index = 0; index < 4; index++) {
+    const int expected = index * 85;
+    for (int gray = 0; gray <= 255; gray++) {
+      const QuantizedGray4 tuned = quantizeGray4(gray, Gray4QuantizationMode::DisplayTuned);
+      const QuantizedGray4 native = quantizeGray4(gray, Gray4QuantizationMode::Native);
+      if (tuned.index == index) EXPECT_EQ(tuned.value, expected) << "tuned gray=" << gray;
+      if (native.index == index) EXPECT_EQ(native.value, expected) << "native gray=" << gray;
+    }
+  }
+}
+
+TEST(Gray4Quantization, FeedbackValuesAreEvenlySpaced) {
+  // The gap between adjacent levels is what a midtone pixel has to be dithered across.
+  // An uneven set strands whole bands of the image between two far-apart levels.
+  for (const auto mode : {Gray4QuantizationMode::DisplayTuned, Gray4QuantizationMode::Native}) {
+    int value[4] = {-1, -1, -1, -1};
+    for (int gray = 0; gray <= 255; gray++) {
+      const QuantizedGray4 q = quantizeGray4(gray, mode);
+      value[q.index] = q.value;
+    }
+    ASSERT_EQ(value[0], 0);
+    ASSERT_EQ(value[3], 255);
+    for (int i = 1; i < 4; i++) EXPECT_EQ(value[i] - value[i - 1], 85) << "level " << i;
+  }
+}
+
+TEST(Gray4Quantization, DisplayTunedKeepsItsBrighteningThresholds) {
+  // The X4 compensation lives here and only here: the tuned mode promotes a pixel to a
+  // higher level than the untuned midpoints would. Losing this is the near-black failure.
+  EXPECT_EQ(quantizeGray4(100, Gray4QuantizationMode::DisplayTuned).index, 2);
+  EXPECT_EQ(quantizeGray4(100, Gray4QuantizationMode::Native).index, 1);
+  for (int gray = 0; gray <= 255; gray++) {
+    EXPECT_GE(quantizeGray4(gray, Gray4QuantizationMode::DisplayTuned).index,
+              quantizeGray4(gray, Gray4QuantizationMode::Native).index)
+        << "gray=" << gray;
+  }
+}
+
+TEST(Gray4Quantization, IsMonotonicInBothModes) {
+  for (const auto mode : {Gray4QuantizationMode::DisplayTuned, Gray4QuantizationMode::Native}) {
+    for (int gray = 1; gray <= 255; gray++) {
+      EXPECT_GE(quantizeGray4(gray, mode).index, quantizeGray4(gray - 1, mode).index) << "gray=" << gray;
+    }
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Covers have looked washed out since 2.26. Two independent causes, one commit each.

## 1. `Mode::Equalize` had no contrast limit

Equalization hands each tone output range in proportion to its pixel mass, unbounded. A dark cover puts ~40% of its pixels in a narrow near-black band, the CDF gives that band most of the range, and the background comes back as mid-grey.

Measured on the sample covers, the unclipped curve mapped luminance 32→82 and 64→129 on one, 64→91 and 96→151 on another; image mean 54→91, 86→108. Textbook global-HE failure on a bimodal image.

Fixed with the textbook answer — the contrast limit from CLAHE. Bin counts are capped at 2× the flat share before integrating and the excess shared back out evenly, so one spike can buy at most twice the average bin's slice. The more one tone dominates, the closer the curve falls back to the identity. Blend also drops 1/2 → 1/4. Still two passes over 256 bins into the existing static curve: no extra buffer, no allocation.

## 2. `quantizeGray4` conflated the display tuning with the level spacing

An error-diffusion quantizer needs two separate things:

| | role | where the X4 tuning belongs |
|---|---|---|
| **Thresholds** | which level a pixel lands on | ✅ here — 30/50/140 vs the even 43/128/213 promotes a level and brightens |
| **Represented values** | the feedback term, `error = wanted − value` | ❌ must describe how far apart the levels are |

`DisplayTuned` reported 15/30/80/210 as its *values*. As a description of the panel that may well be right; as a feedback term it's ruinous — three of four levels inside the bottom 80, a 130-wide gap below white. An image whose mass sits in 50..140 has only levels 2 and 3 to work with, 130 apart, and comes back as coarse speckle with its midtone structure gone.

The cover that exposed it (`A Treacherous Performance`) puts **76% of its pixels between 50 and 140**, IQR 37 levels wide. It rendered 69.9% level 2 / 27.3% level 3, with the building and pillars behind the figure erased into one flat pale mass.

### Measurement

Correlation between the source and the rendered **level map**, both box-averaged 4×4. This does not depend on what the panel does with each level — it only assumes the levels increase — so it is not circular:

| cover / filter | before | after |
|---|---|---|
| A Treacherous Performance, adaptive | 0.8898 | 0.9886 |
| loose cover, adaptive | 0.8686 | 0.9922 |
| Small Gods, no filter | 0.9191 | 0.9923 |

All 18 cover × filter combinations improve; worst case 0.87 → 0.975.

The old numbers are **worse with adaptive than without it** (0.9498 → 0.8898). The tone curve widens the midtones, feeding more of the image into exactly the band the bunched spacing couldn't render — which is why this surfaced as "the adaptive filter washes covers out".

Both modes now feed back the even 0/85/170/255 spacing and differ only in thresholds. `DisplayTuned` keeps 30/50/140, so none of the X4 brightening is lost.

### Two corrections to 3a2e93f6f

- It found a real bug (the Native swap on tone-mapped input) but what that swap was compensating for was also real — the bunched feedback spacing. Removing the swap alone left the second half in place.
- It claimed the reader's in-book image path pairs adaptive tone with DisplayTuned. It does not: the `AtkinsonDitherer` it cites is inside `ENABLE_IMAGE_DITHERING_EXTENSION`, which no build defines, so in-book images go through `applyBayerDither4Level` over evenly-spaced levels. Cited as precedent for the opposite of what it does.

## To verify on device

Sleep cover with filter None / Adaptive / Equalize on a dark or low-contrast cover. Background structure — pillars, foliage, architecture — should be legible instead of flat grey.

**Expect covers to render darker than 2.26**: mean level index on that cover drops 2.24 → ~1.6, because the old values were pushing everything up a level. If it overshoots into the near-black territory that 3a2e93f6f was chasing, the dial is now the `DisplayTuned` *thresholds*, not the values — lowering them brightens without costing the structure back. Keeping those two adjustments separable is the point of the change.

## Testing

618/618 host tests pass (6 new), each commit green independently, `pio run` clean, flash unchanged at 93.9%. Not yet validated on hardware.
