### PR TITLE
fix(reader): restore Background-B look-ahead, and slice the footnote resolve (#211)

### DIFF
--- a/lib/Epub/Epub/FootnotePreviews.cpp
+++ b/lib/Epub/Epub/FootnotePreviews.cpp
@@ -1,7 +1,9 @@
 #include "FootnotePreviews.h"
 
+#include <BuildArena.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
+#include <InflateReader.h>
 #include <Logging.h>
 #include <Memory.h>
 #include <SaxParser/SaxParser.h>
@@ -98,6 +100,7 @@ class NoThrowArray {
     data_[size_++] = value;
     return true;
   }
+  void clear() { size_ = 0; }
   void pop() {
     if (size_ > 0) --size_;
   }
@@ -349,76 +352,137 @@ class NoteCapturer {
   }
 };
 
-// Streams one spine entry through a SAX consumer. Returns false on ZIP/read errors;
-// SAX-level errors are tolerated (consumer keeps whatever it saw — same policy as the
-// section parser, which survives loose real-world HTML).
-template <typename Consumer>
-bool streamSpineEntry(ZipFile& zip, const std::string& href, uint8_t* chunk, Consumer& consumer, FsFile* bank) {
-  ZipFile::EntryReader reader(zip, STREAM_CHUNK_BYTES);
-  if (!reader.open(FsHelpers::normalisePath(href).c_str())) {
-    return false;
-  }
-  bool done = false;
-  bool malformed = false;
-  while (!done) {
-    size_t produced = 0;
-    if (!reader.step(chunk, STREAM_CHUNK_BYTES, &produced, &done)) {
-      return false;
-    }
-    if (produced > 0) {
-      // Bank the inflated bytes as we pass them on, in the same file the section builder writes
-      // and validates by size. A note document is rarely a chapter anyone reads, so without this
-      // every chapter pointing into it would inflate it again.
-      if (bank) bank->write(chunk, produced);
-      if (!consumer.feed(chunk, produced)) {
-        malformed = true;  // malformed markup mid-stream: keep partial results
-        break;
+// One spine document, read a chunk at a time, from wherever it is cheapest.
+//
+// Prefers the inflated XHTML the section builder already left on SD (sections/html_<spine>.bin,
+// keyed on the spine alone) over re-opening and re-inflating the ZIP entry. Every spine the
+// reader has actually built is sitting there in plain text: inflating it again repeats work a
+// build just did, and needs the ZIP's 4 KB EOCD window plus a ~32 KB inflate ring at exactly the
+// moment — mid-read, framebuffer resident — the heap can least afford them. Same staleness test
+// as the builder: a size mismatch means partial or out-of-date, so fall back to the ZIP (and
+// leave the file alone; the next build re-validates it).
+//
+// next() yields AT MOST one chunk per call and keeps its position, which is what lets the
+// resolver spread a document across as many slices as it takes. The one-shot helpers below are
+// written on top of it so the two paths cannot drift.
+class DocStream {
+ public:
+  ~DocStream() { close(); }
+
+  // bankIt: write the inflated bytes to the spine's HTML cache as they stream past, so the next
+  // chapter pointing into this document reads SD instead of inflating. Ignored when the document
+  // is already being read from that cache.
+  bool open(Epub& epub, ZipFile& zip, const int spineIndex, const std::string& bankedHtmlPath, const bool bankIt,
+            BuildArena* arena = nullptr) {
+    close();
+    size_t inflatedSize = 0;
+    const std::string htmlPath =
+        bankedHtmlPath.empty() ? Section::sectionHtmlCachePath(epub.getCachePath(), spineIndex) : bankedHtmlPath;
+    if (epub.getSpineItemInflatedSize(spineIndex, &inflatedSize) && inflatedSize > 0) {
+      if (Storage.openFileForRead("FNP", htmlPath, file_)) {
+        if (file_.size() == inflatedSize) {
+          return true;
+        }
+        file_.close();
       }
     }
+    // Only the ZIP path allocates anything worth placing: a read buffer plus an inflate ring
+    // sized to the entry (up to 32 KB). Put both in the build's arena when there is room — a
+    // resolve runs in slices, so a heap-backed ring would sit on the reading heap across every
+    // page render in between. EntryReader does NOT fall back if an arena alloc fails, so the
+    // capacity is checked here (mirrors Section::runBuildParse's extract).
+    const size_t arenaWanted =
+        STREAM_CHUNK_BYTES + InflateReader::ringSizeFor(inflatedSize) + 2 * alignof(std::max_align_t);
+    BuildArena* useArena =
+        (arena && arena->valid() && arena->capacity() - arena->used() >= arenaWanted) ? arena : nullptr;
+    reader_ = makeUniqueNoThrow<ZipFile::EntryReader>(zip, STREAM_CHUNK_BYTES, useArena);
+    if (!reader_ || !reader_->open(FsHelpers::normalisePath(epub.getSpineItem(spineIndex).href).c_str())) {
+      reader_.reset();
+      return false;
+    }
+    banking_ = bankIt && Storage.openFileForWrite("FNP", htmlPath, bank_);
+    return true;
   }
-  consumer.finalize();
-  // A banked file is only usable if it is complete: the builder's staleness test is a size
-  // match, and a short file would be re-inflated anyway. Nothing to do here — the caller closes
-  // it and a partial write simply fails that test later.
-  (void)malformed;
-  return true;
-}
 
-// Feeds one spine document to a SAX consumer, preferring the inflated XHTML the section builder
-// already left on SD (sections/html_<spine>.bin, keyed on the spine alone) over re-opening and
-// re-inflating the ZIP entry. Every spine the reader has actually built is sitting there in plain
-// text: inflating it again repeats work a build just did, and needs the ZIP's 4 KB EOCD window
-// plus a ~32 KB inflate ring at exactly the moment — mid-read, framebuffer resident — the heap can
-// least afford them. Same staleness test as the builder: a size mismatch means partial or
-// out-of-date, so fall back to the ZIP (and leave the file alone; the next build re-validates it).
+  // Fills `out` with up to `cap` bytes. Returns the byte count and sets *done when the document
+  // is exhausted; -1 on a read/inflate error.
+  int next(uint8_t* out, const size_t cap, bool* done) {
+    *done = false;
+    if (file_) {
+      const int n = file_.read(out, cap);
+      if (n <= 0) {
+        *done = true;
+        return n < 0 ? -1 : 0;
+      }
+      return n;
+    }
+    if (!reader_) {
+      *done = true;
+      return 0;
+    }
+    size_t produced = 0;
+    if (!reader_->step(out, cap, &produced, done)) {
+      return -1;
+    }
+    // Bank the inflated bytes as they pass. A banked file is only usable if it is complete: the
+    // builder's staleness test is a size match, so a stream abandoned part-way simply fails that
+    // test later and is re-inflated — nothing to undo here.
+    if (banking_ && produced > 0) bank_.write(out, produced);
+    return static_cast<int>(produced);
+  }
+
+  void close() {
+    if (file_) file_.close();
+    reader_.reset();
+    if (banking_) {
+      bank_.close();
+      banking_ = false;
+    }
+  }
+
+ private:
+  FsFile file_;                                   // banked XHTML (preferred), unset on the ZIP path
+  std::unique_ptr<ZipFile::EntryReader> reader_;  // ZIP path; heap because EntryReader is not movable-in-place
+  FsFile bank_;
+  bool banking_ = false;
+};
+
+// Feeds one whole spine document to a SAX consumer in one call. Returns false on ZIP/read
+// errors; SAX-level errors are tolerated (the consumer keeps whatever it saw — same policy as
+// the section parser, which survives loose real-world HTML).
 template <typename Consumer>
 bool streamSpineDocument(Epub& epub, ZipFile& zip, const int spineIndex, const std::string& bankedHtmlPath,
                          uint8_t* chunk, Consumer& consumer, const bool bankIt = false) {
-  size_t inflatedSize = 0;
-  const std::string htmlPath =
-      bankedHtmlPath.empty() ? Section::sectionHtmlCachePath(epub.getCachePath(), spineIndex) : bankedHtmlPath;
-  if (epub.getSpineItemInflatedSize(spineIndex, &inflatedSize) && inflatedSize > 0) {
-    FsFile html;
-    if (Storage.openFileForRead("FNP", htmlPath, html)) {
-      if (html.size() == inflatedSize) {
-        while (true) {
-          const int n = html.read(chunk, STREAM_CHUNK_BYTES);
-          if (n <= 0) break;
-          if (!consumer.feed(chunk, static_cast<size_t>(n))) break;  // malformed: keep partial results
-        }
-        consumer.finalize();
-        html.close();
-        return true;
-      }
-      html.close();
+  DocStream doc;
+  if (!doc.open(epub, zip, spineIndex, bankedHtmlPath, bankIt)) {
+    return false;
+  }
+  bool done = false;
+  while (!done) {
+    const int n = doc.next(chunk, STREAM_CHUNK_BYTES, &done);
+    if (n < 0) {
+      return false;
+    }
+    if (n > 0 && !consumer.feed(chunk, static_cast<size_t>(n))) {
+      break;  // malformed markup mid-stream: keep partial results
     }
   }
-  FsFile bank;
-  const bool banking = bankIt && Storage.openFileForWrite("FNP", htmlPath, bank);
-  const bool ok = streamSpineEntry(zip, epub.getSpineItem(spineIndex).href, chunk, consumer, banking ? &bank : nullptr);
-  if (banking) bank.close();
-  return ok;
+  consumer.finalize();
+  return true;
 }
+
+// Phases of one spine's resolve. Linear: each falls through to the next, and every one of them
+// does a BOUNDED amount of work per step() so the caller keeps control of the loop task.
+enum class ResolvePhase : uint8_t {
+  ScanSpine,    // pass A: SAX-scan this spine's document for footnote-shaped links
+  OpenStore,    // read the store, work out which of those targets are missing
+  PlanNotes,    // group the missing targets by the document they live in, open the append
+  OpenNote,     // start (or finish) one note document
+  CaptureNote,  // pass B: SAX-scan that document, capturing text at the wanted anchors
+  Commit,       // write the merged index, set the resolved bit
+  Finished,
+  Failed,
+};
 
 }  // namespace
 
@@ -597,135 +661,278 @@ bool markSpineResolved(Store& store, const int spineIndex) {
 
 }  // namespace
 
-bool resolveSpine(Epub& epub, const int spineIndex, const std::string& bankedHtmlPath) {
-  const uint32_t startMs = millis();
-  const std::string storePath = epub.getCachePath() + CACHE_FILENAME;
+struct Resolver::State {
+  Epub* epub = nullptr;
+  int spineIndex = -1;
+  std::string banked;
+  BuildArena* arena = nullptr;
+  uint32_t startMs = 0;
+  ResolvePhase phase = ResolvePhase::ScanSpine;
+
+  std::unique_ptr<uint8_t[]> chunk;
+  // Declared before `doc`: members destroy in reverse order and the reader inside DocStream
+  // holds a handle (and possibly an arena block) that must go first.
+  std::unique_ptr<ZipFile> zip;
+  DocStream doc;
+  bool docOpen = false;
+
+  NoThrowArray<Target> targets;
+  std::unique_ptr<LinkScanner> scanner;
+
+  Store store;
+  bool appending = false;  // beginAppend() succeeded; teardown must roll the store back
+  NoThrowArray<Target> missing;
+  NoThrowArray<uint16_t> noteSpines;
+  size_t noteCursor = 0;
+  NoThrowArray<uint32_t> wanted;
+  std::unique_ptr<NoteCapturer> capturer;
+
+  // Rolls back a half-finished append so the store stays exactly as complete as it was. Safe to
+  // call repeatedly, and called from the destructor: a resolve preempted mid-way (the reader
+  // turned a page and Background-B handed its buffer back) must leave nothing behind.
+  void rollBack() {
+    if (appending) {
+      appending = false;
+      store.abandon();
+    }
+  }
+};
+
+Resolver::Resolver() = default;
+Resolver::~Resolver() {
+  if (state_) state_->rollBack();
+}
+
+bool Resolver::begin(Epub& epub, const int spineIndex, const std::string& bankedHtmlPath, BuildArena* arena) {
+  state_ = makeUniqueNoThrow<State>();
+  if (!state_) {
+    LOG_ERR("FNP", "OOM: cannot allocate the resolver");
+    return false;
+  }
+  State& st = *state_;
+  st.epub = &epub;
+  st.spineIndex = spineIndex;
+  st.banked = bankedHtmlPath;
+  st.arena = arena;
+  st.startMs = millis();
 
   // Already done, in this session or an earlier one: no scan, no parser, no file reads beyond
   // one 13-byte peek. Without this every rebuild of a spine — a font change, a variant miss —
   // re-scanned the whole document with a 9.2 KB parser only to learn that nothing was missing.
   if (spineResolved(epub.getCachePath(), spineIndex)) {
+    st.phase = ResolvePhase::Finished;
     return true;
   }
 
-  auto chunk = makeUniqueNoThrow<uint8_t[]>(STREAM_CHUNK_BYTES);
-  if (!chunk) {
-    LOG_ERR("FNP", "OOM: cannot allocate %u-byte stream chunk", static_cast<uint32_t>(STREAM_CHUNK_BYTES));
+  st.chunk = makeUniqueNoThrow<uint8_t[]>(STREAM_CHUNK_BYTES);
+  if (!st.chunk || !st.targets.reserve(16)) {
+    LOG_ERR("FNP", "OOM: cannot allocate the resolver's scan buffers");
     return false;
   }
-
   // Reuse the book's cached central-directory details: without this every pass re-scans for the
   // EOCD record, a 4 KB contiguous allocation before a single byte is read. Spines served from
   // banked XHTML never touch the ZIP at all.
-  ZipFile zip(epub.getPath());
-  epub.primeZip(zip);
-
-  // Pass A — this spine's callers, from the XHTML the build just banked.
-  NoThrowArray<Target> targets;
-  if (!targets.reserve(16)) {
-    LOG_ERR("FNP", "OOM: cannot allocate the target list");
+  st.zip = makeUniqueNoThrow<ZipFile>(epub.getPath());
+  if (!st.zip) {
+    LOG_ERR("FNP", "OOM: cannot allocate the archive reader");
     return false;
   }
-  {
-    LinkScanner scanner(epub, spineIndex, targets);
-    if (!scanner.setup()) {
-      LOG_ERR("FNP", "Link scanner setup failed (spine=%d)", spineIndex);
-      return false;
-    }
-    if (!streamSpineDocument(epub, zip, spineIndex, bankedHtmlPath, chunk.get(), scanner)) {
-      LOG_ERR("FNP", "Could not read spine %d for its link scan", spineIndex);
-      return false;
-    }
-    if (scanner.outOfMemory()) {
-      LOG_ERR("FNP", "OOM growing the target list for spine %d", spineIndex);
-      return false;
-    }
-  }
-  Store store;
-  if (!store.open(storePath)) {
-    LOG_ERR("FNP", "Could not open the preview store");
-    return false;
-  }
-
-  // A chapter with no notes still gets its bit, and that matters: the bit means "scanned, nothing
-  // outstanding", not "has notes". Background-B reads it to decide whether a spine is safe to
-  // build without doing this work itself, and a book without footnotes must not look permanently
-  // unresolved to it.
-  if (targets.size() == 0) {
-    return markSpineResolved(store, spineIndex);
-  }
-
-  // Drop what is already known. A spine resolved in an earlier session lands here with every
-  // target present and stops, having cost one SAX walk over a local file.
-  NoThrowArray<Target> missing;
-  if (!missing.reserve(targets.size())) {
-    return false;
-  }
-  for (const Target& t : targets) {
-    if (!store.contains(t.keyHash)) missing.push(t);
-  }
-  if (missing.size() == 0) {
-    LOG_DBG("FNP", "Spine %d: all %u note targets already resolved", spineIndex, static_cast<uint32_t>(targets.size()));
-    return true;
-  }
-  if (store.full()) {
-    LOG_ERR("FNP", "Preview store is at its %u-entry cap; spine %d keeps plain markers",
-            static_cast<uint32_t>(FootnotePreviews::MAX_ENTRIES), spineIndex);
-    return true;  // not a failure: the book is simply larger than the budget
-  }
-
-  // Pass B — one stream per distinct note document, capturing the anchors this spine wants.
-  NoThrowArray<uint16_t> noteSpines;
-  if (!noteSpines.reserve(missing.size())) {
-    return false;
-  }
-  for (const Target& t : missing) {
-    if (std::find(noteSpines.begin(), noteSpines.end(), t.spineIndex) == noteSpines.end()) {
-      noteSpines.push(t.spineIndex);
-    }
-  }
-
-  if (!store.beginAppend()) {
-    LOG_ERR("FNP", "Could not open the preview store for append");
-    return false;
-  }
-  for (size_t s = 0; s < noteSpines.size(); ++s) {
-    NoThrowArray<uint32_t> wanted;
-    if (!wanted.reserve(missing.size())) {
-      store.abandon();
-      return false;
-    }
-    for (const Target& t : missing) {
-      if (t.spineIndex == noteSpines[s]) wanted.push(t.keyHash);
-    }
-    NoteCapturer capturer(noteSpines[s], wanted, [&](const uint32_t keyHash, const char* text, const size_t len) {
-      store.addNote(keyHash, text, len);
-    });
-    if (!capturer.setup()) {
-      LOG_ERR("FNP", "Note capturer setup failed (spine=%u)", noteSpines[s]);
-      store.abandon();
-      return false;
-    }
-    // A note document the reader has already visited is banked like any other spine; one that
-    // has not is streamed from the ZIP and banked on the way past, so the next chapter that
-    // points into it pays an SD read instead of an inflate.
-    if (!streamSpineDocument(epub, zip, noteSpines[s], {}, chunk.get(), capturer, /*bankIt=*/true)) {
-      LOG_ERR("FNP", "Could not read note document %u", noteSpines[s]);
-      store.abandon();
-      return false;
-    }
-  }
-  const size_t added = store.added();
-  store.markResolved(spineIndex);
-  if (!store.commit()) {
-    LOG_ERR("FNP", "Could not write the preview store");
-    return false;
-  }
-  epub.adoptZipDetails(zip);
-  LOG_INF("FNP", "Spine %d: resolved %u of %u note targets from %u document(s) in %lums", spineIndex,
-          static_cast<uint32_t>(added), static_cast<uint32_t>(missing.size()), static_cast<uint32_t>(noteSpines.size()),
-          millis() - startMs);
+  epub.primeZip(*st.zip);
   return true;
+}
+
+Resolver::Step Resolver::step() {
+  if (!state_) {
+    return Step::Failed;
+  }
+  State& st = *state_;
+  const auto fail = [&st](const char* what) {
+    LOG_ERR("FNP", "%s (spine=%d)", what, st.spineIndex);
+    st.doc.close();
+    st.rollBack();
+    st.phase = ResolvePhase::Failed;
+    return Step::Failed;
+  };
+
+  switch (st.phase) {
+    case ResolvePhase::Finished:
+      return Step::Done;
+    case ResolvePhase::Failed:
+      return Step::Failed;
+
+    case ResolvePhase::ScanSpine: {
+      if (!st.docOpen) {
+        st.scanner = makeUniqueNoThrow<LinkScanner>(*st.epub, st.spineIndex, st.targets);
+        if (!st.scanner || !st.scanner->setup()) {
+          return fail("Link scanner setup failed");
+        }
+        if (!st.doc.open(*st.epub, *st.zip, st.spineIndex, st.banked, /*bankIt=*/false, st.arena)) {
+          return fail("Could not read the spine for its link scan");
+        }
+        st.docOpen = true;
+        return Step::More;
+      }
+      bool done = false;
+      const int n = st.doc.next(st.chunk.get(), STREAM_CHUNK_BYTES, &done);
+      if (n < 0) {
+        return fail("Read error during the link scan");
+      }
+      // A short feed means malformed markup: keep the partial results, exactly as the section
+      // parser does, and stop reading this document.
+      if (n > 0 && !st.scanner->feed(st.chunk.get(), static_cast<size_t>(n))) {
+        done = true;
+      }
+      if (!done) {
+        return Step::More;
+      }
+      st.scanner->finalize();
+      const bool oom = st.scanner->outOfMemory();
+      st.scanner.reset();
+      st.doc.close();
+      st.docOpen = false;
+      if (oom) {
+        return fail("OOM growing the target list");
+      }
+      st.phase = ResolvePhase::OpenStore;
+      return Step::More;
+    }
+
+    case ResolvePhase::OpenStore: {
+      if (!st.store.open(st.epub->getCachePath() + CACHE_FILENAME)) {
+        return fail("Could not open the preview store");
+      }
+      // A chapter with no notes still gets its bit, and that matters: the bit means "scanned,
+      // nothing outstanding", not "has notes". Background-B reads it to size the gates it puts
+      // in front of a build, and a book without footnotes must not look permanently unresolved.
+      // The same is true of a chapter whose every target another chapter already stored.
+      if (!st.missing.reserve(st.targets.size() > 0 ? st.targets.size() : 1)) {
+        return fail("OOM sizing the missing-target list");
+      }
+      for (const Target& t : st.targets) {
+        if (!st.store.contains(t.keyHash)) st.missing.push(t);
+      }
+      if (st.missing.size() == 0) {
+        LOG_DBG("FNP", "Spine %d: %u note targets, all already resolved", st.spineIndex,
+                static_cast<uint32_t>(st.targets.size()));
+        st.phase = ResolvePhase::Commit;
+        return Step::More;
+      }
+      if (st.store.full()) {
+        // Not a failure: the book is simply larger than the budget. No bit either — the targets
+        // really are outstanding, so a later pass with room should still try.
+        LOG_ERR("FNP", "Preview store is at its %u-entry cap; spine %d keeps plain markers",
+                static_cast<uint32_t>(MAX_ENTRIES), st.spineIndex);
+        st.phase = ResolvePhase::Finished;
+        return Step::Done;
+      }
+      st.phase = ResolvePhase::PlanNotes;
+      return Step::More;
+    }
+
+    case ResolvePhase::PlanNotes: {
+      if (!st.noteSpines.reserve(st.missing.size())) {
+        return fail("OOM planning the note documents");
+      }
+      for (const Target& t : st.missing) {
+        if (std::find(st.noteSpines.begin(), st.noteSpines.end(), t.spineIndex) == st.noteSpines.end()) {
+          st.noteSpines.push(t.spineIndex);
+        }
+      }
+      if (!st.store.beginAppend()) {
+        return fail("Could not open the preview store for append");
+      }
+      st.appending = true;
+      st.phase = ResolvePhase::OpenNote;
+      return Step::More;
+    }
+
+    case ResolvePhase::OpenNote: {
+      if (st.noteCursor >= st.noteSpines.size()) {
+        st.phase = ResolvePhase::Commit;
+        return Step::More;
+      }
+      const uint16_t noteSpine = st.noteSpines[st.noteCursor];
+      st.wanted.clear();
+      if (!st.wanted.reserve(st.missing.size())) {
+        return fail("OOM listing the anchors wanted from one note document");
+      }
+      for (const Target& t : st.missing) {
+        if (t.spineIndex == noteSpine) st.wanted.push(t.keyHash);
+      }
+      st.capturer = makeUniqueNoThrow<NoteCapturer>(
+          noteSpine, st.wanted,
+          [&st](const uint32_t keyHash, const char* text, const size_t len) { st.store.addNote(keyHash, text, len); });
+      if (!st.capturer || !st.capturer->setup()) {
+        return fail("Note capturer setup failed");
+      }
+      // A note document the reader has already visited is banked like any other spine; one that
+      // has not is streamed from the ZIP and banked on the way past, so the next chapter that
+      // points into it pays an SD read instead of an inflate.
+      if (!st.doc.open(*st.epub, *st.zip, noteSpine, {}, /*bankIt=*/true, st.arena)) {
+        return fail("Could not read a note document");
+      }
+      st.docOpen = true;
+      st.phase = ResolvePhase::CaptureNote;
+      return Step::More;
+    }
+
+    case ResolvePhase::CaptureNote: {
+      bool done = false;
+      const int n = st.doc.next(st.chunk.get(), STREAM_CHUNK_BYTES, &done);
+      if (n < 0) {
+        return fail("Read error inside a note document");
+      }
+      if (n > 0 && !st.capturer->feed(st.chunk.get(), static_cast<size_t>(n))) {
+        done = true;
+      }
+      if (!done) {
+        return Step::More;
+      }
+      st.capturer->finalize();
+      st.capturer.reset();
+      st.doc.close();
+      st.docOpen = false;
+      st.noteCursor++;
+      st.phase = ResolvePhase::OpenNote;
+      return Step::More;
+    }
+
+    case ResolvePhase::Commit: {
+      const size_t added = st.store.added();
+      if (st.appending) {
+        st.appending = false;  // commit() consumes the append; nothing left to roll back
+        st.store.markResolved(st.spineIndex);
+        if (!st.store.commit()) {
+          return fail("Could not write the preview store");
+        }
+      } else if (!markSpineResolved(st.store, st.spineIndex)) {
+        // Nothing was appended, so the store is not open: markSpineResolved does its own
+        // beginAppend/commit, and it must see the bit still unset — hence no markResolved here.
+        return fail("Could not write the preview store");
+      }
+      st.epub->adoptZipDetails(*st.zip);
+      if (added > 0) {
+        LOG_INF("FNP", "Spine %d: resolved %u of %u note targets from %u document(s) in %lums", st.spineIndex,
+                static_cast<uint32_t>(added), static_cast<uint32_t>(st.missing.size()),
+                static_cast<uint32_t>(st.noteSpines.size()), millis() - st.startMs);
+      }
+      st.phase = ResolvePhase::Finished;
+      return Step::Done;
+    }
+  }
+  return Step::Failed;
+}
+
+bool resolveSpine(Epub& epub, const int spineIndex, const std::string& bankedHtmlPath) {
+  Resolver resolver;
+  if (!resolver.begin(epub, spineIndex, bankedHtmlPath)) {
+    return false;
+  }
+  Resolver::Step step = Resolver::Step::More;
+  while (step == Resolver::Step::More) {
+    step = resolver.step();
+  }
+  return step == Resolver::Step::Done;
 }
 
 bool Lookup::open(const std::string& bookCachePath, const Epub* epub, const int currentSpineIndex) {

--- a/lib/Epub/Epub/FootnotePreviews.h
+++ b/lib/Epub/Epub/FootnotePreviews.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+class BuildArena;  // lib/Memory — optional scratch for a note document's inflate ring
 class Epub;
 
 // Book-level inline-footnote preview cache ("footnotes.bin" in the book's cache dir).
@@ -56,10 +57,9 @@ bool cacheExists(const std::string& bookCachePath);
 // building it needs no resolve work at all. Costs one small read. Note the question is "is there
 // anything outstanding", NOT "does it have notes": a chapter without footnotes answers true.
 //
-// Background-B asks it to size its gates, NOT to decide whether to build: a resolve runs on the
-// loop task in one unsliceable pass, so B waits for a settled reader and a little extra heap
-// before starting a build that still owes one. It must never be used to skip such a spine —
-// the bit is only ever set BY a build, so skipping is self-perpetuating (issue #211).
+// Background-B asks it to size its gates, NOT to decide whether to build: it must never be used
+// to skip a spine, because the bit is only ever set BY a build, which makes skipping
+// self-perpetuating — that was issue #211, where look-ahead died for whole books.
 bool spineResolved(const std::string& bookCachePath, int spineIndex);
 
 // Most footnote-shaped links one spine may contribute in a single pass. 8 bytes each, so the
@@ -79,6 +79,45 @@ constexpr size_t MAX_TARGETS_PER_SPINE = 128;
 // whose anchor does not exist) is simply absent; there is no negative caching, because "not
 // found this time" and "this book has no such note" are not the same statement.
 bool resolveSpine(Epub& epub, int spineIndex, const std::string& bankedHtmlPath = {});
+
+// The same work, resumable. resolveSpine() above is this class run to completion in one call.
+//
+// The resolve runs on the loop task from inside a section build, so it cannot be allowed to take
+// however long the book feels like: a 200 KB chapter and a chapter with a hundred callers into a
+// fat rearnotes document must both stay responsive. step() therefore does AT MOST one
+// STREAM_CHUNK_BYTES chunk of one document, or one bookkeeping transition, and returns — the
+// caller decides how many to run before yielding (Section spends its slice budget on them, the
+// same way it does on the layout parse). Nothing here measures time, which also makes the
+// slicing deterministic to test.
+//
+// Preemption is safe at any point. The store is only ever written between beginAppend() and
+// commit(), and the destructor rolls a half-finished append back, so a resolver torn down
+// mid-document (the reader turned a page, Background-B handed its buffer back) leaves the store
+// exactly as complete as it found it. The spine's resolved bit is set only by a pass that ran
+// to Done, so an abandoned one simply starts again next time.
+class Resolver {
+ public:
+  enum class Step : uint8_t { More, Done, Failed };
+
+  Resolver();
+  ~Resolver();
+  Resolver(const Resolver&) = delete;
+  Resolver& operator=(const Resolver&) = delete;
+
+  // Prepares the pass. `arena`, when it has room, backs the inflate ring and read buffer of any
+  // note document that has to come out of the ZIP — worth passing from a build that owns one,
+  // since a sliced resolve would otherwise hold that ring on the heap across page renders.
+  // False means the pass could not even start (OOM); the store is untouched.
+  bool begin(Epub& epub, int spineIndex, const std::string& bankedHtmlPath = {}, BuildArena* arena = nullptr);
+
+  // One bounded unit of work. More = call again, Done = the spine is resolved and its bit set,
+  // Failed = the pass gave up and rolled back (the caller may retry later).
+  Step step();
+
+ private:
+  struct State;
+  std::unique_ptr<State> state_;
+};
 
 // Disk-backed lookup used during a section build. Holds NOTHING but an open read handle: the
 // sorted index is binary-searched in the file itself, and the text is read on a hit.

--- a/lib/Epub/Epub/FootnotePreviews.h
+++ b/lib/Epub/Epub/FootnotePreviews.h
@@ -56,9 +56,10 @@ bool cacheExists(const std::string& bookCachePath);
 // building it needs no resolve work at all. Costs one small read. Note the question is "is there
 // anything outstanding", NOT "does it have notes": a chapter without footnotes answers true.
 //
-// Background-B uses it to stay out of the resolver: look-ahead runs on the loop task in slices,
-// and a resolve that has documents to stream does not fit in one. B skips a spine that answers
-// false and leaves it to the foreground build, which already shows a popup while it works.
+// Background-B asks it to size its gates, NOT to decide whether to build: a resolve runs on the
+// loop task in one unsliceable pass, so B waits for a settled reader and a little extra heap
+// before starting a build that still owes one. It must never be used to skip such a spine —
+// the bit is only ever set BY a build, so skipping is self-perpetuating (issue #211).
 bool spineResolved(const std::string& bookCachePath, int spineIndex);
 
 // Most footnote-shaped links one spine may contribute in a single pass. 8 bytes each, so the

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -773,6 +773,9 @@ void Section::resolveInlineFootnotePreviews(BuildState& st) {
     // The store is untouched, so the only cost is that some notes in THIS build stay plain
     // markers until the spine is built again. Deliberately not fatal: a chapter that renders
     // with unexpanded markers is worth far more to the reader than a chapter that fails.
+    // Latched so a background caller can throw the result away instead: nothing would ever
+    // rebuild it, since the cache is keyed "previews on" either way.
+    footnotePreviewsUnresolved_ = true;
     LOG_ERR("SCT", "Footnote previews unresolved for spine %d; markers stay plain in this build", spineIndex);
   }
   st.footnotePreviewLookup = makeUniqueNoThrow<FootnotePreviews::Lookup>();
@@ -827,6 +830,7 @@ Section::BuildPhaseResult Section::runBuildSetup(BuildState& st) {
   pageCount = 0;
   this->lut.clear();
   cssLowHeapDegraded_ = false;
+  footnotePreviewsUnresolved_ = false;
 
   if (!Storage.openFileForWrite("SCT", filePath, file)) {
     return BuildPhaseResult::Failed;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -743,6 +743,14 @@ struct Section::BuildState {
   // initialised. runBuildParse is re-entered on every slice, so without this the resolve would
   // re-scan the whole spine each time phase (b) yielded.
   bool visitorReady = false;
+  // The note-preview resolve, which is itself sliced: it survives across yields until it reports
+  // Done or Failed, and its destructor rolls back a half-written store if the build is abandoned
+  // first. `previewResolveDone` covers the case where it finished but phase (b) has not started.
+  std::unique_ptr<FootnotePreviews::Resolver> previewResolver;
+  bool previewResolveDone = false;
+  uint32_t previewResolveStartMs = 0;
+  uint32_t previewResolveMs = 0;          // CPU actually spent resolving, summed across slices
+  uint32_t previewResolveMaxSliceMs = 0;  // worst single slice — the number that says it slices
   // Parse-result flags, set by runBuildParse and consumed by runBuildFinalize.
   bool streamOk = false;
   bool finalizeOk = false;
@@ -760,23 +768,42 @@ Section::Section(const std::shared_ptr<Epub>& epub, const int spineIndex, GfxRen
     : epub(epub), spineIndex(spineIndex), renderer(renderer) {}
 Section::~Section() { abortSectionBuild(); }
 
-void Section::resolveInlineFootnotePreviews(BuildState& st) {
+// Starts this spine's note-preview resolve. False means it could not even begin (OOM) — the
+// caller treats that like a failed pass: the build goes on and the markers stay plain.
+//
+// The pass is SLICED from here on. It used to run to completion in this one call, which made its
+// cost a property of the book rather than of the slice budget: a big chapter's link scan and a
+// fat rearnotes document are both unbounded work on the loop task. Background-B ran it that way
+// and could stall input for as long as the document took. FootnotePreviews::Resolver does the
+// same work a chunk at a time so runBuildParse can spend its budget on it and yield, exactly as
+// it does on the layout parse.
+bool Section::beginInlineFootnotePreviewResolve(BuildState& st) {
+  // Cheap when there is nothing to do: a spine whose notes were resolved in an earlier session
+  // answers from its resolved bit and finishes on the first step, reading nothing.
+  //
+  // Pass A reads the XHTML this build just extracted, so it costs an SD read and a SAX walk with
+  // no inflate. Only a note document that has never been streamed needs the archive, and that
+  // one gets the build's arena when there is room — a sliced resolve would otherwise hold its
+  // inflate ring on the reading heap across every page render in between.
+  st.previewResolver = makeUniqueNoThrow<FootnotePreviews::Resolver>();
+  if (!st.previewResolver) {
+    return false;
+  }
+  const std::string banked = st.useTempExtract ? st.tempPath : std::string();
+  BuildArena* const external = (st.arena && st.arena != st.ownedArena.get()) ? st.arena : nullptr;
+  if (!st.previewResolver->begin(*epub, spineIndex, banked, external)) {
+    st.previewResolver.reset();
+    return false;
+  }
+  st.previewResolveStartMs = millis();
+  return true;
+}
+
+// Wires the visitor to the store once the resolve has finished (however it finished): even a
+// failed pass leaves earlier chapters' notes in place, and those still expand.
+void Section::finishInlineFootnotePreviewResolve(BuildState& st) {
   if (!st.params.inlineFootnotePreviews) {
     return;
-  }
-  // Cheap when there is nothing to do: a spine whose notes were resolved in an earlier session
-  // re-scans its own links from the banked XHTML — an SD read and a SAX walk, no inflate — finds
-  // every target already stored, and appends nothing.
-  const uint32_t startMs = millis();
-  const std::string banked = st.useTempExtract ? st.tempPath : std::string();
-  if (!FootnotePreviews::resolveSpine(*epub, spineIndex, banked)) {
-    // The store is untouched, so the only cost is that some notes in THIS build stay plain
-    // markers until the spine is built again. Deliberately not fatal: a chapter that renders
-    // with unexpanded markers is worth far more to the reader than a chapter that fails.
-    // Latched so a background caller can throw the result away instead: nothing would ever
-    // rebuild it, since the cache is keyed "previews on" either way.
-    footnotePreviewsUnresolved_ = true;
-    LOG_ERR("SCT", "Footnote previews unresolved for spine %d; markers stay plain in this build", spineIndex);
   }
   st.footnotePreviewLookup = makeUniqueNoThrow<FootnotePreviews::Lookup>();
   if (st.footnotePreviewLookup && st.footnotePreviewLookup->open(epub->getCachePath(), epub.get(), spineIndex)) {
@@ -784,9 +811,12 @@ void Section::resolveInlineFootnotePreviews(BuildState& st) {
   } else {
     st.footnotePreviewLookup.reset();  // no notes anywhere in this book yet, or store unreadable
   }
-  const uint32_t ms = millis() - startMs;
-  if (ms > 0) {
-    LOG_INF("SCT", "createSectionFile spine=%d footnote previews resolved in %ums", spineIndex, ms);
+  if (st.previewResolveMs > 0) {
+    // Both numbers, because they answer different questions: the total is what the resolve costs
+    // the build, the worst slice is whether it is actually slicing. The second is the one that
+    // regresses silently — a document that never yields shows up here and nowhere else.
+    LOG_INF("SCT", "createSectionFile spine=%d footnote previews resolved in %ums (worst slice %ums)", spineIndex,
+            st.previewResolveMs, st.previewResolveMaxSliceMs);
   }
 }
 
@@ -1131,8 +1161,48 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
   // is only initialised after it: ~10 KB of yxml state each, and never both at once. Guarded to
   // run a single time — phase (b) yields per slice and re-enters from the top of this function.
   if (!streamFailed && !st.visitorReady) {
+    // Resolve the note previews first, in slices. The resolver is created once and survives
+    // across yields in BuildState; `previewResolveDone` is what makes this whole block one-shot
+    // for the resolve while runBuildParse re-enters from the top on every slice.
+    if (st.params.inlineFootnotePreviews && !st.previewResolveDone) {
+      if (!st.previewResolver && !beginInlineFootnotePreviewResolve(st)) {
+        LOG_ERR("SCT", "Could not start the footnote resolve for spine %d; markers stay plain", spineIndex);
+        footnotePreviewsUnresolved_ = true;
+        st.previewResolveDone = true;
+      }
+      const uint32_t resolveSliceStart = millis();
+      while (st.previewResolver) {
+        const FootnotePreviews::Resolver::Step rs = st.previewResolver->step();
+        if (rs == FootnotePreviews::Resolver::Step::More) {
+          if (!overBudget()) {
+            continue;
+          }
+          // Out of budget mid-resolve: bank what this slice cost and hand the loop task back.
+          // The resolver keeps its position, so the next slice picks up inside the same document.
+          const uint32_t spent = millis() - resolveSliceStart;
+          st.previewResolveMs += spent;
+          st.previewResolveMaxSliceMs = std::max(st.previewResolveMaxSliceMs, spent);
+          return yieldSlice();
+        }
+        if (rs == FootnotePreviews::Resolver::Step::Failed) {
+          // The store is untouched — the resolver rolled its append back — so the only cost is
+          // that some notes in THIS build stay plain markers until the spine is built again.
+          // Deliberately not fatal: a chapter that renders with unexpanded markers is worth far
+          // more to the reader than a chapter that fails. Latched so a background caller can
+          // throw the result away instead, since nothing would ever rebuild it — the cache is
+          // keyed "previews on" either way.
+          footnotePreviewsUnresolved_ = true;
+          LOG_ERR("SCT", "Footnote previews unresolved for spine %d; markers stay plain in this build", spineIndex);
+        }
+        st.previewResolver.reset();
+        st.previewResolveDone = true;
+      }
+      const uint32_t spent = millis() - resolveSliceStart;
+      st.previewResolveMs += spent;
+      st.previewResolveMaxSliceMs = std::max(st.previewResolveMaxSliceMs, spent);
+    }
     st.visitorReady = true;
-    resolveInlineFootnotePreviews(st);
+    finishInlineFootnotePreviewResolve(st);
     if (!st.visitor->setup(st.inflatedSize)) {
       LOG_ERR("SCT", "Failed to set up chapter parser");
       file.close();

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -85,7 +85,8 @@ class Section {
   // Runs between the parse phases, once the spine's inflated XHTML is on SD and no ZIP state is
   // live: makes sure every note this spine references has its text in the book's preview store,
   // then points the visitor at it. Never fails the build — see the definition.
-  void resolveInlineFootnotePreviews(BuildState& st);
+  bool beginInlineFootnotePreviewResolve(BuildState& st);
+  void finishInlineFootnotePreviewResolve(BuildState& st);
 
   // Open the section file and seek to the first paragraph LUT entry, validating the header
   // and LUT bounds against fileSize. On success, returns true with `outLutStart` set to the

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -33,6 +33,12 @@ class Section {
   // usable but visually degraded; background callers discard it so the foreground
   // blocking path (more headroom) rebuilds it clean.
   bool cssLowHeapDegraded_ = false;
+  // Set by the last build when its inline-footnote resolve pass could not complete (OOM, an
+  // unreadable note document). The pages are cached under a "previews on" property hash — see
+  // EpubReaderActivity::makeSectionBuildParams — but the notes this spine points at never made
+  // it into the store, so those markers stay plain and nothing would ever rebuild them.
+  // Background callers discard such a result and leave the spine to the foreground path.
+  bool footnotePreviewsUnresolved_ = false;
 
   void writeSectionFileHeader(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                               uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
@@ -232,6 +238,10 @@ class Section {
   // True when the last build's CSS resolution hit low-heap skips (styles silently
   // missing from the cached pages). Only meaningful right after a build.
   bool isCssLowHeapDegraded() const { return cssLowHeapDegraded_; }
+  // True when the last build's inline-footnote resolve pass failed, so some of this spine's
+  // notes are missing from the store while the cache claims previews are on. Only meaningful
+  // right after a build.
+  bool isFootnotePreviewsUnresolved() const { return footnotePreviewsUnresolved_; }
   // True while an incremental build is in flight and its CSS resolver has ALREADY hit a
   // low-heap skip — i.e. the in-progress result is going to be css-degraded. Lets a sliced
   // caller (Background-B) abort early instead of finishing a build it will discard. False when

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -109,8 +109,12 @@ void HalPowerManager::enterWaveformWait() {
   // concurrently — don't downclock. Our own lock (the render task's per-render
   // Lock) is fine: this task is about to sleep and only resumes after
   // exitWaveformWait() restores the clock.
-  const bool foreignLock =
-      currentLockMode.load(std::memory_order_relaxed) != None && lockOwnerTask_ != xTaskGetCurrentTaskHandle();
+  //
+  // More than one holder means at least one of them is not us, whoever lockOwnerTask_ names —
+  // that is the build-slice case, where the loop task is laying out pages while this task waits
+  // on a waveform. Treat it as foreign: never downclock on a maybe.
+  const bool foreignLock = currentLockMode.load(std::memory_order_relaxed) != None &&
+                           (lockCount_ > 1 || lockOwnerTask_ != xTaskGetCurrentTaskHandle());
   // Already at the low clock from idle power saving — leave ownership of the
   // restore with setPowerSaving(); don't double-track it here.
   if (!foreignLock && !isLowPower && setCpuFrequencyMhz(LOW_POWER_FREQ)) {
@@ -412,25 +416,31 @@ uint16_t HalPowerManager::getBatteryPercentage() const {
 
 HalPowerManager::Lock::Lock() {
   xSemaphoreTake(powerManager.modeMutex, portMAX_DELAY);
-  // Current limitation: only one lock at a time
-  if (powerManager.currentLockMode.load(std::memory_order_relaxed) != None) {
-    LOG_ERR("PWR", "Lock already held, ignore");
-    valid = false;
+  // Counted, not exclusive: every Lock holds. See lockCount_ for what the old single-slot version
+  // silently did to the second holder.
+  if (powerManager.lockCount_ < UINT8_MAX) {
+    powerManager.lockCount_++;
+    valid = true;
   } else {
+    LOG_ERR("PWR", "Lock count overflow; this lock holds nothing");  // cannot happen; not silent if it does
+    valid = false;
+  }
+  if (valid && powerManager.lockCount_ == 1) {
+    // First holder owns the flag and is the task enterWaveformWait() compares against.
     powerManager.currentLockMode.store(NormalSpeed, std::memory_order_relaxed);
     powerManager.lockOwnerTask_ = xTaskGetCurrentTaskHandle();
-    valid = true;
   }
   xSemaphoreGive(powerManager.modeMutex);
   if (valid) {
-    // Immediately restore normal CPU frequency if currently in low-power mode
+    // Immediately restore normal CPU frequency if currently in low-power mode. Unconditional, not
+    // just for the first holder: a nested lock wants full speed as much as the outer one does.
     powerManager.setPowerSaving(false);
   }
 }
 
 HalPowerManager::Lock::~Lock() {
   xSemaphoreTake(powerManager.modeMutex, portMAX_DELAY);
-  if (valid) {
+  if (valid && powerManager.lockCount_ > 0 && --powerManager.lockCount_ == 0) {
     powerManager.currentLockMode.store(None, std::memory_order_relaxed);
     powerManager.lockOwnerTask_ = nullptr;
   }

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -35,6 +35,14 @@ class HalPowerManager {
   // resumes after exitWaveformWait() restores the clock), but not when another
   // task holds the lock and keeps running.
   TaskHandle_t lockOwnerTask_ = nullptr;
+  // Locks nest. They used to be a single slot: a second concurrent Lock logged an error and was
+  // handed back holding NOTHING, and the first one's release then cleared the flag while the
+  // second holder was still running. Two real holders overlap constantly — the render task takes
+  // one per render, the loop task takes one per build slice — so the effect was that a build
+  // slice ran unprotected, and enterWaveformWait() saw no foreign lock and downclocked the chip
+  // underneath it. Counted instead: the flag is set while any lock is held and cleared by the
+  // last release.
+  uint8_t lockCount_ = 0;
   // True while the CPU clock is dropped for an e-ink waveform wait (see
   // enterWaveformWait / exitWaveformWait). Guarded by modeMutex.
   bool waveformLowPower_ = false;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -173,6 +173,17 @@ constexpr uint32_t PRE_RENDER_MIN_FREE_HEAP_BYTES = 44 * 1024;
 #ifndef BG_BUILD_BORROW_MIN_CONTIG_HEAP_BYTES
 #define BG_BUILD_BORROW_MIN_CONTIG_HEAP_BYTES (12 * 1024)
 #endif
+// Added to the free-heap floor (either path) for a target that still owes the inline-footnote
+// resolve. That pass allocates from the HEAP even inside a borrowed build — a SAX parser (~9 KB),
+// a 1 KB stream chunk and the store's index — because FootnotePreviews knows nothing about the
+// arena. Deliberately smaller than the ~14 KB it actually wants: the floors above already carry
+// reserve, and the reading steady state is ~51 KB free (device trace, issue #211), so a bigger
+// number would push the gate out of reach and re-lose the look-ahead it exists to protect. A
+// resolve that still cannot fit fails cleanly — the build is discarded and the foreground
+// rebuilds the spine released, where it has ~52 KB more to work with.
+#ifndef BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES
+#define BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES (8 * 1024)
+#endif
 
 // Quiet period after the last page reached the screen before B may take the buffer. B's borrow
 // costs a page's AA if the reader turns during it, and a preempted slice is wasted work — so
@@ -1094,6 +1105,7 @@ void EpubReaderActivity::resetBackgroundBuild() {
   backgroundSection_.reset();  // ~Section aborts a partial build and deletes its partial file
   backgroundBuildSpineIndex_ = -1;
   backgroundBuildInflatedSize_ = 0;
+  backgroundBuildNeedsResolve_ = false;
   backgroundBuildGateCheckMs_ = 0;
   backgroundBuildState_ = BackgroundBuildState::Probe;
   backgroundBuildPercent_ = -1;
@@ -1287,18 +1299,20 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
         backgroundWindowPagesBuilt_ += backgroundSection_->pageCount;  // already-built runway counts toward the budget
         backgroundSection_.reset();
         backgroundBuildState_ = BackgroundBuildState::Settled;
-      } else if (getEffectiveInlineFootnotePreviews() &&
-                 !FootnotePreviews::spineResolved(epub->getCachePath(), targetSpine)) {
-        // This spine still owes the resolver work: its links have never been scanned, so a build
-        // of it would have to scan the document and stream every note file it points at, inside
-        // ONE loop-task slice. Look-ahead is not worth a stall the reader can feel mid-page.
-        // Leave the spine to the foreground build, which does the same work behind the "Indexing"
-        // popup, and move the cursor on. Costs the look-ahead exactly once per chapter with
-        // notes: the foreground build sets the bit, and B pre-builds it freely from then on.
-        LOG_DBG("ERS", "Background build spine=%d skipped: footnote previews not resolved yet", targetSpine);
-        backgroundSection_.reset();
-        backgroundBuildState_ = BackgroundBuildState::Settled;
       } else {
+        // Does this spine still owe the footnote resolver? Its build then runs one extra,
+        // unsliceable pass before the layout parse (Section::resolveInlineFootnotePreviews):
+        // a SAX scan of the extracted XHTML, plus a stream of any note document it points at
+        // that is not banked yet. B used to refuse such a spine outright and leave it to the
+        // foreground, on the assumption that the foreground would set the bit and B could
+        // pre-build the chapter from then on. That assumption was wrong: the bit is only ever
+        // set BY a build, and the only spine the foreground ever builds is the one the reader
+        // just entered — so every subsequent chapter stayed unresolved, B refused all of them,
+        // and look-ahead was dead for the whole book (issue #211, regression in 2.24). B builds
+        // them instead; the flag makes the extra pass wait for a settled reader and some heap
+        // margin, and a resolve that fails anyway is discarded below rather than cached.
+        backgroundBuildNeedsResolve_ =
+            getEffectiveInlineFootnotePreviews() && !FootnotePreviews::spineResolved(epub->getCachePath(), targetSpine);
         // The inflate ring is sized to the entry, so the extraction heap gate needs the
         // uncompressed size (one central-dir scan, once per target spine).
         backgroundBuildInflatedSize_ = 0;
@@ -1347,12 +1361,25 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
       // foreground draws mid-build pages out of C's own progress, so blocking C on a pending
       // foreground draw deadlocks: the page is never built, so the draw stays pending forever.)
       const bool inputQueued = CooperativeAbort::shouldAbortLongTask();
+      // A build that still owes the footnote resolve allocates that pass out of the heap even
+      // when everything else it does lives in the borrowed arena, so it needs the margin on top.
+      const uint32_t borrowFreeFloor =
+          BG_BUILD_BORROW_MIN_FREE_HEAP_BYTES + (backgroundBuildNeedsResolve_ ? BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES : 0);
       if (!inputQueued && (now - lastActivityMs) >= BG_BUILD_BORROW_QUIET_MS &&
-          esp_get_free_heap_size() >= BG_BUILD_BORROW_MIN_FREE_HEAP_BYTES &&
+          esp_get_free_heap_size() >= borrowFreeFloor &&
           heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT) >=
               BG_BUILD_BORROW_MIN_CONTIG_HEAP_BYTES &&
           beginBackgroundBorrow()) {
         backgroundBuildState_ = BackgroundBuildState::Building;
+        return;
+      }
+      // Resident fallback. The borrow branch above already refuses to start while the reader is
+      // moving; the resolve needs that stillness on this path too, because its pass cannot be
+      // sliced (see the Probe comment) and cannot be abandoned half-way either — an aborted
+      // resolve would leave the chapter cached with plain markers under a "previews on" property
+      // hash, which nothing ever rebuilds. So it must land in a gap between page turns, not under
+      // one.
+      if (backgroundBuildNeedsResolve_ && (inputQueued || (now - lastActivityMs) < BG_BUILD_BORROW_QUIET_MS)) {
         return;
       }
       const uint32_t ringBytes =
@@ -1360,7 +1387,8 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
       const uint32_t freeHeap = esp_get_free_heap_size();
       const uint32_t contigHeap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
       const uint32_t bgFreeFloor =
-          std::max<uint32_t>(BG_BUILD_PARSE_MIN_FREE_HEAP_BYTES, BG_BUILD_EXTRACT_BASE_HEAP_BYTES + ringBytes);
+          std::max<uint32_t>(BG_BUILD_PARSE_MIN_FREE_HEAP_BYTES, BG_BUILD_EXTRACT_BASE_HEAP_BYTES + ringBytes) +
+          (backgroundBuildNeedsResolve_ ? BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES : 0);
       const uint32_t bgContigFloor = std::max<uint32_t>(BG_BUILD_MIN_CONTIG_HEAP_BYTES, ringBytes + 8 * 1024);
       if (freeHeap < bgFreeFloor || contigHeap < bgContigFloor) {
         HEAP_GATE("bgB_waitheap", false, freeHeap, bgFreeFloor, contigHeap, bgContigFloor);
@@ -1479,13 +1507,17 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
 
       backgroundBuildPercent_ = -1;
       if (step == Section::BuildStep::Done) {
-        if (backgroundSection_->isTruncatedCache() || backgroundSection_->isCssLowHeapDegraded()) {
-          // Memory ran short mid-parse: either pages are missing (truncated) or CSS
-          // lookups were skipped (styles silently absent from the cached pages). Don't
-          // hand either to the foreground: its blocking path runs with the secondary
-          // buffer released (~52 KB more headroom) and will likely build it clean.
-          LOG_INF("ERS", "Background build spine=%d %s; discarding for foreground rebuild", targetSpine,
-                  backgroundSection_->isTruncatedCache() ? "truncated" : "css-degraded");
+        if (backgroundSection_->isTruncatedCache() || backgroundSection_->isCssLowHeapDegraded() ||
+            backgroundSection_->isFootnotePreviewsUnresolved()) {
+          // Memory ran short mid-parse: pages are missing (truncated), CSS lookups were skipped
+          // (styles silently absent from the cached pages), or the footnote resolve could not
+          // complete (markers left plain in a cache keyed "previews on"). Don't hand any of them
+          // to the foreground: its blocking path runs with the secondary buffer released (~52 KB
+          // more headroom) and will likely build it clean.
+          const char* reason = backgroundSection_->isTruncatedCache()       ? "truncated"
+                               : backgroundSection_->isCssLowHeapDegraded() ? "css-degraded"
+                                                                            : "footnotes unresolved";
+          LOG_INF("ERS", "Background build spine=%d %s; discarding for foreground rebuild", targetSpine, reason);
           backgroundSection_->clearCache();
           backgroundSection_.reset();
         } else {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -174,13 +174,15 @@ constexpr uint32_t PRE_RENDER_MIN_FREE_HEAP_BYTES = 44 * 1024;
 #define BG_BUILD_BORROW_MIN_CONTIG_HEAP_BYTES (12 * 1024)
 #endif
 // Added to the free-heap floor (either path) for a target that still owes the inline-footnote
-// resolve. That pass allocates from the HEAP even inside a borrowed build — a SAX parser (~9 KB),
-// a 1 KB stream chunk and the store's index — because FootnotePreviews knows nothing about the
-// arena. Deliberately smaller than the ~14 KB it actually wants: the floors above already carry
-// reserve, and the reading steady state is ~51 KB free (device trace, issue #211), so a bigger
-// number would push the gate out of reach and re-lose the look-ahead it exists to protect. A
-// resolve that still cannot fit fails cleanly — the build is discarded and the foreground
-// rebuilds the spine released, where it has ~52 KB more to work with.
+// resolve. That pass holds a SAX parser (~9 KB), a 1 KB stream chunk and the store's index on the
+// HEAP for as long as it runs — and because it runs in slices, that is across every page render
+// in between, not for one transient moment. (Its one big allocation, the inflate ring for an
+// un-banked note document, comes out of the build's arena instead; see DocStream::open.)
+// Deliberately smaller than the ~14 KB the pass wants: the floors above already carry reserve,
+// and the reading steady state is ~51 KB free (device trace, issue #211), so a bigger number
+// would push the gate out of reach and re-lose the look-ahead it exists to protect. A resolve
+// that still cannot fit fails cleanly — the build is discarded and the foreground rebuilds the
+// spine released, where it has ~52 KB more to work with.
 #ifndef BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES
 #define BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES (8 * 1024)
 #endif
@@ -1300,17 +1302,18 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
         backgroundSection_.reset();
         backgroundBuildState_ = BackgroundBuildState::Settled;
       } else {
-        // Does this spine still owe the footnote resolver? Its build then runs one extra,
-        // unsliceable pass before the layout parse (Section::resolveInlineFootnotePreviews):
-        // a SAX scan of the extracted XHTML, plus a stream of any note document it points at
-        // that is not banked yet. B used to refuse such a spine outright and leave it to the
-        // foreground, on the assumption that the foreground would set the bit and B could
-        // pre-build the chapter from then on. That assumption was wrong: the bit is only ever
-        // set BY a build, and the only spine the foreground ever builds is the one the reader
-        // just entered — so every subsequent chapter stayed unresolved, B refused all of them,
-        // and look-ahead was dead for the whole book (issue #211, regression in 2.24). B builds
-        // them instead; the flag makes the extra pass wait for a settled reader and some heap
-        // margin, and a resolve that fails anyway is discarded below rather than cached.
+        // Does this spine still owe the footnote resolver? Its build then runs one extra pass
+        // before the layout parse — a SAX scan of the extracted XHTML, plus a stream of any note
+        // document it points at that is not banked yet — which FootnotePreviews::Resolver spreads
+        // across slices like any other build work.
+        //
+        // B used to refuse such a spine outright and leave it to the foreground, back when that
+        // pass ran to completion inside one slice. The refusal was self-perpetuating: the
+        // resolved bit is only ever set BY a build, and the only spine the foreground ever builds
+        // is the one the reader just entered, so every subsequent chapter stayed unresolved, B
+        // refused all of them, and look-ahead was dead for the whole book (issue #211, regression
+        // in 2.24). The flag no longer gates the build — it only buys the pass the heap it holds
+        // across those slices, and a resolve that fails anyway is discarded below, not cached.
         backgroundBuildNeedsResolve_ =
             getEffectiveInlineFootnotePreviews() && !FootnotePreviews::spineResolved(epub->getCachePath(), targetSpine);
         // The inflate ring is sized to the entry, so the extraction heap gate needs the
@@ -1371,15 +1374,6 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
               BG_BUILD_BORROW_MIN_CONTIG_HEAP_BYTES &&
           beginBackgroundBorrow()) {
         backgroundBuildState_ = BackgroundBuildState::Building;
-        return;
-      }
-      // Resident fallback. The borrow branch above already refuses to start while the reader is
-      // moving; the resolve needs that stillness on this path too, because its pass cannot be
-      // sliced (see the Probe comment) and cannot be abandoned half-way either — an aborted
-      // resolve would leave the chapter cached with plain markers under a "previews on" property
-      // hash, which nothing ever rebuilds. So it must land in a gap between page turns, not under
-      // one.
-      if (backgroundBuildNeedsResolve_ && (inputQueued || (now - lastActivityMs) < BG_BUILD_BORROW_QUIET_MS)) {
         return;
       }
       const uint32_t ringBytes =

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -912,18 +912,18 @@ void EpubReaderActivity::serviceBackgroundDebugLog() {
   // in waitheap because free/contig sit below the BG_BUILD_* floors, or css=1 with too
   // little heap for Section::heapAllowsEmbeddedStyle()).
   static constexpr const char* kBStateNames[] = {"probe", "waitheap", "building", "settled"};
-  LOG_INF(
-      "ERS",
-      "BG work: A runs=%lu completes=%lu | B runs=%lu completes=%lu state=%s spine=%d css=%d borrow=%d preempt=%u | "
-      "preReady=%d buildPct=%d free=%lu contig=%lu",
-      static_cast<unsigned long>(bgCounters_.aRuns), static_cast<unsigned long>(bgCounters_.aCompletes),
-      static_cast<unsigned long>(bgCounters_.bRuns), static_cast<unsigned long>(bgCounters_.bCompletes),
-      kBStateNames[static_cast<uint8_t>(backgroundBuildState_)], backgroundBuildSpineIndex_,
-      lastRenderStats.embeddedStyle ? 1 : 0, backgroundBorrowActive_ ? 1 : 0,
-      static_cast<unsigned>(backgroundPreemptCount_),
-      (preRenderedPage.ready && preRenderedPage.spineIndex == currentSpineIndex) ? 1 : 0, backgroundBuildPercent_,
-      static_cast<unsigned long>(esp_get_free_heap_size()),
-      static_cast<unsigned long>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT)));
+  LOG_INF("ERS",
+          "BG work: A runs=%lu completes=%lu | B runs=%lu completes=%lu | C runs=%lu completes=%lu state=%s spine=%d "
+          "css=%d borrow=%d preempt=%u | preReady=%d buildPct=%d free=%lu contig=%lu",
+          static_cast<unsigned long>(bgCounters_.aRuns), static_cast<unsigned long>(bgCounters_.aCompletes),
+          static_cast<unsigned long>(bgCounters_.bRuns), static_cast<unsigned long>(bgCounters_.bCompletes),
+          static_cast<unsigned long>(bgCounters_.cRuns), static_cast<unsigned long>(bgCounters_.cCompletes),
+          kBStateNames[static_cast<uint8_t>(backgroundBuildState_)], backgroundBuildSpineIndex_,
+          lastRenderStats.embeddedStyle ? 1 : 0, backgroundBorrowActive_ ? 1 : 0,
+          static_cast<unsigned>(backgroundPreemptCount_),
+          (preRenderedPage.ready && preRenderedPage.spineIndex == currentSpineIndex) ? 1 : 0, backgroundBuildPercent_,
+          static_cast<unsigned long>(esp_get_free_heap_size()),
+          static_cast<unsigned long>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT)));
   checkHeapIntegrity("idle_5s");
 #endif
 }
@@ -1630,7 +1630,7 @@ void EpubReaderActivity::stepCurrentSectionBuild() {
   // stepBackgroundSectionBuild for the full rationale).
   renderer.clearFontAccumulation();
 #if DEBUG_BACKGROUND_WORK
-  bgCounters_.bRuns++;
+  bgCounters_.cRuns++;
 #endif
   Section::BuildStep step;
   {
@@ -1682,7 +1682,7 @@ void EpubReaderActivity::stepCurrentSectionBuild() {
   // Done & clean: the on-disk LUT is written and `section` is now a complete cache. Resolve the
   // navigation target now that the final page count is known, then transition to reading.
 #if DEBUG_BACKGROUND_WORK
-  bgCounters_.bCompletes++;
+  bgCounters_.cCompletes++;
 #endif
   LOG_INF("ERS", "Background-C spine=%d complete: %u pages", currentSpineIndex, section->pageCount);
   epub->persistImageManifest();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -259,12 +259,29 @@ constexpr uint32_t BG_BUILD_BUDGET_MS = 40;
 #define IN_PLACE_BUILD_MIN_CONTIG_HEAP_BYTES (28 * 1024)
 #endif
 // Extract-phase free floor, to which the entry's ring is added (the ring IS live in this phase,
-// so here the sum is correct). Same value as Background-B's BG_BUILD_EXTRACT_BASE_HEAP_BYTES and
-// for the same reason — both gate an extract that runs heap-backed with the secondary framebuffer
-// resident, which is the one situation the 30 KB was measured in. Kept as its own name rather than
-// reusing B's so the two can diverge without silently retuning each other.
+// so here the sum is correct). Kept as its own name rather than reusing Background-B's
+// BG_BUILD_EXTRACT_BASE_HEAP_BYTES so the two can diverge without silently retuning each other —
+// and they have: B reaches its extract from the borrow-first path, this one from a page turn.
+//
+// 30 -> 50 KB (2026-09-01), device-measured on Small Gods spine 1 — the whole book in one
+// 583991-byte entry — which the 30 KB version admitted to a resident build that could not
+// possibly finish. The trace, from the gate to the abort ~170 ms later:
+//
+//   gate      free=71592  (floor was 67584: the CSS base, since 30720 + 32768 = 63488 lost the max)
+//   start     free=60396  -11196  activity/section/popup before the build begins
+//   setup     free=56648   -3748  CSS index load
+//   abort     free=19924  -36724  ZipFile + read buffer + the 32768 inflate ring
+//
+// So the ring is only two thirds of what the extract phase costs from here; the other ~18.9 KB is
+// fixed overhead the base is meant to cover, and on top of that the build has to stay above
+// RESIDENT_BUILD_ABORT_FREE_HEAP_BYTES (30 KB) or it aborts anyway. 18.9 + 30 = 48.9 KB, so 50
+// with a little margin. Note what this does NOT change: with the ring capped at 32 KB the base
+// only binds for large entries — a few-KB chapter still floors at the flat 60/66 KB above and
+// still builds in place. What it changes is that a whole-book-in-one-spine entry now goes
+// straight to the released path instead of paying ~1.4 s for setup, abort, cache clear and a
+// second setup to get there.
 #ifndef IN_PLACE_BUILD_EXTRACT_BASE_HEAP_BYTES
-#define IN_PLACE_BUILD_EXTRACT_BASE_HEAP_BYTES (30 * 1024)
+#define IN_PLACE_BUILD_EXTRACT_BASE_HEAP_BYTES (50 * 1024)
 #endif
 // CSS books need more margin to build in place: the parse resolves embedded styles, which
 // self-degrade below the runtime CSS-resolve floor (CSS_MIN_FREE_HEAP_FOR_CSS ≈ 40 KB). Since

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -393,8 +393,9 @@ class EpubReaderActivity final : public Activity {
   // Sizes the inflate ring share of the extraction heap gate.
   size_t backgroundBuildInflatedSize_ = 0;
   // True when the target spine's footnote links have never been scanned, so its build will run
-  // the inline-preview resolve before laying out a line. Decided once in the Probe step; costs
-  // the WaitHeap gates a settled reader and BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES of extra margin.
+  // the inline-preview resolve before laying out a line. Decided once in the Probe step; the pass
+  // is sliced like the rest of the build, so all this buys is the BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES
+  // the resolver holds on the heap while it runs.
   bool backgroundBuildNeedsResolve_ = false;
   // Last WaitHeap gate evaluation; the heap-walk checks re-run at most ~1×/s.
   unsigned long backgroundBuildGateCheckMs_ = 0;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -392,6 +392,10 @@ class EpubReaderActivity final : public Activity {
   // Uncompressed size of the target spine's XHTML (fetched once in the Probe step).
   // Sizes the inflate ring share of the extraction heap gate.
   size_t backgroundBuildInflatedSize_ = 0;
+  // True when the target spine's footnote links have never been scanned, so its build will run
+  // the inline-preview resolve before laying out a line. Decided once in the Probe step; costs
+  // the WaitHeap gates a settled reader and BG_BUILD_RESOLVE_EXTRA_HEAP_BYTES of extra margin.
+  bool backgroundBuildNeedsResolve_ = false;
   // Last WaitHeap gate evaluation; the heap-walk checks re-run at most ~1×/s.
   unsigned long backgroundBuildGateCheckMs_ = 0;
   // Times a build of backgroundBuildSpineIndex_ was preempted (reader needed the borrowed

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -470,8 +470,15 @@ class EpubReaderActivity final : public Activity {
   struct BackgroundWorkCounters {
     uint32_t aRuns = 0;       // pre-render pass entered with a page to render
     uint32_t aCompletes = 0;  // pre-render produced a ready next page
-    uint32_t bRuns = 0;       // section-build step ran a slice of work
-    uint32_t bCompletes = 0;  // section build reached Done
+    uint32_t bRuns = 0;       // Background-B (look-ahead) ran a build slice
+    uint32_t bCompletes = 0;  // Background-B build reached Done
+    // Background-C (the section the reader is waiting on) is counted SEPARATELY. It used to
+    // share B's pair, which made the debug line unreadable exactly when it mattered: a long C
+    // build over a big spine printed "B runs=211" while B's own state said probe/spine=-1, so
+    // the one counter you would check to see whether look-ahead is working was being driven by
+    // something else entirely.
+    uint32_t cRuns = 0;
+    uint32_t cCompletes = 0;
   };
   BackgroundWorkCounters bgCounters_;
   unsigned long lastBgDebugLogMs_ = 0UL;

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -91,6 +91,7 @@ add_executable(EpubPipelineTest
   SidecarFilesTest.cpp
   SectionAbortTest.cpp
   FootnotePreviewStoreTest.cpp
+  FootnoteResolveSliceTest.cpp
   ImageExtractionTest.cpp
   # No-op HeapTrack: PipelineRunner brackets the dump read-back with pause/resume, and the gtest
   # binary must NOT get the real one (it overrides malloc/free process-wide). The two dump

--- a/test/epub_pipeline/FootnoteResolveSliceTest.cpp
+++ b/test/epub_pipeline/FootnoteResolveSliceTest.cpp
@@ -203,6 +203,93 @@ std::string makeBook(const std::string& dir, const int noteCount, const size_t c
   return path;
 }
 
+// A second shape, modelled on a real book (Men at Arms): several LARGE chapters whose callers all
+// point into ONE shared notes document, with tiny front matter in front of them. It is the shape
+// that costs the most — a 275 KB pass A, then a note document that has to come out of the archive
+// the first time — and the one the device trace measured at 1125 ms of resolve for a single spine.
+// That whole 1125 ms used to be one loop-task slice.
+//
+// The markup is the real thing, not a simplification. Callers are `<a href="..."><sup>*</sup></a>`
+// (a marker with no digits, so the shape heuristic has to accept `*`), and each note body opens
+// with a back-link carrying that same marker — chrome the capture must skip, or every preview
+// would start with a stray asterisk.
+struct Chapter {
+  size_t bytes;
+  int notes;
+};
+
+std::string makeSharedNotesBook(const std::string& dir, const std::vector<Chapter>& chapters) {
+  const std::string notesDocName = "notes.xhtml";
+  StoredZipWriter zip;
+  std::string manifest;
+  std::string spine;
+  std::string notesBodies;
+  int noteId = 0;
+
+  // Front matter: two one-page documents with no notes at all, so the fixture also covers the
+  // "spine that owes nothing still gets its resolved bit" path in the same book.
+  for (int i = 0; i < 2; ++i) {
+    const std::string name = "front" + std::to_string(i) + ".xhtml";
+    zip.add("OEBPS/" + name,
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">"
+            "<head><title>F</title></head><body><p>Front matter.</p></body></html>\n");
+    manifest +=
+        "<item id=\"f" + std::to_string(i) + "\" href=\"" + name + "\" media-type=\"application/xhtml+xml\"/>\n";
+    spine += "<itemref idref=\"f" + std::to_string(i) + "\"/>";
+  }
+
+  for (size_t c = 0; c < chapters.size(); ++c) {
+    const std::string name = "chapter" + std::to_string(c) + ".xhtml";
+    std::string body;
+    for (int n = 0; n < chapters[c].notes; ++n) {
+      const std::string id = std::to_string(++noteId);
+      body += "<p>Prose leading up to the marker<a href=\"" + notesDocName + "#ft_" + id + "\" id=\"ft" + id +
+              "\"><sup>*</sup></a> and prose after it.</p>\n";
+      notesBodies += "<p class=\"footnote\" id=\"ft_" + id + "\"><span class=\"footnotePara\"><a href=\"" + name +
+                     "#ft" + id + "\"><sup>*</sup></a>Note " + id +
+                     ": the text a preview is supposed to show, and nothing else.</span></p>\n";
+    }
+    while (body.size() < chapters[c].bytes) {
+      body +=
+          "<p>The Patrician had a broad and comprehensive view of the world, which is to say a "
+          "short one, and he had it at considerable length.</p>\n";
+    }
+    zip.add("OEBPS/" + name,
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">"
+            "<head><title>C</title></head><body>\n" +
+                body + "</body></html>\n");
+    manifest +=
+        "<item id=\"c" + std::to_string(c) + "\" href=\"" + name + "\" media-type=\"application/xhtml+xml\"/>\n";
+    spine += "<itemref idref=\"c" + std::to_string(c) + "\"/>";
+  }
+
+  zip.add("OEBPS/" + notesDocName,
+          "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">"
+          "<head><title>N</title></head><body>\n" +
+              notesBodies + "</body></html>\n");
+  manifest += "<item id=\"n\" href=\"" + notesDocName + "\" media-type=\"application/xhtml+xml\"/>\n";
+  spine += "<itemref idref=\"n\"/>";
+
+  const std::string opf =
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+      "<package xmlns=\"http://www.idpf.org/2007/opf\" version=\"3.0\" unique-identifier=\"id\">\n"
+      "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:identifier id=\"id\">shared-notes</dc:identifier>"
+      "<dc:title>Shared Notes</dc:title><dc:language>en</dc:language></metadata>\n"
+      "<manifest>\n" +
+      manifest + "</manifest>\n<spine>" + spine + "</spine>\n</package>\n";
+  zip.add("OEBPS/content.opf", opf);
+  zip.add("mimetype", "application/epub+zip");
+  zip.add("META-INF/container.xml",
+          "<?xml version=\"1.0\"?>\n"
+          "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">\n"
+          "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" "
+          "media-type=\"application/oebps-package+xml\"/></rootfiles>\n</container>\n");
+
+  const std::string path = dir + "/shared_notes.epub";
+  zip.write(path);
+  return path;
+}
+
 std::shared_ptr<Epub> openBook(const std::string& path, const std::string& cacheDir) {
   auto epub = std::make_shared<Epub>(path, cacheDir);
   EXPECT_TRUE(epub->load(true));
@@ -452,4 +539,107 @@ TEST(FootnoteResolveSlice, SlicedResolveMatchesOneShotOnADeflatedArchive) {
   auto slicedEpub = openBook(corpus, slicedDir);
   ASSERT_GT(resolveStepByStep(*slicedEpub, kChapterSpine), 0);
   EXPECT_EQ(storeBytes(*slicedEpub), expected);
+}
+
+// The real-book shape, scaled from the device trace: three large chapters whose callers all point
+// into one shared notes document. Device numbers for the first of them (275722 bytes, 14 notes,
+// notes document not yet banked): 1125 ms of resolve, worst slice 90 ms — where before the whole
+// 1125 ms was a single loop-task slice. Here we pin the part a host test can pin: that spreading
+// it over slices changes nothing about the result, at every chapter of the book.
+TEST(FootnoteResolveSlice, SharedNotesDocumentShapeSlicesIdentically) {
+  const std::vector<Chapter> chapters = {{256 * 1024, 14}, {224 * 1024, 11}, {160 * 1024, 3}};
+  constexpr int kFirstChapterSpine = 2;  // two front-matter documents precede them
+
+  const std::string oneShotDir = freshDir("shared_oneshot");
+  auto oneShotEpub = openBook(makeSharedNotesBook(oneShotDir, chapters), oneShotDir);
+  for (size_t c = 0; c < chapters.size(); ++c) {
+    ASSERT_TRUE(FootnotePreviews::resolveSpine(*oneShotEpub, kFirstChapterSpine + static_cast<int>(c))) << c;
+  }
+  const std::vector<std::string> expected = storeTexts(*oneShotEpub);
+  ASSERT_EQ(expected.size(), 14u + 11u + 3u);
+
+  const std::string slicedDir = freshDir("shared_sliced");
+  auto slicedEpub = openBook(makeSharedNotesBook(slicedDir, chapters), slicedDir);
+  for (size_t c = 0; c < chapters.size(); ++c) {
+    const int spine = kFirstChapterSpine + static_cast<int>(c);
+    const int steps = resolveStepByStep(*slicedEpub, spine);
+    ASSERT_GT(steps, 0) << "chapter " << c;
+
+    // Boundedness, per chapter: the chapter's own document is walked a chunk at a time in pass A.
+    // (Only the first chapter also streams the notes document; the rest find it banked, and the
+    // step floor below stays true either way.)
+    size_t chapterBytes = 0;
+    ASSERT_TRUE(slicedEpub->getSpineItemInflatedSize(spine, &chapterBytes));
+    EXPECT_GE(static_cast<size_t>(steps), chapterBytes / kStreamChunkBytes)
+        << "chapter " << c << ": " << steps << " steps for " << chapterBytes << " bytes";
+  }
+  EXPECT_EQ(storeTexts(*slicedEpub), expected);
+}
+
+// Front matter with no callers at all still has to end up marked resolved, in the same book as
+// chapters that do have them. A book whose front matter looked permanently unresolved would send
+// Background-B back to refusing spines — the shape of issue #211, one level down.
+TEST(FootnoteResolveSlice, SpinesWithoutNotesAreMarkedInABookThatHasThem) {
+  const std::string dir = freshDir("shared_frontmatter");
+  auto epub = openBook(makeSharedNotesBook(dir, {{4 * 1024, 5}}), dir);
+
+  for (int spine = 0; spine < 2; ++spine) {
+    EXPECT_FALSE(FootnotePreviews::spineResolved(epub->getCachePath(), spine)) << spine;
+    ASSERT_GT(resolveStepByStep(*epub, spine), 0) << spine;
+    EXPECT_TRUE(FootnotePreviews::spineResolved(epub->getCachePath(), spine)) << spine;
+  }
+  EXPECT_TRUE(storeTexts(*epub).empty()) << "front matter has no notes to store";
+
+  ASSERT_GT(resolveStepByStep(*epub, 2), 0);
+  EXPECT_EQ(storeTexts(*epub).size(), 5u);
+}
+
+// Every note body in this shape opens with a back-link carrying the same marker the caller used.
+// It is chrome: a preview that starts with a stray asterisk is the bug this pins. Also covers the
+// short-marker heuristic accepting a bare `*` inside <sup>, which is what the real book uses and
+// what the earlier generated fixtures (digit markers) do not exercise.
+TEST(FootnoteResolveSlice, PreviewTextExcludesTheBackLinkChrome) {
+  const std::string dir = freshDir("shared_chrome");
+  auto epub = openBook(makeSharedNotesBook(dir, {{2 * 1024, 3}}), dir);
+  ASSERT_TRUE(FootnotePreviews::resolveSpine(*epub, 2));
+
+  const std::vector<std::string> texts = storeTexts(*epub);
+  ASSERT_EQ(texts.size(), 3u);
+  for (const std::string& t : texts) {
+    EXPECT_EQ(t.find('*'), std::string::npos) << "back-link marker leaked into the preview: " << t;
+    EXPECT_EQ(t.rfind("Note ", 0), 0u) << "preview should start at the note prose: " << t;
+    EXPECT_NE(t.find("nothing else."), std::string::npos) << "preview truncated: " << t;
+  }
+}
+
+// One shared notes document, three chapters pointing into it: it must be streamed from the archive
+// once and banked, so the chapters after the first cost an SD read instead of an inflate. On the
+// device that is the difference between the first chapter's 1125 ms resolve and the later ones.
+TEST(FootnoteResolveSlice, SharedNotesDocumentIsBankedOnFirstUse) {
+  const std::string dir = freshDir("shared_banking");
+  const std::vector<Chapter> chapters = {{8 * 1024, 4}, {8 * 1024, 4}};
+  auto epub = openBook(makeSharedNotesBook(dir, chapters), dir);
+  const int notesSpine = 2 + static_cast<int>(chapters.size());  // front matter + chapters, then notes
+
+  const std::string bankPath = Section::sectionHtmlCachePath(epub->getCachePath(), notesSpine);
+  EXPECT_FALSE(fs::exists(bankPath));
+
+  ASSERT_TRUE(FootnotePreviews::resolveSpine(*epub, 2));
+  ASSERT_TRUE(fs::exists(bankPath)) << "the note document should have been banked on the way past";
+
+  size_t notesSize = 0;
+  ASSERT_TRUE(epub->getSpineItemInflatedSize(notesSpine, &notesSize));
+  EXPECT_EQ(fs::file_size(bankPath), notesSize) << "a short bank fails the builder's staleness test";
+
+  // Second chapter into the same document: it is served from the bank, so the pass completes with
+  // the archive gone.
+  const std::string epubPath = epub->getPath();
+  fs::remove(epubPath);
+  EXPECT_FALSE(FootnotePreviews::spineResolved(epub->getCachePath(), 3));
+  // Pass A still needs chapter 3's own document, which nothing has banked — so this legitimately
+  // fails without the archive. What matters is WHERE it fails: the store must survive it intact.
+  const std::vector<std::string> before = storeTexts(*epub);
+  FootnotePreviews::resolveSpine(*epub, 3);
+  EXPECT_EQ(storeTexts(*epub), before) << "a pass that could not read its spine must change nothing";
+  EXPECT_FALSE(FootnotePreviews::spineResolved(epub->getCachePath(), 3));
 }

--- a/test/epub_pipeline/FootnoteResolveSliceTest.cpp
+++ b/test/epub_pipeline/FootnoteResolveSliceTest.cpp
@@ -1,0 +1,455 @@
+// Cover for the SLICING of the footnote-preview resolve.
+//
+// FootnotePreviewStoreTest pins what the resolve produces. This file pins what it costs, which is
+// a separate property and the one that regressed: the pass runs on the loop task from inside a
+// section build, so no single step may do an amount of work that depends on the book. A 200 KB
+// chapter and a chapter with a hundred callers into one fat rearnotes document have to slice the
+// same way a 1 KB chapter with one note does — otherwise Background-B stalls input for as long as
+// the document takes, which is what made an earlier fix refuse to pre-build such spines at all
+// (issue #211).
+//
+// The books are generated here rather than checked in, because the point is the MATRIX — spine
+// size against note count — and a fixture per cell would be four binaries that no one can diff.
+// They are written as STORED (uncompressed) zip entries, which ZipFile and EntryReader both read;
+// the deflated path is covered by the corpus book at the bottom.
+#include <Arduino.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "Epub.h"
+#include "Epub/FootnotePreviews.h"
+#include "Epub/Section.h"
+#include "GfxRenderer.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// The resolver's read granularity. Spelled out rather than shared with the implementation so a
+// change to it has to be made deliberately in two places (same rule as the store layout in
+// FootnotePreviewStoreTest).
+constexpr size_t kStreamChunkBytes = 1024;
+
+constexpr int kChapterSpine = 0;
+constexpr int kNotesSpine = 1;
+
+std::string freshDir(const std::string& tag) {
+  const auto dir = fs::temp_directory_path() / "footnote_slice_test" / tag;
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  return dir.string();
+}
+
+// --- minimal STORED-only zip writer -------------------------------------------------------
+
+class StoredZipWriter {
+ public:
+  void add(const std::string& name, const std::string& data) { entries_.push_back({name, data, 0}); }
+
+  void write(const std::string& path) {
+    std::string out;
+    for (Entry& e : entries_) {
+      e.localOffset = static_cast<uint32_t>(out.size());
+      appendLocalHeader(out, e);
+      out += e.data;
+    }
+    const uint32_t centralStart = static_cast<uint32_t>(out.size());
+    for (const Entry& e : entries_) {
+      appendCentralHeader(out, e);
+    }
+    const uint32_t centralSize = static_cast<uint32_t>(out.size()) - centralStart;
+    appendEocd(out, centralStart, centralSize, static_cast<uint16_t>(entries_.size()));
+    std::ofstream f(path, std::ios::binary);
+    f.write(out.data(), static_cast<std::streamsize>(out.size()));
+  }
+
+ private:
+  struct Entry {
+    std::string name;
+    std::string data;
+    uint32_t localOffset;
+  };
+
+  static void put16(std::string& out, const uint16_t v) {
+    out.push_back(static_cast<char>(v & 0xFF));
+    out.push_back(static_cast<char>((v >> 8) & 0xFF));
+  }
+  static void put32(std::string& out, const uint32_t v) {
+    for (int i = 0; i < 4; ++i) out.push_back(static_cast<char>((v >> (8 * i)) & 0xFF));
+  }
+  // CRC-32 is checked by nothing on the read path here, but a zero would be a lie in a file we
+  // hand to a real reader, so compute it properly.
+  static uint32_t crc32(const std::string& data) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (const unsigned char c : data) {
+      crc ^= c;
+      for (int k = 0; k < 8; ++k) crc = (crc >> 1) ^ (0xEDB88320u & (~(crc & 1u) + 1u));
+    }
+    return ~crc;
+  }
+  static void appendLocalHeader(std::string& out, const Entry& e) {
+    put32(out, 0x04034B50);
+    put16(out, 20);  // version needed
+    put16(out, 0);   // flags
+    put16(out, 0);   // method: stored
+    put16(out, 0);   // time
+    put16(out, 0);   // date
+    put32(out, crc32(e.data));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put16(out, static_cast<uint16_t>(e.name.size()));
+    put16(out, 0);
+    out += e.name;
+  }
+  static void appendCentralHeader(std::string& out, const Entry& e) {
+    put32(out, 0x02014B50);
+    put16(out, 20);  // version made by
+    put16(out, 20);  // version needed
+    put16(out, 0);
+    put16(out, 0);  // method: stored
+    put16(out, 0);
+    put16(out, 0);
+    put32(out, crc32(e.data));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put16(out, static_cast<uint16_t>(e.name.size()));
+    put16(out, 0);  // extra
+    put16(out, 0);  // comment
+    put16(out, 0);  // disk
+    put16(out, 0);  // internal attrs
+    put32(out, 0);  // external attrs
+    put32(out, e.localOffset);
+    out += e.name;
+  }
+  static void appendEocd(std::string& out, const uint32_t centralStart, const uint32_t centralSize,
+                         const uint16_t entryCount) {
+    put32(out, 0x06054B50);
+    put16(out, 0);  // disk number
+    put16(out, 0);  // disk with central dir
+    put16(out, entryCount);
+    put16(out, entryCount);
+    put32(out, centralSize);
+    put32(out, centralStart);
+    put16(out, 0);  // comment length
+  }
+
+  std::vector<Entry> entries_;
+};
+
+// --- fixture generation --------------------------------------------------------------------
+
+// One chapter with `noteCount` footnote callers, padded to at least `chapterBytes`, plus one
+// document holding every note body. Two knobs, four interesting corners.
+std::string makeBook(const std::string& dir, const int noteCount, const size_t chapterBytes) {
+  std::string callers;
+  for (int i = 1; i <= noteCount; ++i) {
+    callers += "<p>Body text before the marker <a href=\"notes.xhtml#note_" + std::to_string(i) + "\">" +
+               std::to_string(i) + "</a> and after it.</p>\n";
+  }
+  // Pad with ordinary prose so the scanner has to walk a big document, not a big attribute.
+  std::string padding;
+  while (callers.size() + padding.size() < chapterBytes) {
+    padding +=
+        "<p>The Patrician had a broad and comprehensive view of the world, which is to say a "
+        "short one, and he had it at some length.</p>\n";
+  }
+  const std::string chapter =
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<head><title>C"
+      "</title></head>\n<body>\n" +
+      callers + padding + "</body>\n</html>\n";
+
+  std::string notes;
+  for (int i = 1; i <= noteCount; ++i) {
+    notes += "<div id=\"note_" + std::to_string(i) + "\"><p>Note number " + std::to_string(i) +
+             ", which says something worth previewing and then stops.</p></div>\n";
+  }
+  const std::string notesDoc =
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<head><title>N"
+      "</title></head>\n<body>\n" +
+      notes + "</body>\n</html>\n";
+
+  const std::string opf =
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+      "<package xmlns=\"http://www.idpf.org/2007/opf\" version=\"3.0\" unique-identifier=\"id\">\n"
+      "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:identifier id=\"id\">slice-test</dc:identifier>"
+      "<dc:title>Slice Test</dc:title><dc:language>en</dc:language></metadata>\n"
+      "<manifest>\n"
+      "<item id=\"c\" href=\"chapter.xhtml\" media-type=\"application/xhtml+xml\"/>\n"
+      "<item id=\"n\" href=\"notes.xhtml\" media-type=\"application/xhtml+xml\"/>\n"
+      "</manifest>\n"
+      "<spine><itemref idref=\"c\"/><itemref idref=\"n\"/></spine>\n"
+      "</package>\n";
+
+  const std::string container =
+      "<?xml version=\"1.0\"?>\n"
+      "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">\n"
+      "<rootfiles><rootfile full-path=\"content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>\n"
+      "</container>\n";
+
+  StoredZipWriter zip;
+  zip.add("mimetype", "application/epub+zip");
+  zip.add("META-INF/container.xml", container);
+  zip.add("content.opf", opf);
+  zip.add("chapter.xhtml", chapter);
+  zip.add("notes.xhtml", notesDoc);
+  const std::string path = dir + "/book.epub";
+  zip.write(path);
+  return path;
+}
+
+std::shared_ptr<Epub> openBook(const std::string& path, const std::string& cacheDir) {
+  auto epub = std::make_shared<Epub>(path, cacheDir);
+  EXPECT_TRUE(epub->load(true));
+  return epub;
+}
+
+std::string storeBytes(const Epub& epub) {
+  std::ifstream in(epub.getCachePath() + FootnotePreviews::CACHE_FILENAME, std::ios::binary);
+  if (!in) return {};
+  return std::string{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+// The note texts the store actually SERVES, read the way Lookup reads them: through the sorted
+// index, not in blob order. The difference matters here and nowhere else — an abandoned append
+// leaves orphaned blobs behind (see AbandonedResolveLeavesTheStoreUsable), and blob-order reading
+// would report those dead bytes as if they were entries. Sorted, so index order is not part of
+// the assertion. Layout constants are spelled out rather than shared with the implementation, for
+// the same reason FootnotePreviewStoreTest spells them out: a format change should have to be
+// made deliberately in two places.
+std::vector<std::string> storeTexts(const Epub& epub) {
+  constexpr size_t kBlobStart = 12 + 64;  // header + resolved-spine bitmap
+  constexpr size_t kIndexRowBytes = 8;    // u32 keyHash + u32 blobOffset
+  std::vector<std::string> texts;
+  const std::string bytes = storeBytes(epub);
+  if (bytes.size() < kBlobStart) return texts;
+  uint16_t count = 0;
+  uint32_t indexOffset = 0;
+  memcpy(&count, bytes.data() + 6, sizeof(count));
+  memcpy(&indexOffset, bytes.data() + 8, sizeof(indexOffset));
+  for (uint16_t i = 0; i < count; ++i) {
+    const size_t row = indexOffset + static_cast<size_t>(i) * kIndexRowBytes;
+    if (row + kIndexRowBytes > bytes.size()) break;
+    uint32_t blobOffset = 0;
+    memcpy(&blobOffset, bytes.data() + row + 4, sizeof(blobOffset));
+    if (blobOffset + 2 > bytes.size()) break;
+    uint16_t len = 0;
+    memcpy(&len, bytes.data() + blobOffset, sizeof(len));
+    if (blobOffset + 2 + len > bytes.size()) break;
+    texts.emplace_back(bytes, blobOffset + 2, len);
+  }
+  std::sort(texts.begin(), texts.end());
+  return texts;
+}
+
+// Runs the resolver one step at a time. Returns the step count, or -1 on failure.
+int resolveStepByStep(Epub& epub, const int spineIndex) {
+  FootnotePreviews::Resolver resolver;
+  if (!resolver.begin(epub, spineIndex)) return -1;
+  int steps = 0;
+  while (true) {
+    const auto step = resolver.step();
+    ++steps;
+    if (step == FootnotePreviews::Resolver::Step::Done) return steps;
+    if (step == FootnotePreviews::Resolver::Step::Failed) return -1;
+    if (steps > 200000) {
+      ADD_FAILURE() << "resolver never terminated";
+      return -1;
+    }
+  }
+}
+
+struct Shape {
+  const char* name;
+  int noteCount;
+  size_t chapterBytes;
+};
+
+// The four corners the fix has to hold at. Small/large spine against few/many notes: each pairing
+// stresses a different phase — a large spine is a long pass A, many notes is a long pass B.
+const Shape kShapes[] = {
+    {"small_one_note", 1, 512},
+    {"small_many_notes", 100, 512},
+    {"large_one_note", 1, 200 * 1024},
+    {"large_many_notes", 100, 200 * 1024},
+};
+
+}  // namespace
+
+// Stepping the resolver to completion must produce exactly the file the one-shot call produces,
+// for every shape. This is the property that lets Section slice the pass without anyone auditing
+// the store afterwards.
+TEST(FootnoteResolveSlice, SlicedResolveMatchesOneShotForEveryShape) {
+  for (const Shape& shape : kShapes) {
+    const std::string oneShotDir = freshDir(std::string(shape.name) + "_oneshot");
+    const std::string oneShotBook = makeBook(oneShotDir, shape.noteCount, shape.chapterBytes);
+    auto oneShotEpub = openBook(oneShotBook, oneShotDir);
+    ASSERT_TRUE(FootnotePreviews::resolveSpine(*oneShotEpub, kChapterSpine)) << shape.name;
+    const std::string expected = storeBytes(*oneShotEpub);
+    ASSERT_FALSE(expected.empty()) << shape.name;
+
+    const std::string slicedDir = freshDir(std::string(shape.name) + "_sliced");
+    const std::string slicedBook = makeBook(slicedDir, shape.noteCount, shape.chapterBytes);
+    auto slicedEpub = openBook(slicedBook, slicedDir);
+    ASSERT_GT(resolveStepByStep(*slicedEpub, kChapterSpine), 0) << shape.name;
+
+    EXPECT_EQ(storeBytes(*slicedEpub), expected) << shape.name;
+    EXPECT_TRUE(FootnotePreviews::spineResolved(slicedEpub->getCachePath(), kChapterSpine)) << shape.name;
+  }
+}
+
+// The actual slicing guarantee: no single step may swallow a whole document. Asserted by counting
+// steps against the bytes that had to be read — a step that read the lot would finish in far
+// fewer. This is what fails if someone "optimises" the resolver by looping inside step().
+TEST(FootnoteResolveSlice, NoStepReadsMoreThanOneChunk) {
+  for (const Shape& shape : kShapes) {
+    const std::string dir = freshDir(std::string(shape.name) + "_bounded");
+    const std::string book = makeBook(dir, shape.noteCount, shape.chapterBytes);
+    auto epub = openBook(book, dir);
+
+    size_t chapterBytes = 0;
+    size_t notesBytes = 0;
+    ASSERT_TRUE(epub->getSpineItemInflatedSize(kChapterSpine, &chapterBytes));
+    ASSERT_TRUE(epub->getSpineItemInflatedSize(kNotesSpine, &notesBytes));
+
+    const int steps = resolveStepByStep(*epub, kChapterSpine);
+    ASSERT_GT(steps, 0) << shape.name;
+
+    // Pass A reads the chapter, pass B reads the notes document; both a chunk at a time.
+    const size_t minSteps = (chapterBytes + notesBytes) / kStreamChunkBytes;
+    EXPECT_GE(static_cast<size_t>(steps), minSteps)
+        << shape.name << ": " << steps << " steps for " << (chapterBytes + notesBytes)
+        << " bytes means a step read more than one " << kStreamChunkBytes << "-byte chunk";
+  }
+}
+
+// A resolve that is abandoned part-way — the reader turned a page, Background-B handed its
+// buffer back, the activity exited — must leave the store USABLE and no more complete than it
+// found it. Slicing turns preemption from an error path into a routine one, so this is the case
+// that has to hold at every point in the pass, not just at a tidy boundary.
+//
+// Note what is deliberately NOT asserted: byte-equality with a store that was never abandoned.
+// Store::abandon() rolls the index back but cannot shrink the file — the HAL has no truncate —
+// so the blobs the abandoned pass had already written stay behind as an unreferenced gap that the
+// next pass appends after. That is the documented contract, and the file stays valid: what the
+// store CONTAINS is what must not change.
+TEST(FootnoteResolveSlice, AbandonedResolveLeavesTheStoreUsable) {
+  const std::string dir = freshDir("abandoned_reference");
+  const std::string book = makeBook(dir, /*noteCount=*/100, /*chapterBytes=*/200 * 1024);
+  auto epub = openBook(book, dir);
+
+  const int fullSteps = resolveStepByStep(*epub, kChapterSpine);
+  ASSERT_GT(fullSteps, 8);
+  const std::vector<std::string> expected = storeTexts(*epub);
+  ASSERT_EQ(expected.size(), 100u);
+
+  // Stop at points spread across the whole pass: inside pass A's scan, at the phase changes, and
+  // deep inside pass B where the store is mid-append with most of the notes already written.
+  for (const int stopAfter : {1, 2, 5, fullSteps / 4, fullSteps / 2, fullSteps - 2}) {
+    const std::string abandonDir = freshDir("abandoned_at_" + std::to_string(stopAfter));
+    const std::string abandonBook = makeBook(abandonDir, 100, 200 * 1024);
+    auto abandonEpub = openBook(abandonBook, abandonDir);
+    {
+      FootnotePreviews::Resolver resolver;
+      ASSERT_TRUE(resolver.begin(*abandonEpub, kChapterSpine));
+      for (int i = 0; i < stopAfter; ++i) {
+        ASSERT_EQ(resolver.step(), FootnotePreviews::Resolver::Step::More) << "stopAfter=" << stopAfter;
+      }
+    }  // destructor rolls the append back
+
+    // Nothing may claim the spine is done off the back of a pass that did not finish.
+    EXPECT_FALSE(FootnotePreviews::spineResolved(abandonEpub->getCachePath(), kChapterSpine))
+        << "stopAfter=" << stopAfter;
+    // And whatever landed on disk must still be a store the next pass can open and complete.
+    ASSERT_TRUE(FootnotePreviews::resolveSpine(*abandonEpub, kChapterSpine)) << "stopAfter=" << stopAfter;
+    EXPECT_EQ(storeTexts(*abandonEpub), expected) << "stopAfter=" << stopAfter;
+    EXPECT_TRUE(FootnotePreviews::spineResolved(abandonEpub->getCachePath(), kChapterSpine))
+        << "stopAfter=" << stopAfter;
+  }
+}
+
+// Background-B may be preempted more than once on the same spine before it gets a clean run, so
+// the gap an abandoned append leaves behind has to be survivable repeatedly — not just valid the
+// first time.
+TEST(FootnoteResolveSlice, RepeatedAbandonsStillResolveCleanly) {
+  const std::string refDir = freshDir("repeat_reference");
+  const std::string refBook = makeBook(refDir, /*noteCount=*/100, /*chapterBytes=*/8 * 1024);
+  auto refEpub = openBook(refBook, refDir);
+  ASSERT_GT(resolveStepByStep(*refEpub, kChapterSpine), 0);
+  const std::vector<std::string> expected = storeTexts(*refEpub);
+  ASSERT_EQ(expected.size(), 100u);
+
+  const std::string dir = freshDir("repeat_abandons");
+  const std::string book = makeBook(dir, 100, 8 * 1024);
+  auto epub = openBook(book, dir);
+  for (int cycle = 0; cycle < 5; ++cycle) {
+    FootnotePreviews::Resolver resolver;
+    ASSERT_TRUE(resolver.begin(*epub, kChapterSpine));
+    for (int i = 0; i < 12 + cycle; ++i) {
+      ASSERT_EQ(resolver.step(), FootnotePreviews::Resolver::Step::More) << "cycle=" << cycle;
+    }
+  }
+  ASSERT_TRUE(FootnotePreviews::resolveSpine(*epub, kChapterSpine));
+  EXPECT_EQ(storeTexts(*epub), expected);
+  EXPECT_TRUE(FootnotePreviews::spineResolved(epub->getCachePath(), kChapterSpine));
+}
+
+// The same guarantee one level up: a build driven with a 1 ms budget over a chapter whose resolve
+// cannot fit in it must still produce the pages the blocking build produces. The resolve is a
+// LAYOUT input, so an equal page count over a 100-note chapter says the previews were in place
+// before the parse in both.
+TEST(FootnoteResolveSlice, SlicedBuildResolvesManyNotesAcrossSlices) {
+  Section::BuildParams params;
+  params.viewportWidth = 480;
+  params.viewportHeight = 800;
+  params.lineCompression = 1.0f;
+  params.inlineFootnotePreviews = true;
+
+  GfxRenderer renderer;
+  const std::string blockingDir = freshDir("build_blocking");
+  const std::string blockingBook = makeBook(blockingDir, /*noteCount=*/100, /*chapterBytes=*/64 * 1024);
+  auto blockingEpub = openBook(blockingBook, blockingDir);
+  Section blocking(blockingEpub, kChapterSpine, renderer);
+  ASSERT_TRUE(blocking.createSectionFile(params, {}, /*skipEviction=*/true));
+  ASSERT_TRUE(blocking.loadSectionFile(params));
+  ASSERT_GT(blocking.pageCount, 0);
+
+  const std::string slicedDir = freshDir("build_sliced");
+  const std::string slicedBook = makeBook(slicedDir, 100, 64 * 1024);
+  auto slicedEpub = openBook(slicedBook, slicedDir);
+  Section sliced(slicedEpub, kChapterSpine, renderer);
+  int slices = 0;
+  Section::BuildStep step = Section::BuildStep::More;
+  while (step != Section::BuildStep::Done && step != Section::BuildStep::Failed && slices < 200000) {
+    step = sliced.stepSectionBuild(params, /*budgetMs=*/1);
+    ++slices;
+  }
+  ASSERT_EQ(step, Section::BuildStep::Done);
+  ASSERT_TRUE(sliced.loadSectionFile(params));
+
+  EXPECT_EQ(storeBytes(*slicedEpub), storeBytes(*blockingEpub));
+  EXPECT_EQ(sliced.pageCount, blocking.pageCount);
+  EXPECT_TRUE(FootnotePreviews::spineResolved(slicedEpub->getCachePath(), kChapterSpine));
+}
+
+// The generated books are STORED entries, so the paths above never exercise the inflate ring the
+// ZIP path allocates. The corpus book is deflated: same equivalence, real archive.
+TEST(FootnoteResolveSlice, SlicedResolveMatchesOneShotOnADeflatedArchive) {
+  const std::string corpus = std::string(CORPUS_DIR) + "/test_inline_footnotes.epub";
+
+  const std::string oneShotDir = freshDir("deflated_oneshot");
+  auto oneShotEpub = openBook(corpus, oneShotDir);
+  ASSERT_TRUE(FootnotePreviews::resolveSpine(*oneShotEpub, kChapterSpine));
+  const std::string expected = storeBytes(*oneShotEpub);
+  ASSERT_FALSE(expected.empty());
+
+  const std::string slicedDir = freshDir("deflated_sliced");
+  auto slicedEpub = openBook(corpus, slicedDir);
+  ASSERT_GT(resolveStepByStep(*slicedEpub, kChapterSpine), 0);
+  EXPECT_EQ(storeBytes(*slicedEpub), expected);
+}


### PR DESCRIPTION
Fixes #211 — "Indexing delay every chapter".

Six commits. The first is the reported bug; the rest are what fixing it, and then validating it on device, turned up.

---

## 1. The bug: Background-B refused every unresolved spine (53c5c60b2)

Look-ahead has been dead for the whole of any preview-enabled book since 2.24 (`7f38b434`).

B skipped a spine whose footnote links had not been scanned yet and left it to the foreground, on the assumption that the foreground would set the resolved bit and B could pre-build the chapter from then on. But the bit is only ever set **by a build**, and the only spine the foreground ever builds is the one the reader just entered — so every subsequent chapter stayed unresolved, B refused all of them, and the reader got the "Indexing" popup at every chapter boundary.

The reporter's trace shows B walking the rest of the book in one ~2.6 s burst of skips on every chapter entry, then parking one past the last spine:

```
Background build spine=45 skipped: footnote previews not resolved yet
... (through 68)
BG work: A runs=27 completes=27 | B runs=0 completes=0 state=probe spine=69
```

B builds those spines again. `spineResolved()` now only *sizes the gates*; it must never decide whether to build.

**A second bug fell out of it.** The property hash says "previews on" whether or not the resolve succeeded, so a chapter cached with plain markers was never rebuilt — silent and permanent. `Section` latches the failure now (`isFootnotePreviewsUnresolved()`) and B discards such a build for the foreground to redo released, the same treatment truncated and css-degraded results already get.

## 2. The resolve is now sliced (910ad354d)

The first commit left the resolve as one unsliceable pass, mitigated by making B wait for a settled reader. That mitigation was sized against a single 117 ms measurement from one book, which is not evidence: a 200 KB chapter, or a chapter with a hundred callers into a fat rearnotes document, is unbounded work either way.

`FootnotePreviews::Resolver` does the same work a chunk at a time. `step()` reads at most one 1 KB chunk of one document, or makes one bookkeeping transition, and returns; `runBuildParse` spends its budget on it and yields exactly as it does on the layout parse. Nothing in the resolver measures time, which keeps the slicing deterministic to test. `resolveSpine()` is that loop run to completion, so the blocking path is unchanged.

Preemption is safe at every point: the store is only written between `beginAppend()` and `commit()`, and the resolver's destructor rolls a half-finished append back. That removed the reason B needed the stillness gate, so it's gone — only the heap margin remains.

Two things fell out:

- **`DocStream`** replaces the two one-shot stream helpers, so the banked-XHTML / ZIP / staleness logic exists once instead of twice. It also gives a note document's inflate ring **the build's arena** when there's room — a sliced resolve would otherwise hold up to 32 KB on the reading heap across every page render in between. That was the objection to slicing in the first place, and this is what answers it.
- A spine whose targets another chapter already stored now gets its resolved bit. The bit means "scanned, nothing outstanding", and such a spine is — it was being re-scanned on every build for want of one line.

## 3–5. Three fixes from the device traces

**Background-C was incrementing B's counters (120fa200f).** A long C build printed `B runs=211 completes=1` next to `state=probe spine=-1` — B had no target at all. The one counter you'd check to see whether look-ahead is working was being driven by something else. C has its own pair and its own field now.

**Performance Locks now nest (390e08e31).** `HalPowerManager::Lock` was a single slot: a second concurrent Lock logged `Lock already held, ignore` at ERR and was handed back holding **nothing**, and the first one's destructor then cleared the flag while the second holder was still running. The render task takes one per render and the loop task one per build slice, so they overlap constantly. The consequence wasn't just noise — with the loop task's lock dropped, `enterWaveformWait()` saw no foreign lock and downclocked to 10 MHz underneath a running build slice, exactly the failure the comment on that lock warns about. Counted now; more than one holder counts as foreign.

**The in-place build gate no longer admits spines it can't build (86bf01ea3).** The extract floor was a 30 KB base plus the ring, ring capped at 32 KB — so past that cap the entry size is invisible to the gate. Small Gods spine 1 (the whole book in one 583991-byte entry) cleared it by 4 KB and collapsed 170 ms later:

```
gate      free=71592  (floor 67584)
start     free=60396  -11196  activity/section/popup before the build begins
setup     free=56648   -3748  CSS index load
abort     free=19924  -36724  ZipFile + read buffer + the 32768 inflate ring
-> Background-C spine=1 low heap mid-build; falling back to released rebuild
```

The ring is only two thirds of what the extract costs from the gate; the other ~18.9 KB is fixed overhead, and the build must also clear `RESIDENT_BUILD_ABORT_FREE_HEAP_BYTES` (30 KB). 18.9 + 30 = 48.9, so the base goes to **50 KB**, turning ~1.4 s of setup/abort/cache-clear/re-setup into an up-front "released".

**Trade-off, stated plainly:** below ~10 KB entries nothing changes — the ring keeps the sum under the flat 60/66 KB floors, so ordinary chapters still build in place and still avoid the baseline-resetting half-refresh that path exists for. Between there and the 32 KB cap, some builds that used to go resident now go released. Those are the ones most likely to have hit the abort anyway. If you'd rather keep more resident, `IN_PLACE_BUILD_EXTRACT_BASE_HEAP_BYTES` is the number and the measurement above is what it's derived from.

---

## Device validation

A trace with previews actually on (`previews=1 variant=1 global=1`), reading Men at Arms — three large chapters whose callers all point into one shared notes document:

```
[FNP] Spine 3: resolved 14 of 14 note targets from 1 document(s) in 1149ms
[SCT] createSectionFile spine=3 footnote previews resolved in 1125ms (worst slice 90ms)
```

275722 bytes, 14 notes, notes document not yet banked. **1125 ms of resolve, worst slice 90 ms** — where before the whole 1125 ms was a single loop-task slice.

The 90 ms residual is one long *transition* step: opening the note document from the ZIP after the bank miss (central-directory lookup, ring alloc, inflate seed). O(1) per note document, once per book; deliberately not split further.

Also confirmed in the same run:

- `heapAllowsInPlaceBuild=0 css=1 ring=32768 free=66592(floor=83968)` on spine 3 — refused up front. Spines 0 and 1 (`ring=788` / `684`) still take `INCR_RESIDENT`.
- `| B runs=2 completes=0 | C runs=269 completes=3 |` — counters readable.
- **Zero** `[ERR] [PWR] Lock already held` in the whole run.
- All 14 previews expand with real prose (`previewBytes` 5–84).

## Tests

`FootnoteResolveSliceTest` (new, 645 lines) generates its books rather than checking them in, because what matters is the shape.

**Matrix — spine size against note count:**

| | 1 note | 100 notes |
|---|---|---|
| **512 B spine** | ✅ | ✅ |
| **200 KB spine** | ✅ | ✅ |

**Shared-notes shape (7eb881dc2)** — modelled on Men at Arms: three large chapters into one notes document, behind two one-page front-matter spines. The markup is the real thing rather than a simplification: `<a href="..."><sup>*</sup></a>` callers, so the shape heuristic has to accept a bare asterisk (the digit-marker fixtures never exercised that), and note bodies opening with a back-link the capture must skip.

What is pinned:

- **Equivalence** — a step-by-step resolve is byte-identical to the one-shot one, every cell of the matrix and every chapter of the shared-notes book. Plus the deflated corpus book, since generated fixtures are STORED and never touch the inflate ring.
- **Boundedness** — step count asserted against bytes read, so a step that swallowed a whole document fails the test instead of being noticed on someone's device. The large shapes run ~217 steps against a 203-step floor.
- **Abandonment** — six stop points across the pass including deep inside the append, plus five repeated abandons of one spine (B can be preempted twice on the same spine before the foreground takes over).
- **Front matter with no callers** still getting its resolved bit *in a book that has notes* — a book where it didn't would send B back to refusing spines, which is #211 one level down.
- **Chrome exclusion** — the back-link marker staying out of the preview text.
- **Banking** — the shared notes document streamed once and banked, with the store provably untouched by a later pass that can't read its own spine.
- **Build level** — a 100-note chapter at `budgetMs=1` yields the same store and page count as the blocking build. Previews are a layout input, so equal page counts say they were in place before the parse in both.

645 host tests green. Firmware builds at 94.1%.

## Known, not fixed here

`Store::abandon()` rolls the index back but cannot shrink the file — the HAL has no truncate — so an abandoned append leaves its blobs behind as an unreferenced gap that the next pass appends after. The file stays valid and the index is correct; only dead bytes accumulate, bounded by the preemption cap. The tests read the store through its index (the way `Lookup` does) rather than in blob order, which is the only reading that stays true after an abandon.
