### PR TITLE
perf(images): stop re-doing work in the image pipeline — cover open 35 s → 9.6 s

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1,6 +1,7 @@
 #include "Epub.h"
 
 #include <Bitmap.h>
+#include <BufferedFileIO.h>
 #include <CooperativeAbort.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
@@ -1461,14 +1462,68 @@ bool Epub::readItemContentsToStreamWithArena(const std::string& itemHref, Print&
   return true;
 }
 
+namespace {
+
+// Buffers the extract's writes on their way to SD.
+//
+// Both stream paths below hand the sink 512 B - 1 KB at a time, which is how they read; written
+// straight through, a cover-sized entry becomes thousands of single-sector SD writes. Device-
+// measured on X4: 857182 bytes took ~17 s that way, ~50 KB/s, while the SAME file read back by
+// the PNG decoder through its 2 KB buffer managed ~215 KB/s. Batching into EXTRACT_WRITE_BUFFER_
+// BYTES lets SdFat issue multi-sector transfers instead.
+//
+// A null/failed buffer degrades to pass-through rather than failing the extract — slow is a
+// nuisance, no cover is a bug.
+class BufferedExtractSink : public Print {
+ public:
+  BufferedExtractSink(FsFile& file, uint8_t* buffer, const size_t capacity)
+      : writer_(file, buffer, buffer ? capacity : 0) {}
+
+  size_t write(const uint8_t byte) override { return write(&byte, 1); }
+  size_t write(const uint8_t* data, const size_t size) override { return writer_.write(data, size) ? size : 0; }
+
+  // Named drain() rather than flush(): Print::flush() is virtual with a void return, and this
+  // one's result decides whether the extract succeeded.
+  bool drain() { return writer_.flush(); }
+
+ private:
+  serialization::BufferedFileWriter writer_;
+};
+
+}  // namespace
+
 bool Epub::extractItemToFileOnce(const std::string& itemHref, const std::string& destPath, BuildArena* arena) const {
   FsFile destFile;
   if (!Storage.openFileForWrite("EBP", destPath, destFile)) {
     LOG_ERR("EBP", "Failed to open dest for extract: %s", destPath.c_str());
     return false;
   }
-  const bool ok = arena ? readItemContentsToStreamWithArena(itemHref, destFile, arena)
-                        : readItemContentsToStream(itemHref, destFile, 1024);
+  // The write buffer is reserved BEFORE the reader takes its own block, because BuildArena is
+  // LIFO: the reader is created and released inside the call below, so it must sit on top of
+  // this one. Falls back to a heap buffer (and then to pass-through) when there is no arena.
+  BuildArena::Block writeBlock;
+  uint8_t* writeBuf = nullptr;
+  std::unique_ptr<uint8_t[]> heapWriteBuf;
+  if (arena && arena->valid() && arena->capacity() - arena->used() >= EXTRACT_WRITE_BUFFER_BYTES) {
+    writeBlock = arena->reserveBlock();
+    writeBuf = static_cast<uint8_t*>(arena->alloc(EXTRACT_WRITE_BUFFER_BYTES));
+  }
+  if (!writeBuf) {
+    heapWriteBuf = makeUniqueNoThrow<uint8_t[]>(EXTRACT_WRITE_BUFFER_BYTES);
+    writeBuf = heapWriteBuf.get();
+  }
+
+  bool ok;
+  {
+    BufferedExtractSink sink(destFile, writeBuf, EXTRACT_WRITE_BUFFER_BYTES);
+    ok = arena ? readItemContentsToStreamWithArena(itemHref, sink, arena)
+               : readItemContentsToStream(itemHref, sink, 1024);
+    // Drain before the file is flushed/closed, and let a failed final write fail the extract:
+    // a short file would otherwise pass as a complete one and be decoded as garbage.
+    if (!sink.drain()) ok = false;
+  }
+  if (writeBlock.valid()) arena->release(writeBlock);
+
   destFile.flush();
   destFile.close();
   if (!ok) Storage.remove(destPath.c_str());

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -37,14 +37,17 @@ namespace {
 // support" becomes a PERMANENT answer rather than "the extractor hasn't got that far yet".
 constexpr uint32_t COVER_FORMAT_SNIFF_BYTES = 8;
 
-ImageFormatDetector::Format detectCoverImageFormat(FsFile& imageFile) {
-  if (!imageFile || !imageFile.seek(0)) {
+// `base` is where the image starts inside the file: 0 for an extracted cover.img, the entry's
+// data offset when the cover is being read in place out of the EPUB. The stream is left back at
+// `base` either way, ready for a decoder.
+ImageFormatDetector::Format detectCoverImageFormat(FsFile& imageFile, const uint32_t base = 0) {
+  if (!imageFile || !imageFile.seek(base)) {
     return ImageFormatDetector::Format::Unknown;
   }
 
   uint8_t header[8] = {};
   const int readBytes = imageFile.read(header, sizeof(header));
-  imageFile.seek(0);
+  imageFile.seek(base);
 
   return ImageFormatDetector::detect(header, readBytes);
 }
@@ -825,6 +828,40 @@ void Epub::applyMetadataSidecar() const {
   LOG_DBG("EBP", "Applied metadata sidecar: %s", path.c_str());
 }
 
+// One-entry memo for loadForCover().
+//
+// loadForCover() re-parses content.opf whenever book.bin is absent, and the home screen asks the
+// SAME book for cover metadata three to five times in a row: once to try the thumb, once to check
+// whether cover.img is cached, once to start the extract session, then once more per thumb size.
+// Device-measured on X4, one Cyrillic book paid 5 x 301 ms and a five-book carousel spent ~3.3 s
+// re-deriving answers it had just computed.
+//
+// One entry is all it takes, because those repeats are consecutive. Keyed by path AND file size,
+// so a book replaced under the same name cannot serve a stale cover. Cleared by
+// clearCoverMetadataMemo() when the burst ends; until then it is simply replaced as the carousel
+// moves on, so at most one book's metadata is ever held.
+namespace {
+struct CoverMetadataMemo {
+  std::string path;
+  uint32_t size = 0;
+  BookMetadataCache::BookMetadata meta;
+  bool valid = false;
+};
+CoverMetadataMemo g_coverMemo;
+
+// 0 when the book cannot be opened, which disables the memo for that call rather than risking a
+// match on an unknown size.
+uint32_t coverMemoKeySize(const std::string& path) {
+  FsFile f;
+  if (!Storage.openFileForRead("EBP", path, f)) return 0;
+  const uint32_t size = static_cast<uint32_t>(f.size());
+  f.close();
+  return size;
+}
+}  // namespace
+
+void Epub::clearCoverMetadataMemo() { g_coverMemo = CoverMetadataMemo{}; }
+
 bool Epub::loadForCover() {
   // Cover-only load: get coverItemHref WITHOUT building the spine/TOC book.bin (which, on a huge
   // book, is both slow and the site of the large manifest-index build). Used by RecentBooks / Home
@@ -838,12 +875,30 @@ bool Epub::loadForCover() {
     return true;
   }
 
+  // Second fast path: this book's OPF was parsed moments ago (see the memo note above).
+  const uint32_t memoKey = coverMemoKeySize(filepath);
+  if (memoKey != 0 && g_coverMemo.valid && g_coverMemo.size == memoKey && g_coverMemo.path == filepath) {
+    bookMetadataCache->coreMetadata = g_coverMemo.meta;
+    if (bookMetadataCache->coreMetadata.coverItemHref.empty()) return false;
+    bookMetadataCache->markCoverMetadataLoaded();
+    applyMetadataSidecar();
+    return true;
+  }
+
   // No cache: metadata-only OPF parse. OpfCacheMode::Disabled passes a null cache to ContentOpfParser,
   // so NO manifest item index / .items.bin / spine cache is built — only title/author/coverItemHref
   // are extracted. This is the whole point: a 1732-spine book contributes no giant index here.
   if (!parseContentOpf(bookMetadataCache->coreMetadata, OpfCacheMode::Disabled)) {
     LOG_INF("EBP", "loadForCover: content.opf parse failed for %s", filepath.c_str());
-    return false;
+    return false;  // deliberately not memoized: a failed parse may be transient
+  }
+  // Memoized even when there is no cover: "this book has none" is exactly the answer the next
+  // three calls would otherwise re-parse the OPF to rediscover.
+  if (memoKey != 0) {
+    g_coverMemo.path = filepath;
+    g_coverMemo.size = memoKey;
+    g_coverMemo.meta = bookMetadataCache->coreMetadata;
+    g_coverMemo.valid = true;
   }
   if (bookMetadataCache->coreMetadata.coverItemHref.empty()) {
     return false;  // no discoverable cover — caller shows a placeholder
@@ -1217,6 +1272,21 @@ void Epub::writeThumbSentinel(const std::string& thumbPath) {
   thumbBmp.close();
 }
 
+bool Epub::openStoredCoverInPlace(FsFile& out, uint32_t* offset) const {
+  const std::string href = getCoverItemHref();
+  if (href.empty() || !offset) return false;
+  uint32_t size = 0;
+  if (!getStoredItemRange(href, offset, &size) || size == 0) return false;
+  if (!Storage.openFileForRead("EBP", filepath, out)) return false;
+  if (!out.seek(*offset)) {
+    out.close();
+    return false;
+  }
+  LOG_DBG("EBP", "Cover is stored: decoding in place, no extraction (%u bytes at %u)", static_cast<unsigned>(size),
+          static_cast<unsigned>(*offset));
+  return true;
+}
+
 ThumbResult Epub::generateThumbBmp(int height, bool allowExtract) const {
   {
     FsFile existing;
@@ -1254,17 +1324,20 @@ ThumbResult Epub::generateThumbBmp(int height, bool allowExtract) const {
     return ThumbResult::StructurallyAbsent;
   }
 
-  if (!coverImageCachedAndValid(allowExtract)) {
-    // cover.img not yet extracted (or extraction failed transiently). No sentinel — let the
-    // sliced extractor produce it, or retry next pass/boot. The caller counts these.
+  // Same in-place shortcut as the (width, height) overload above: a stored cover needs no
+  // extraction at all.
+  FsFile coverImage;
+  uint32_t coverBase = 0;
+  if (coverImageCachedAndValid(allowExtract)) {
+    if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return ThumbResult::TransientFail;
+  } else if (!openStoredCoverInPlace(coverImage, &coverBase)) {
+    // Neither cached nor stored. No sentinel — let the sliced extractor produce it, or retry
+    // next pass/boot. The caller counts these.
     LOG_DBG("EBP", "cover.img not cached/valid for h=%d — transient, deferring", height);
     return ThumbResult::TransientFail;
   }
 
-  FsFile coverImage;
-  if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return ThumbResult::TransientFail;
-
-  const auto detectedFormat = detectCoverImageFormat(coverImage);
+  const auto detectedFormat = detectCoverImageFormat(coverImage, coverBase);
   if (detectedFormat == ImageFormatDetector::Format::Unknown) {
     // Cover extracted but its format is unsupported — structural, re-extraction yields the same
     // bytes. Sentinel so we stop trying.
@@ -1338,17 +1411,22 @@ ThumbResult Epub::generateThumbBmp(int width, int height, bool allowExtract) con
     return ThumbResult::StructurallyAbsent;
   }
 
-  if (!coverImageCachedAndValid(allowExtract)) {
-    // cover.img not yet extracted (or extraction failed transiently). No sentinel — let the
-    // sliced extractor produce it, or retry next pass/boot. The caller counts these.
+  // Prefer the extracted cover.img when we have it; otherwise the cover can still be decoded
+  // straight out of the archive if the ZIP stores it uncompressed, which skips the extraction
+  // entirely. Measured on X4: four carousel covers spent ~6.0 s being copied to cover.img before
+  // any of them could be decoded.
+  FsFile coverImage;
+  uint32_t coverBase = 0;
+  if (coverImageCachedAndValid(allowExtract)) {
+    if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return ThumbResult::TransientFail;
+  } else if (!openStoredCoverInPlace(coverImage, &coverBase)) {
+    // Neither cached nor stored (a deflated entry has to be inflated first). No sentinel — let
+    // the sliced extractor produce it, or retry next pass/boot. The caller counts these.
     LOG_DBG("EBP", "cover.img not cached/valid for %dx%d — transient, deferring", width, height);
     return ThumbResult::TransientFail;
   }
 
-  FsFile coverImage;
-  if (!Storage.openFileForRead("EBP", getCoverImageCachePath(), coverImage)) return ThumbResult::TransientFail;
-
-  const auto detectedFormat = detectCoverImageFormat(coverImage);
+  const auto detectedFormat = detectCoverImageFormat(coverImage, coverBase);
   if (detectedFormat == ImageFormatDetector::Format::Unknown) {
     // Cover extracted but its format is unsupported — structural, re-extraction yields the same
     // bytes. Sentinel so we stop trying.

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -846,6 +846,13 @@ struct CoverMetadataMemo {
   uint32_t size = 0;
   BookMetadataCache::BookMetadata meta;
   bool valid = false;
+  // Whether the cover entry is STORED, and where. -1 = not yet asked. Memoized alongside the
+  // metadata because answering it costs a central-directory scan, and the thumbnail path asks
+  // once per size per attempt -- allocation churn immediately before the cover extract session
+  // needs a large contiguous chunk, which is the last place to be fragmenting the heap.
+  int8_t stored = -1;
+  uint32_t storedOffset = 0;
+  uint32_t storedSize = 0;
 };
 CoverMetadataMemo g_coverMemo;
 
@@ -1275,8 +1282,23 @@ void Epub::writeThumbSentinel(const std::string& thumbPath) {
 bool Epub::openStoredCoverInPlace(FsFile& out, uint32_t* offset) const {
   const std::string href = getCoverItemHref();
   if (href.empty() || !offset) return false;
+
+  // Ask the archive at most once per book (see CoverMetadataMemo::stored).
+  const bool memoUsable = g_coverMemo.valid && g_coverMemo.path == filepath;
   uint32_t size = 0;
-  if (!getStoredItemRange(href, offset, &size) || size == 0) return false;
+  if (memoUsable && g_coverMemo.stored >= 0) {
+    if (g_coverMemo.stored == 0) return false;
+    *offset = g_coverMemo.storedOffset;
+    size = g_coverMemo.storedSize;
+  } else {
+    const bool stored = getStoredItemRange(href, offset, &size) && size != 0;
+    if (memoUsable) {
+      g_coverMemo.stored = stored ? 1 : 0;
+      g_coverMemo.storedOffset = *offset;
+      g_coverMemo.storedSize = size;
+    }
+    if (!stored) return false;
+  }
   if (!Storage.openFileForRead("EBP", filepath, out)) return false;
   if (!out.seek(*offset)) {
     out.close();

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1551,6 +1551,16 @@ bool Epub::getItemSize(const std::string& itemHref, size_t* size) const {
   return ok;
 }
 
+bool Epub::getStoredItemRange(const std::string& itemHref, uint32_t* offset, uint32_t* size) const {
+  if (!offset || !size) return false;
+  const std::string path = FsHelpers::normalisePath(itemHref);
+  ZipFile zip(filepath);
+  primeZip(zip);
+  const bool ok = zip.getStoredEntryRange(path.c_str(), offset, size);
+  adoptZipDetails(zip);
+  return ok;
+}
+
 void Epub::ensureSpineStats() const {
   if (spineStatsResolved_) return;
   spineStatsResolved_ = true;  // one attempt per book instance; on failure fall back to scans

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -237,6 +237,19 @@ class Epub {
   // at once -- more contiguous heap than this device has. Already-compressed formats (PNG, JPEG)
   // are commonly stored, which is exactly where the copy hurts most.
   bool getStoredItemRange(const std::string& itemHref, uint32_t* offset, uint32_t* size) const;
+
+  // Drop the loadForCover() memo (see Epub.cpp). Call when a cover-loading burst is over; the
+  // memo holds one book's metadata and is otherwise replaced as the next book is queried.
+  static void clearCoverMetadataMemo();
+
+ private:
+  // Open the cover image for decoding straight out of the EPUB, positioned at its first byte,
+  // when the ZIP stores that entry uncompressed. False for a deflated entry (or no cover), which
+  // leaves the caller extracting cover.img as before. `offset` receives the entry's position, to
+  // rewind to after sniffing the format.
+  bool openStoredCoverInPlace(FsFile& out, uint32_t* offset) const;
+
+ public:
   bool getSpineItemInflatedSize(int spineIndex, size_t* size) const;
   BookMetadataCache::SpineEntry getSpineItem(int spineIndex) const;
   BookMetadataCache::TocEntry getTocItem(int tocIndex) const;

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -228,6 +228,15 @@ class Epub {
   // extraction into a failed one. See docs/memory-allocation-strategy.md §4 (class D).
   bool extractItemToFile(const std::string& itemHref, const std::string& destPath, BuildArena* arena = nullptr) const;
   bool getItemSize(const std::string& itemHref, size_t* size) const;
+  // Byte range of an item's raw data inside the EPUB, valid ONLY when the ZIP stores that entry
+  // uncompressed (method 0). Lets a decoder read the entry in place instead of extracting it to
+  // SD first -- worth ~3.4 s on an 857 KB cover, which is pure copying at ~255 KB/s.
+  //
+  // Returns false for a deflated entry, and it must: the bytes there are DEFLATE, not the file,
+  // and streaming them into a decoder that inflates again would need two 32 KB uzlib rings live
+  // at once -- more contiguous heap than this device has. Already-compressed formats (PNG, JPEG)
+  // are commonly stored, which is exactly where the copy hurts most.
+  bool getStoredItemRange(const std::string& itemHref, uint32_t* offset, uint32_t* size) const;
   bool getSpineItemInflatedSize(int spineIndex, size_t* size) const;
   BookMetadataCache::SpineEntry getSpineItem(int spineIndex) const;
   BookMetadataCache::TocEntry getTocItem(int tocIndex) const;

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -210,7 +210,13 @@ class Epub {
   // Arena bytes one extractItemToFile() needs to keep its inflate ring off the heap:
   // a 1 KB read buffer plus the worst-case 32 KB ring (the entry size is not known until
   // open(), so budget the cap). Callers gate on image_scratch::canServe(this).
-  static constexpr size_t EXTRACT_ARENA_BYTES = 33 * 1024;
+  // Staging buffer for an extract's SD writes. See BufferedExtractSink in the .cpp for the
+  // device measurement behind it; 4 KB is eight sectors, which is where SdFat's multi-sector
+  // path starts paying off, and small enough to come out of the heap when there is no arena.
+  static constexpr size_t EXTRACT_WRITE_BUFFER_BYTES = 4 * 1024;
+  // Inflate ring (<=32 KB) + the reader's 1 KB chunk + the write buffer above: what an extract
+  // needs from the arena to run entirely off the heap.
+  static constexpr size_t EXTRACT_ARENA_BYTES = 33 * 1024 + EXTRACT_WRITE_BUFFER_BYTES;
 
   // Extract a ZIP entry to a local SD file. Used for lazy image extraction at render time.
   //

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -37,8 +37,8 @@ void PageImage::render(GfxRenderer& renderer, const int fontId, const int xOffse
 }
 
 void PageImage::renderWithForceLoad(GfxRenderer& renderer, const int xOffset, const int yOffset, const bool forceLoad,
-                                    const bool monochromeOutput) {
-  imageBlock->render(renderer, xPos + xOffset, yPos + yOffset, forceLoad, monochromeOutput);
+                                    const bool monochromeOutput, const bool alsoCacheOtherVariant) {
+  imageBlock->render(renderer, xPos + xOffset, yPos + yOffset, forceLoad, monochromeOutput, alsoCacheOtherVariant);
 }
 
 bool PageImage::serialize(FsFile& file) {
@@ -328,13 +328,21 @@ void Page::warmImageCaches(GfxRenderer& renderer, const int xOffset, const int y
     if (ib.wouldShowPlaceholder(forceLoadLargeImages, monochromeOutput)) continue;
     // Check whether the appropriate cache already exists
     const bool alreadyCached = monochromeOutput ? ib.hasPixelCache() : ib.hasGrayscaleCache();
+    // Both variants missing and both wanted: ask the decoder for them in a single inflate
+    // instead of paying two. Requires BOTH to be absent — if the BW cache is already on disk
+    // the merged pass would redo work that is already done, so the plain second pass below is
+    // the cheaper route.
+    const bool mergeVariants = alsoWarmGrayscale && monochromeOutput && !alreadyCached && !ib.hasGrayscaleCache();
     if (!alreadyCached) {
       static_cast<PageImage&>(*element).renderWithForceLoad(renderer, xOffset, yOffset, forceLoadLargeImages,
-                                                            monochromeOutput);
+                                                            monochromeOutput, mergeVariants);
     }
     // Second decode for the other variant when AA needs the grayscale planes on top of
     // the BW frame. Skipped when monochromeOutput is already false — that pass wrote the
-    // grayscale cache itself.
+    // grayscale cache itself — and skipped when the merged pass above already produced it.
+    // Left in place as the fallback that keeps this correct for every decoder and every
+    // failure: the companion is best-effort (JPEG and GIF ignore it, and its cache file can
+    // fail to open on its own), so the re-check is what makes it safe to ask for.
     if (alsoWarmGrayscale && monochromeOutput && !ib.hasGrayscaleCache()) {
       static_cast<PageImage&>(*element).renderWithForceLoad(renderer, xOffset, yOffset, forceLoadLargeImages,
                                                             /*monochromeOutput=*/false);

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -62,7 +62,7 @@ class PageImage final : public PageElement {
       : PageElement(xPos, yPos), imageBlock(std::move(block)) {}
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   void renderWithForceLoad(GfxRenderer& renderer, int xOffset, int yOffset, bool forceLoad,
-                           bool monochromeOutput = true);
+                           bool monochromeOutput = true, bool alsoCacheOtherVariant = false);
   bool serialize(FsFile& file) override;
   PageElementTag getTag() const override { return TAG_PageImage; }
   static std::unique_ptr<PageImage> deserialize(FsFile& file);

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -861,6 +861,7 @@ Section::BuildPhaseResult Section::runBuildSetup(BuildState& st) {
   this->lut.clear();
   cssLowHeapDegraded_ = false;
   footnotePreviewsUnresolved_ = false;
+  imageHeaderDegraded_ = false;
 
   if (!Storage.openFileForWrite("SCT", filePath, file)) {
     return BuildPhaseResult::Failed;
@@ -1321,6 +1322,12 @@ Section::BuildPhaseResult Section::runBuildParse(BuildState& st, const uint32_t 
           static_cast<uint32_t>((esp_timer_get_time() - tFin) / 1000));
 #endif
   st.parserStreamOk = st.visitor->streamSucceeded();
+  // Latch a heap-degraded image before the visitor is torn down. Same contract as the CSS and
+  // footnote latches: the cache is written either way, but a background caller can throw it away
+  // and leave the spine to a build with more headroom.
+  if (st.visitor->imageHeaderDegraded()) {
+    imageHeaderDegraded_ = true;
+  }
   if (st.cssParser) {
     st.cssParser->logResolveStats(st.localPath.c_str());
     // Latch before Finalize clears the parser (which resets its stats): lowHeapSkips

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -292,11 +292,15 @@ std::string Section::sectionHtmlCachePath(const std::string& bookCachePath, cons
 
 std::string Section::getSectionHtmlCachePath() const { return sectionHtmlCachePath(epub->getCachePath(), spineIndex); }
 
-std::string Section::getImageBasePath(uint32_t propertyHash) const {
-  char buf[32];
-  snprintf(buf, sizeof(buf), "img_%d_%08x_", spineIndex, propertyHash);
-  return epub->getCachePath() + "/" + buf;
-}
+// Deliberately carries NEITHER the spine index nor the layout property hash. What gets written
+// here is the archive entry's own bytes, which do not depend on either -- only the .pxc pixel
+// caches do, because those are dithered at display dimensions.
+//
+// It used to be keyed by both, so changing font size, margins or orientation re-extracted every
+// image from scratch: 3.3 s and 857 KB of SD writes for one cover, per layout, with up to five
+// byte-identical copies alive at once (evictOldVariants keeps 5 section variants). Now one
+// extraction serves every variant, and two spines referencing the same image share it too.
+std::string Section::getImageBasePath() const { return epub->getCachePath() + "/img_"; }
 
 struct SectionVariant {
   std::string filename;
@@ -347,7 +351,13 @@ void Section::evictOldVariants() const {
       std::string hashStr = variants[i].filename.substr(underscore + 1, dot - underscore - 1);
       uint32_t parsedHash = strtoul(hashStr.c_str(), nullptr, 16);
       if (parsedHash != 0 || hashStr == "00000000") {
-        std::string imgBasePath = getImageBasePath(parsedHash);
+        // Legacy layout-keyed image caches (img_<spine>_<hash>_<n>) only. Current names are
+        // content-keyed and shared across variants, so they must NOT die with a section variant;
+        // they are reclaimed by Epub::clearCache like any other parsing artifact. This branch
+        // stays to sweep up what older firmware left behind.
+        char legacyPrefix[32];
+        snprintf(legacyPrefix, sizeof(legacyPrefix), "img_%d_%08x_", spineIndex, parsedHash);
+        std::string imgBasePath = epub->getCachePath() + "/" + legacyPrefix;
         // Find and delete matching images
         auto rootFiles = Storage.listFiles(epub->getCachePath().c_str(), 100);
         size_t lastSlash = imgBasePath.find_last_of('/');
@@ -878,7 +888,7 @@ Section::BuildPhaseResult Section::runBuildSetup(BuildState& st) {
   // Derive the content base directory and image cache path prefix for the parser
   size_t lastSlash = st.localPath.find_last_of('/');
   st.contentBase = (lastSlash != std::string::npos) ? st.localPath.substr(0, lastSlash + 1) : "";
-  st.imageBasePath = getImageBasePath(st.propertyHash);
+  st.imageBasePath = getImageBasePath();
 
   st.cssParser = nullptr;
   if (p.embeddedStyle) {

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -109,7 +109,9 @@ class Section {
   // to skip ZIP inflation. Adapted from crosspoint-reader PR #2452 by GitHub user itsthisjustin.
   std::string getSectionHtmlCachePath() const;
   // Computes the image base path for extract images related to this specific section variant
-  std::string getImageBasePath(uint32_t propertyHash) const;
+  // Directory prefix for extracted source images. Content-keyed by the caller (see
+  // ChapterHtmlSlimParser), so one extraction serves every layout variant.
+  std::string getImageBasePath() const;
   // Garbage collection: Keep only the most recent N variants per chapter
   void evictOldVariants() const;
 

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -39,6 +39,10 @@ class Section {
   // it into the store, so those markers stay plain and nothing would ever rebuild them.
   // Background callers discard such a result and leave the spine to the foreground path.
   bool footnotePreviewsUnresolved_ = false;
+  // Set by the last build when an image was dropped to alt text because the heap gate refused
+  // its header read. The pages are cached under the same property hash as a complete build, so
+  // the missing image would otherwise be permanent — background callers discard instead.
+  bool imageHeaderDegraded_ = false;
 
   void writeSectionFileHeader(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                               uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
@@ -243,6 +247,9 @@ class Section {
   // notes are missing from the store while the cache claims previews are on. Only meaningful
   // right after a build.
   bool isFootnotePreviewsUnresolved() const { return footnotePreviewsUnresolved_; }
+  // True when the last build dropped an image to alt text on a heap refusal — transient, unlike
+  // an unreadable image. Only meaningful right after a build.
+  bool isImageHeaderDegraded() const { return imageHeaderDegraded_; }
   // True while an incremental build is in flight and its CSS resolver has ALREADY hit a
   // low-heap skip — i.e. the in-progress result is going to be css-degraded. Lets a sliced
   // caller (Background-B) abort early instead of finishing a build it will discard. False when

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -269,10 +269,30 @@ bool renderFromCache(GfxRenderer& renderer, const std::string& cachePath, int x,
 }  // namespace
 
 bool ImageBlock::isLargeImage() const {
-  // width and height are always set at construction from the ZIP manifest or
-  // image header — no file read needed. The SD cache file may not exist yet
-  // (lazy extraction), so reading it here would produce spurious error logs.
-  return int32_t(width) * int32_t(height) > LARGE_IMAGE_PIXEL_THRESHOLD;
+  if (largeImageCached_ >= 0) {
+    return largeImageCached_ != 0;
+  }
+  size_t sourceBytes = 0;
+  // Cheapest source first: once the image has been extracted (a re-render, or the other cache
+  // variant decoded earlier in the same pass) the answer is a stat away.
+  FsFile file;
+  if (Storage.openFileForRead("IMG", imagePath, file)) {
+    sourceBytes = file.size();
+    file.close();
+  } else if (!epubFilePath_.empty() && !epubEntryPath_.empty()) {
+    // Not extracted yet: ask the archive. One central-directory scan, and only ever on a
+    // pixel-cache miss — the very next thing that happens is either a placeholder (cheap) or a
+    // decode that costs seconds, so the scan is noise against both.
+    Epub epub(epubFilePath_, "/.crosspoint");
+    if (!epub.getItemSize(epubEntryPath_, &sourceBytes)) {
+      sourceBytes = 0;  // unknown: treat as not-large, i.e. render it rather than hide it
+    }
+  }
+  largeImageCached_ = static_cast<int8_t>(sourceBytes > LARGE_IMAGE_SOURCE_BYTES ? 1 : 0);
+  if (largeImageCached_ != 0) {
+    LOG_DBG("IMG", "Large image (%u bytes): %s", static_cast<uint32_t>(sourceBytes), imagePath.c_str());
+  }
+  return largeImageCached_ != 0;
 }
 
 bool ImageBlock::hasPixelCache() const { return Storage.exists(getBwCachePath(imagePath).c_str()); }

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -301,7 +301,7 @@ void ImageBlock::renderPlaceholder(GfxRenderer& renderer, const int x, const int
 }
 
 void ImageBlock::render(GfxRenderer& renderer, const int x, const int y, const bool forceLoad,
-                        const bool monochromeOutput) {
+                        const bool monochromeOutput, const bool alsoCacheOtherVariant) {
   // The font-prewarm scan pass only accumulates glyphs; an image contributes
   // none, and its DirectPixelWriter output bypasses the renderer's scan-mode
   // suppression, so it would otherwise do a full (discarded) cache render every
@@ -372,6 +372,11 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y, const b
   config.performanceMode = false;
   config.useExactDimensions = true;
   config.cachePath = cachePath;
+  // One inflate, both caches. Only set on a real decode, which is the only place it can pay:
+  // the cache-hit and placeholder paths above already returned.
+  if (alsoCacheOtherVariant) {
+    config.companionCachePath = monochromeOutput ? getGrayscaleCachePath(imagePath) : getBwCachePath(imagePath);
+  }
 
   // Deliberately no adaptive tone on either variant: both .pxc files are dithered straight
   // from the raw luminance. The curve has to be derived from a completed histogram, and a

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -12,6 +12,7 @@
 #include "../converters/DirectPixelWriter.h"
 #include "../converters/ImageDecoderFactory.h"
 #include "../converters/PixelCache.h"
+#include "../converters/PngToFramebufferConverter.h"
 
 // Cache file format (see PixelCache::PXC_MAGIC):
 // - uint16_t magic/version (high bit always set, distinguishing it from the legacy
@@ -94,6 +95,39 @@ std::string getBwCachePath(const std::string& imagePath) { return withSuffix(ima
 // Like the BW plane above, these pixels carry no tone correction, so one cache per image
 // serves every display setting — the name needs no key and never forks.
 std::string getGrayscaleCachePath(const std::string& imagePath) { return withSuffix(imagePath, ".bayer.pxc"); }
+
+// Decode a PNG straight out of the EPUB, with no extraction to SD first.
+//
+// Only possible when the ZIP STORES the entry (already-compressed formats usually are): the
+// bytes in the archive are then the file, and PngStreamDecoder reads forward and seeks only
+// relatively, so a handle parked at the entry's first byte is all it needs.
+//
+// Worth doing because the extract it replaces is pure copying — 857 KB measured at ~255 KB/s,
+// 3.36 s of the 14.93 s an uncached cover cost, plus 857 KB written to the card. Deflated
+// entries cannot take this path (see Epub::getStoredItemRange) and still extract.
+//
+// Returns false if anything at all is not right, leaving the caller to extract and retry: a
+// failed attempt costs one bounded seek and whatever partial decode happened, and PixelCache
+// deletes its own partial file, so the fallback starts clean.
+bool decodePngInPlace(const std::string& epubFilePath, const std::string& epubEntryPath, GfxRenderer& renderer,
+                      const RenderConfig& config) {
+  Epub epub(epubFilePath, "/.crosspoint");
+  uint32_t offset = 0;
+  uint32_t size = 0;
+  if (!epub.getStoredItemRange(epubEntryPath, &offset, &size) || size == 0) return false;
+
+  FsFile file;
+  if (!Storage.openFileForRead("IMG", epubFilePath, file)) return false;
+  if (!file.seekSet(offset)) {
+    file.close();
+    return false;
+  }
+  LOG_DBG("IMG", "Decoding in place from archive: %s (%u bytes at %u)", epubEntryPath.c_str(),
+          static_cast<unsigned>(size), static_cast<unsigned>(offset));
+  const bool ok = PngToFramebufferConverter::decodeOpenFile(file, epubEntryPath, renderer, config);
+  file.close();
+  return ok;
+}
 
 // srcYOffset: first source row to render (0 = top of image).
 // srcHeight:  number of rows to render (0 = full image from srcYOffset).
@@ -339,28 +373,8 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y, const b
     return;
   }
 
-  // Ensure the image is extracted to SD (lazy extraction if not already present).
-  if (!ensureExtracted()) {
-    LOG_ERR("IMG", "Image unavailable: %s", imagePath.c_str());
-    return;
-  }
-
-  // Proceed with full decode
-  FsFile file;
-  if (!Storage.openFileForRead("IMG", imagePath, file)) {
-    LOG_ERR("IMG", "Image file not found after extraction: %s", imagePath.c_str());
-    return;
-  }
-  size_t fileSize = file.size();
-  file.close();
-
-  if (fileSize == 0) {
-    LOG_ERR("IMG", "Image file is empty: %s", imagePath.c_str());
-    return;
-  }
-
-  LOG_TRC("IMG", "Decoding and caching: %s", imagePath.c_str());
-
+  // Build the decode config before deciding HOW to reach the bytes: the in-place shortcut
+  // below needs the same config the extracted path would use.
   RenderConfig config;
   config.x = x;
   config.y = y;
@@ -387,6 +401,38 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y, const b
   //
   // Leaving both variants untoned is also what keeps them interchangeable inputs: they now
   // differ only in ditherer (1-bit Atkinson vs 4-level Bayer) over an identical grey stream.
+
+  // Shortcut: a PNG the archive stores uncompressed needs no extraction at all — decode it
+  // where it lies (see decodePngInPlace). Only attempted while the file is genuinely absent
+  // from SD; once extracted, reading the plain file is simpler and no slower.
+  //
+  // The extension is a hint, not a guarantee (a .png that is really an AVIF is a thing that
+  // happens), but it costs nothing to be wrong: the decoder rejects the signature and we fall
+  // through to the extract exactly as before.
+  if (!epubFilePath_.empty() && !epubEntryPath_.empty() && !Storage.exists(imagePath.c_str()) &&
+      FsHelpers::hasPngExtension(imagePath) && decodePngInPlace(epubFilePath_, epubEntryPath_, renderer, config)) {
+    return;
+  }
+
+  // Ensure the image is extracted to SD (lazy extraction if not already present).
+  if (!ensureExtracted()) {
+    LOG_ERR("IMG", "Image unavailable: %s", imagePath.c_str());
+    return;
+  }
+
+  FsFile file;
+  if (!Storage.openFileForRead("IMG", imagePath, file)) {
+    LOG_ERR("IMG", "Image file not found after extraction: %s", imagePath.c_str());
+    return;
+  }
+  const size_t fileSize = file.size();
+  file.close();
+  if (fileSize == 0) {
+    LOG_ERR("IMG", "Image file is empty: %s", imagePath.c_str());
+    return;
+  }
+
+  LOG_TRC("IMG", "Decoding and caching: %s", imagePath.c_str());
 
   ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(imagePath);
   if (!decoder) {

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -11,9 +11,7 @@
 #include "../../Epub.h"
 #include "../converters/DirectPixelWriter.h"
 #include "../converters/ImageDecoderFactory.h"
-#include "../converters/JpegToFramebufferConverter.h"
 #include "../converters/PixelCache.h"
-#include "../converters/PngToFramebufferConverter.h"
 
 // Cache file format (see PixelCache::PXC_MAGIC):
 // - uint16_t magic/version (high bit always set, distinguishing it from the legacy
@@ -59,19 +57,6 @@ bool ImageBlock::ensureExtracted() const {
 
 bool ImageBlock::imageExists() const { return Storage.exists(imagePath.c_str()); }
 
-namespace image_tone {
-namespace {
-uint8_t g_filterId = 0;
-adaptive_tone::Mode g_mode = adaptive_tone::Mode::Stretch;
-}  // namespace
-void setFilter(const uint8_t filterId, const adaptive_tone::Mode mode) {
-  g_filterId = filterId;
-  g_mode = mode;
-}
-uint8_t getFilterId() { return g_filterId; }
-adaptive_tone::Mode getMode() { return g_mode; }
-}  // namespace image_tone
-
 namespace image_scratch {
 namespace {
 BuildArena* g_arena = nullptr;
@@ -106,35 +91,9 @@ std::string withSuffix(const std::string& imagePath, const std::string& suffix) 
 std::string getBwCachePath(const std::string& imagePath) { return withSuffix(imagePath, ".1bit.pxc"); }
 
 // Grayscale cache: 4-level Bayer (0–3), replayed in GRAYSCALE_LSB/MSB passes when AA is on.
-// Tone mapping IS baked into these pixels, so the filter id keys the name: switching the
-// setting must not replay pixels levelled for the old filter, and keying by name means
-// both variants survive a switch back (no invalidation hook needed). Filter 0 keeps the
-// historical unsuffixed name so existing caches stay valid.
-std::string getGrayscaleCachePath(const std::string& imagePath) {
-  const uint8_t filterId = image_tone::getFilterId();
-  const std::string toneSuffix = filterId == 0 ? std::string() : ".f" + std::to_string(filterId);
-  return withSuffix(imagePath, toneSuffix + ".bayer.pxc");
-}
-
-// Derive adaptive tone points for one image. Both analyzers return inactive points on
-// any failure (low heap, unsupported coding mode, read error), which makes the tone
-// curve an identity — a failed analysis degrades to the untoned image, never to no image.
-// GIF has no analyzer and stays untoned.
-adaptive_tone::Points analyzeImageTone(const std::string& imagePath) {
-  std::string ext;
-  const size_t dot = imagePath.rfind('.');
-  if (dot != std::string::npos) {
-    ext = imagePath.substr(dot);
-    for (auto& c : ext) c = tolower(c);
-  }
-  if (JpegToFramebufferConverter::supportsFormat(ext)) {
-    return JpegToFramebufferConverter::analyzeAdaptiveTone(imagePath, image_tone::getMode());
-  }
-  if (PngToFramebufferConverter::supportsFormat(ext)) {
-    return PngToFramebufferConverter::analyzeAdaptiveTone(imagePath, image_tone::getMode());
-  }
-  return {};
-}
+// Like the BW plane above, these pixels carry no tone correction, so one cache per image
+// serves every display setting — the name needs no key and never forks.
+std::string getGrayscaleCachePath(const std::string& imagePath) { return withSuffix(imagePath, ".bayer.pxc"); }
 
 // srcYOffset: first source row to render (0 = top of image).
 // srcHeight:  number of rows to render (0 = full image from srcYOffset).
@@ -414,14 +373,15 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y, const b
   config.useExactDimensions = true;
   config.cachePath = cachePath;
 
-  // Adaptive tone applies only to the 4-level grayscale variant. On the BW plane the
-  // output is just 0/3, so a level stretch mostly shifts where the Atkinson threshold
-  // falls rather than adding information — and it would desync the BW frame from the
-  // grey planes layered on top of it. Only reached on a cache miss, so the analysis
-  // decode is paid once per image and amortized by the .pxc.
-  if (!monochromeOutput && image_tone::getFilterId() != 0) {
-    config.adaptiveTone = analyzeImageTone(imagePath);
-  }
+  // Deliberately no adaptive tone on either variant: both .pxc files are dithered straight
+  // from the raw luminance. The curve has to be derived from a completed histogram, and a
+  // PNG cannot be rewound to build one -- it costs a second full inflate of every image, on
+  // the warm pass that already gates how fast a page with pictures opens. The correction is
+  // still offered on the sleep screen, which pays it once per wake rather than once per page
+  // and keys its single cache by the filter id.
+  //
+  // Leaving both variants untoned is also what keeps them interchangeable inputs: they now
+  // differ only in ditherer (1-bit Atkinson vs 4-level Bayer) over an identical grey stream.
 
   ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(imagePath);
   if (!decoder) {

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -114,7 +114,12 @@ bool decodePngInPlace(const std::string& epubFilePath, const std::string& epubEn
   Epub epub(epubFilePath, "/.crosspoint");
   uint32_t offset = 0;
   uint32_t size = 0;
-  if (!epub.getStoredItemRange(epubEntryPath, &offset, &size) || size == 0) return false;
+  if (!epub.getStoredItemRange(epubEntryPath, &offset, &size) || size == 0) {
+    // Logged because it decides seconds: a deflated entry has to be extracted first, and
+    // otherwise the shortcut's absence is invisible in a trace (the extract itself is TRC).
+    LOG_DBG("IMG", "Not stored in the archive, extracting first: %s", epubEntryPath.c_str());
+    return false;
+  }
 
   FsFile file;
   if (!Storage.openFileForRead("IMG", epubFilePath, file)) return false;

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -10,10 +10,25 @@
 
 class BuildArena;  // lib/Memory — optional decode scratch (see image_scratch below)
 
-// Source pixel area above which an image is considered "large" and rendered
-// as a placeholder until the user explicitly requests it.
-// 800x600 covers most full-page illustrations that take >1s to dither on ESP32.
-static constexpr int32_t LARGE_IMAGE_PIXEL_THRESHOLD = 800 * 600;
+// Source file size above which an image is considered "large" and rendered as a placeholder
+// until the user explicitly requests it.
+//
+// This used to be a PIXEL area (800*600), compared against ImageBlock's width/height — which are
+// the DISPLAY dimensions, not the source's. On a 480x800 panel the largest image that can be
+// drawn covers 384000 pixels, so the test could never be true and the placeholder never appeared,
+// whatever the setting said. Bytes also happen to be the better predictor: what costs seconds is
+// pulling the entry out of the ZIP and inflating it, and that scales with the file, not with the
+// area it ends up occupying on screen.
+//
+// 256 KB, from device measurements on X4: Men at Arms' 857182-byte cover PNG cost ~17 s to
+// extract plus ~5.8 s per decode pass, while the same book's 113588-byte and 155096-byte JPEGs
+// are unremarkable. The line wants to sit above the second group and well below the first.
+//
+// Note what this does NOT cover: a small file that inflates to an enormous bitmap (a flat-colour
+// 5000x5000 PNG) is cheap to read and slow to decode, and nothing here sees that. Source pixel
+// dimensions are known at parse time but are not carried on the block; if such a book turns up,
+// that is the axis to add rather than moving this number.
+static constexpr uint32_t LARGE_IMAGE_SOURCE_BYTES = 256 * 1024;
 
 // Tone mapping for inline images. Set once from src/ (which owns the settings) before a
 // render pass; lib/Epub must not read settings itself. Applies to every ImageBlock: the
@@ -98,8 +113,11 @@ class ImageBlock final : public Block {
 
   bool imageExists() const;
 
-  // Returns true if the source image dimensions exceed LARGE_IMAGE_PIXEL_THRESHOLD.
-  // Result is cached after the first call to avoid repeated header reads.
+  // Returns true if the source image's file size exceeds LARGE_IMAGE_SOURCE_BYTES. Answered from
+  // the extracted file when there is one, otherwise from the ZIP entry's uncompressed size (one
+  // central-directory scan). Result is cached after the first call: the lookup is only ever
+  // reached on a pixel-cache miss, i.e. immediately before a decode that costs orders of
+  // magnitude more, but a page can render several times.
   bool isLargeImage() const;
 
   // Returns true if this image would be shown as a placeholder given forceLoad.
@@ -136,6 +154,9 @@ class ImageBlock final : public Block {
   // Vertical crop window into the decoded image. srcYOffset_==0 && srcHeight_==0 means full image.
   int16_t srcYOffset_ = 0;
   int16_t srcHeight_ = 0;
+  // Cached isLargeImage() answer: -1 not yet resolved, 0 no, 1 yes. Mutable because the query is
+  // const and the answer cannot change for the life of the block.
+  mutable int8_t largeImageCached_ = -1;
   std::string epubFilePath_;   // source EPUB on SD (empty if already extracted)
   std::string epubEntryPath_;  // internal EPUB entry path (e.g. "OEBPS/images/foo.jpg")
 

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <AdaptiveTone.h>
 #include <HalStorage.h>
 #include <stdint.h>
 
@@ -30,22 +29,6 @@ class BuildArena;  // lib/Memory — optional decode scratch (see image_scratch 
 // that is the axis to add rather than moving this number.
 static constexpr uint32_t LARGE_IMAGE_SOURCE_BYTES = 256 * 1024;
 
-// Tone mapping for inline images. Set once from src/ (which owns the settings) before a
-// render pass; lib/Epub must not read settings itself. Applies to every ImageBlock: the
-// filter is a global display preference, not per-image state, and threading it through
-// every cache-query and warm signature would touch a dozen call sites to carry a constant.
-//
-// filterId keys the pixel caches, because tone mapping is baked into the cached pixels —
-// see the cache-path helpers in ImageBlock.cpp. 0 means "no filter" and keeps the
-// historical unsuffixed cache names.
-namespace image_tone {
-// filterId and mode are set together so they cannot drift apart: the id keys the cache,
-// the mode decides which curve those cached pixels were levelled with.
-void setFilter(uint8_t filterId, adaptive_tone::Mode mode);
-uint8_t getFilterId();
-adaptive_tone::Mode getMode();
-}  // namespace image_tone
-
 // Process-wide scratch arena for image decoding, installed for the duration of a multi-image
 // pass (see Section::warmAllImageCaches).
 //
@@ -58,7 +41,7 @@ adaptive_tone::Mode getMode();
 // A global rather than a parameter because the arena has to reach decoders several layers down
 // (Section -> Page -> ImageBlock -> converter -> PngStreamDecoder) through interfaces shared
 // with callers that have no arena. Decoders fall back to the heap when none is installed, so
-// this is an optimisation, never a requirement. Mirrors image_tone above.
+// this is an optimisation, never a requirement.
 namespace image_scratch {
 // The installed arena, or nullptr. Not owned.
 BuildArena* get();

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -125,7 +125,12 @@ class ImageBlock final : public Block {
 
   // monochromeOutput=true: 1-bit Atkinson dither → BW-plane rendering (AA off)
   // monochromeOutput=false: 4-level Bayer dither → also replayed in grayscale passes (AA on)
-  void render(GfxRenderer& renderer, int x, int y, bool forceLoad = true, bool monochromeOutput = true);
+  // alsoCacheOtherVariant: on a decode (cache miss), write the OTHER dither variant's .pxc in
+  // the same pass as well. Saves the second full inflate when the caller knows it needs both --
+  // see Page::warmImageCaches. Ignored when the render is served from cache or a placeholder,
+  // and best-effort: only the PNG decoder honours it, so callers must re-check.
+  void render(GfxRenderer& renderer, int x, int y, bool forceLoad = true, bool monochromeOutput = true,
+              bool alsoCacheOtherVariant = false);
   bool serialize(FsFile& file);
   static std::unique_ptr<ImageBlock> deserialize(FsFile& file);
 

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
@@ -74,6 +74,19 @@ struct RenderConfig {
   // sleep screen renders three passes that must all share one set of points.
   adaptive_tone::Points adaptiveTone;
   std::string cachePath;  // If non-empty, decoder will write pixel cache to this path
+  // If non-empty, the decoder ALSO writes the other dither variant of the same decode to this
+  // path -- 4-level Bayer when monochromeOutput is set, 1-bit Atkinson when it is not. Cache
+  // only: the companion is never drawn, so the framebuffer still shows exactly the variant
+  // `monochromeOutput` selects.
+  //
+  // This is what lets the reader's BW and grayscale .pxc pair come out of ONE inflate. It is
+  // only sound because neither variant is tone-mapped (see ImageBlock::render): a tone curve
+  // has to be derived from a completed histogram, which a PNG cannot produce without a second
+  // full pass, and the two sinks would then need different source samples.
+  //
+  // Honoured by PngToFramebufferConverter. Other decoders ignore it and write only cachePath;
+  // callers must treat the companion as best-effort and check before relying on it.
+  std::string companionCachePath;
 };
 
 class ImageToFramebufferDecoder {

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -77,12 +77,6 @@ struct JpegContext {
   PixelCache cache;
   bool caching{false};
 
-  // Adaptive-tone analysis pre-pass only (see analyzeAdaptiveTone): when histogram is
-  // non-null the decode writes no pixels and just tallies luminance. Never set on a
-  // real render.
-  uint32_t* histogram{nullptr};
-  uint64_t histogramSamples{0};
-
   // See PngContext for the rationale: monochromeOutput requests a 1-bit Atkinson dither
   // emitting only 0/3 so the BW DirectPixelWriter (`pixelValue < 3` rule) maps cleanly.
   int oneBitDitherRow{-1};
@@ -782,21 +776,6 @@ int tjpgOutput(JDEC* jd, void* bitmap, JRECT* rect) {
   return emitGrayBlock(*ctx, static_cast<const uint8_t*>(bitmap), rect->left, rect->top, validW, blockH, validW);
 }
 
-// TJpgDec output callback for the adaptive-tone pre-pass: tally luminance, write nothing.
-// Feeds the WDT like the real decode does — even at 1/8 scale a large image is many blocks.
-int tjpgHistogramOutput(JDEC* jd, void* bitmap, JRECT* rect) {
-  JpegContext* ctx = static_cast<TJpgSession*>(jd->device)->ctx;
-  if (!ctx || !ctx->histogram) return 0;
-  const int validW = rect->right - rect->left + 1;
-  const int blockH = rect->bottom - rect->top + 1;
-  const auto* px = static_cast<const uint8_t*>(bitmap);
-  const size_t count = static_cast<size_t>(validW) * static_cast<size_t>(blockH);
-  for (size_t i = 0; i < count; i++) ctx->histogram[px[i]]++;
-  ctx->histogramSamples += count;
-  esp_task_wdt_reset();
-  return 1;
-}
-
 bool progressiveOutput(void* user, uint16_t y, const uint8_t* grayscale, uint16_t width) {
   auto* ctx = static_cast<JpegContext*>(user);
   if (!ctx || width != ctx->dstWidth || y >= ctx->dstHeight) return false;
@@ -941,63 +920,6 @@ bool JpegToFramebufferConverter::getDimensionsStatic(const std::string& imagePat
   }
   LOG_TRC("JPG", "Image dimensions: %dx%d", out.width, out.height);
   return true;
-}
-
-adaptive_tone::Points JpegToFramebufferConverter::analyzeAdaptiveTone(const std::string& imagePath,
-                                                                      const adaptive_tone::Mode toneMode) {
-  adaptive_tone::Points points;  // inactive by default — identity tone curve
-
-  // Only baseline JPEGs go through TJpgDec. The progressive path reconstructs a DC-only
-  // preview whose sample distribution is not the real image, so analysing it would derive
-  // the wrong points; leave those untoned.
-  JpegMode mode = JpegMode::Baseline;
-  if (!getModeFromHeader(imagePath, mode) || mode != JpegMode::Baseline) {
-    return points;
-  }
-
-  const size_t freeHeap = ESP.getFreeHeap();
-  if (freeHeap < minFreeHeapForJpeg()) {
-    LOG_DBG("JPG", "Skipping adaptive tone analysis, low heap (%u free)", static_cast<unsigned>(freeHeap));
-    return points;
-  }
-
-  FsFile file;
-  if (!Storage.openFileForRead("JPG", imagePath, file)) {
-    return points;
-  }
-
-  JpegWorkPool pool;
-  auto histogram = makeUniqueNoThrow<uint32_t[]>(256);
-  if (!pool || !histogram) {
-    file.close();
-    return points;
-  }
-  for (int i = 0; i < 256; i++) histogram[i] = 0;
-
-  // The histogram only needs the tonal distribution, not resolution: decode at TJpgDec's
-  // coarsest DCT scale (1/8) so this pre-pass costs ~1/64 of the samples of a real decode.
-  // This is the shortcut PNG cannot take, which is why its analysis is a full extra decode.
-  JpegContext histCtx;
-  histCtx.histogram = histogram.get();
-  TJpgSession session{&file, &histCtx};
-  JDEC jdec{};
-  if (jd_prepare(&jdec, tjpgInput, pool.get(), TJPG_WORK_POOL_SIZE, &session) != JDR_OK) {
-    file.close();
-    return points;
-  }
-  const JRESULT jr = jd_decomp(&jdec, tjpgHistogramOutput, 3 /* 1/8 scale */);
-  file.close();
-  if (jr != JDR_OK) {
-    LOG_DBG("JPG", "Adaptive tone analysis decode failed (jr=%d): %s", jr, imagePath.c_str());
-    return points;
-  }
-
-  if (histCtx.histogramSamples == 0) return points;
-  points = adaptive_tone::derivePoints(histogram.get(), histCtx.histogramSamples, toneMode);
-  LOG_TRC("JPG", "Adaptive tone (%s): active=%d black=%u white=%u (%llu samples): %s",
-          toneMode == adaptive_tone::Mode::Equalize ? "equalize" : "stretch", points.active ? 1 : 0, points.blackPoint,
-          points.whitePoint, static_cast<unsigned long long>(histCtx.histogramSamples), imagePath.c_str());
-  return points;
 }
 
 bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath, GfxRenderer& renderer,

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.h
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.h
@@ -30,16 +30,6 @@ class JpegToFramebufferConverter final : public ImageToFramebufferDecoder {
   static bool getDimensionsFromZipEntryStreaming(const std::string& epubPath, const std::string& entryPath,
                                                  ImageDimensions& out, JpegMode* outMode = nullptr);
 
-  // Derive adaptive tone points by histogramming the image. Unlike the PNG equivalent this
-  // is cheap: the pre-pass runs at TJpgDec's 1/8 DCT scale, so it decodes ~1/64 of the
-  // samples of a full render. Returns inactive points on any failure (unsupported mode, low
-  // heap, read error), which makes the tone curve an identity — never a hard failure.
-  // Call once and reuse across render passes; the result must be shared so every pass
-  // quantizes against the same black/white points.
-  // `mode` selects the endpoint stretch or the CDF equalization; see AdaptiveTone.h.
-  static adaptive_tone::Points analyzeAdaptiveTone(const std::string& imagePath,
-                                                   adaptive_tone::Mode mode = adaptive_tone::Mode::Stretch);
-
   bool decodeToFramebuffer(const std::string& imagePath, GfxRenderer& renderer, const RenderConfig& config) override;
 
   bool getDimensions(const std::string& imagePath, ImageDimensions& dims) const override {

--- a/lib/Epub/Epub/converters/PixelCache.h
+++ b/lib/Epub/Epub/converters/PixelCache.h
@@ -37,11 +37,12 @@ struct PixelCache {
   int width;
   int height;
   int bytesPerRow;
-  int originX;      // config.x - to convert screen coords to cache coords
-  int originY;      // config.y + bandStart - band-local screen-to-cache mapping
-  int bandRows;     // rows held in the band buffer
-  int bandStart;    // image-local row index of band buffer row 0
-  int flushedRows;  // image-local rows already written to file
+  int originX;       // config.x - to convert screen coords to cache coords
+  int originY;       // config.y + bandStart - band-local screen-to-cache mapping
+  int bandRows;      // rows held in the band buffer
+  int bandStart;     // image-local row index of band buffer row 0
+  int flushedRows;   // image-local rows already written to file
+  int maxBlockRows;  // tallest single decode block, from begin() -- see advanceTo()
   FsFile file;
   std::string cachePathStr;
   bool ok;
@@ -65,6 +66,7 @@ struct PixelCache {
         bandRows(0),
         bandStart(0),
         flushedRows(0),
+        maxBlockRows(1),
         ok(false) {}
   PixelCache(const PixelCache&) = delete;
   PixelCache& operator=(const PixelCache&) = delete;
@@ -112,6 +114,7 @@ struct PixelCache {
       return false;
     }
     bandRows = wantRows;
+    maxBlockRows = maxBlockDstRows > 0 ? maxBlockDstRows : 1;
 
     const size_t bufSize = (size_t)(bandRows + 1) * bytesPerRow;  // +1 spare zero row
     buffer = static_cast<uint8_t*>(malloc(bufSize));
@@ -146,18 +149,22 @@ struct PixelCache {
     return true;
   }
 
-  // Flush every output row below newTopRow (they are final in raster order) and
-  // reposition the band to start at newTopRow. Returns false if a write failed,
-  // in which case the caller must stop caching for the rest of the decode.
-  bool advanceTo(int newTopRow) {
-    if (!ok) return false;
-    if (newTopRow <= bandStart) return true;
-    if (newTopRow > height) newTopRow = height;
+  // Write rows [bandStart, newTopRow) and rebase the band. The rows still held in the band are
+  // contiguous in `buffer`, so they go out as ONE write; only rows past the band's end (gaps
+  // left by a clipped or short decode) fall back to the pre-filled spare row.
+  bool flushThrough(int newTopRow) {
+    const int pending = newTopRow - flushedRows;
+    if (pending <= 0) return true;
+    const int inBand = pending < bandRows ? pending : bandRows;
 
-    for (int r = bandStart; r < newTopRow; ++r) {
-      const int idx = r - bandStart;
-      const uint8_t* rowPtr = (idx < bandRows) ? (buffer + (size_t)idx * bytesPerRow) : fillRow;
-      if (file.write(rowPtr, (size_t)bytesPerRow) != (size_t)bytesPerRow) {
+    const size_t runBytes = (size_t)inBand * bytesPerRow;
+    if (inBand > 0 && file.write(buffer, runBytes) != runBytes) {
+      LOG_ERR("IMG", "Cache write error at row %d", flushedRows);
+      ok = false;
+      return false;
+    }
+    for (int r = flushedRows + inBand; r < newTopRow; ++r) {
+      if (file.write(fillRow, (size_t)bytesPerRow) != (size_t)bytesPerRow) {
         LOG_ERR("IMG", "Cache write error at row %d", r);
         ok = false;
         return false;
@@ -169,6 +176,30 @@ struct PixelCache {
     return true;
   }
 
+  // Tell the cache that every output row below newTopRow is final. Returns false only if a
+  // write failed, in which case the caller must stop caching for the rest of the decode.
+  //
+  // Final does NOT mean written yet. The PNG decoder calls this once per destination row, and
+  // flushing on the spot meant one file.write() per row: a 464x618 cache went to disk as 618
+  // separate 116-byte writes, plus a full band memset each time. Device-measured on X4, that
+  // was ~2.3 s per cache -- roughly 40% of a decode, and the reason adding a second cache to
+  // the same pass cost 2274 ms when its dither and packing are nearly free. (Same shape as the
+  // 512-byte extract writes fixed in PR #220; small writes are simply very expensive here.)
+  //
+  // So rows accumulate in the band and go out in one call when the next block would no longer
+  // fit. Deferring is always safe -- final rows are immutable, the band is already sized to
+  // hold them, and finalize() writes whatever is still pending.
+  bool advanceTo(int newTopRow) {
+    if (!ok) return false;
+    if (newTopRow <= bandStart) return true;
+    if (newTopRow > height) newTopRow = height;
+    // Room for another whole block? Then nothing has to move yet. maxBlockRows is what makes
+    // this safe for a block-at-a-time decoder (JPEG MCU rows): the caller may write up to that
+    // many rows starting at newTopRow, and they must all still land inside the band.
+    if (newTopRow - bandStart + maxBlockRows <= bandRows) return true;
+    return flushThrough(newTopRow);
+  }
+
   // Flush the final band and fill any rows never covered (image clipped by the
   // screen, or a decode that produced fewer rows than the box), then close the file.
   bool finalize() {
@@ -176,14 +207,9 @@ struct PixelCache {
       abort();
       return false;
     }
-    for (int r = flushedRows; r < height; ++r) {
-      const int idx = r - bandStart;
-      const uint8_t* rowPtr = (idx >= 0 && idx < bandRows) ? (buffer + (size_t)idx * bytesPerRow) : fillRow;
-      if (file.write(rowPtr, (size_t)bytesPerRow) != (size_t)bytesPerRow) {
-        LOG_ERR("IMG", "Cache write error at row %d", r);
-        abort();
-        return false;
-      }
+    if (!flushThrough(height)) {
+      abort();
+      return false;
     }
     file.close();
     LOG_DBG("IMG", "Cache written: %s (%dx%d, %d bytes)", cachePathStr.c_str(), width, height,

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -43,10 +43,10 @@ struct DitherState {
 // Map one grayscale sample to a 2-bit value (0..3). Called for every destination
 // column — including off-screen ones — so error-diffusion state stays consistent
 // across the row; only the framebuffer/cache write is bounds-guarded by the caller.
+//
+// `gray` arrives already level-corrected: the caller applies the tone curve once so that a
+// companion sink (below) dithers the SAME sample rather than re-deriving it.
 uint8_t ditherGray(DitherState& d, uint8_t gray, int localX, int outX, int outY) {
-  // Level-correct before dithering, so the ditherer sees the stretched range.
-  // Identity when the caller supplied no points.
-  gray = adaptive_tone::apply(d.config->adaptiveTone, gray);
   if (d.atkinson1Bit) return d.atkinson1Bit->processPixel(gray, localX) ? 3 : 0;
 #ifdef ENABLE_IMAGE_DITHERING_EXTENSION
   if (d.config->useDithering) {
@@ -72,6 +72,36 @@ void advanceDitherRow(DitherState& d) {
   if (d.bayerDiff) d.bayerDiff->nextRow();
 #endif
 }
+
+// A second rendition of the same decode, written to its own .pxc and never drawn.
+//
+// The reader wants two caches per image — 1-bit Atkinson for the BW plane, 4-level Bayer for
+// the grayscale planes — and used to get them from two full decodes. They are the same 2 bpp
+// format over the same source samples and (since in-book adaptive tone was dropped) the same
+// tone, so they differ only in ditherer: one inflate can feed both. On the X4 cover that
+// measured 5.72 s of the 14.93 s an uncached image page cost.
+//
+// Deliberately limited to the two plain ditherers. The error-diffusion modes behind
+// ENABLE_IMAGE_DITHERING_EXTENSION stay primary-only: a companion is only ever asked for by
+// the reader's BW+grey pair, and the extension modes are alternatives to the grey rendition,
+// not a third variant anyone caches.
+struct CompanionSink {
+  // Non-null => 1-bit Atkinson; null => stateless ordered 4-level Bayer, which is why the
+  // common case (BW primary + grey companion) costs no extra ditherer state at all.
+  std::unique_ptr<Atkinson1BitDitherer> atkinson1Bit;
+  PixelCache cache;
+  DirectCacheWriter writer;
+  bool caching{false};
+  bool rowCaching{false};
+
+  uint8_t dither(uint8_t gray, int localX, int outX, int outY) {
+    if (atkinson1Bit) return atkinson1Bit->processPixel(gray, localX) ? 3 : 0;
+    return applyBayerDither4Level(gray, outX, outY);
+  }
+  void nextRow() {
+    if (atkinson1Bit) atkinson1Bit->nextRow();
+  }
+};
 
 // Below this free heap we don't even start: the uzlib ring (≤32 KB) plus scanline
 // buffers won't fit. begin() also fails gracefully if a specific malloc fails.
@@ -314,6 +344,22 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
     caching = false;
   }
 
+  // Optional second rendition off the same inflate (see CompanionSink). Its failures are
+  // independent of the primary's: losing the companion costs a later second decode, which is
+  // exactly the status quo, so it must never take the primary cache or the render down with it.
+  CompanionSink companion;
+  if (!config.companionCachePath.empty()) {
+    if (!config.monochromeOutput) {
+      companion.atkinson1Bit.reset(new (std::nothrow) Atkinson1BitDitherer(dstWidth));
+    }
+    companion.caching = companion.cache.begin(config.companionCachePath, dstWidth, dstHeight, config.x, config.y, 1);
+    if (!companion.caching) {
+      LOG_ERR("PNG", "Failed to start companion cache stream, continuing with one variant");
+    } else {
+      LOG_TRC("PNG", "Companion variant streaming to %s", config.companionCachePath.c_str());
+    }
+  }
+
   DirectPixelWriter pw;
   pw.init(renderer);
 
@@ -363,15 +409,35 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
       }
     }
 
+    companion.rowCaching = companion.caching;
+    if (companion.rowCaching) {
+      if (!companion.cache.advanceTo(dstY)) {
+        companion.caching = false;
+        companion.rowCaching = false;
+      } else {
+        companion.writer.init(companion.cache.buffer, companion.cache.bytesPerRow, companion.cache.originX,
+                              config.y + companion.cache.bandStart, companion.cache.width, companion.cache.bandRows);
+        companion.writer.beginRow(outY);
+      }
+    }
+
     // Bresenham-style horizontal scaling: advance srcX by srcWidth/dstWidth per dst column.
     int srcX = 0;
     int error = 0;
     for (int dstX = 0; dstX < dstWidth; dstX++) {
       const int outX = config.x + dstX;
-      const uint8_t value = ditherGray(dither, grayLine[srcX], dstX, outX, outY);
+      // Level-correct once, then hand the SAME sample to both ditherers: the two renditions must
+      // differ only in dither, never in the tone they were dithered from. Identity when the
+      // caller supplied no points (every reader image; only the sleep screen supplies any).
+      const uint8_t gray = adaptive_tone::apply(config.adaptiveTone, grayLine[srcX]);
+      const uint8_t value = ditherGray(dither, gray, dstX, outX, outY);
+      // Both ditherers see every destination column, on-screen or not, so their diffusion state
+      // stays in step across the row; only the writes below are bounds-guarded.
+      const uint8_t companionValue = companion.caching ? companion.dither(gray, dstX, outX, outY) : 0;
       if (outX >= 0 && outX < screenWidth) {
         pw.writePixel(outX, value);
         if (rowCaching) cw.writePixel(outX, value);
+        if (companion.rowCaching) companion.writer.writePixel(outX, companionValue);
       }
       error += srcWidth;
       while (error >= dstWidth) {
@@ -380,6 +446,7 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
       }
     }
     advanceDitherRow(dither);
+    if (companion.caching) companion.nextRow();
   }
 
   decoder->end();
@@ -392,8 +459,16 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
       cache.abort();
     }
   }
+  if (companion.caching) {
+    if (ok) {
+      companion.cache.finalize();
+    } else {
+      companion.cache.abort();
+    }
+  }
 
-  LOG_DBG("PNG", "PNG decoding complete - render time: %lu ms", millis() - decodeStart);
+  LOG_DBG("PNG", "PNG decoding complete - render time: %lu ms%s", millis() - decodeStart,
+          companion.caching ? " (both variants)" : "");
   return ok;
 }
 

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -256,7 +256,20 @@ adaptive_tone::Points PngToFramebufferConverter::analyzeAdaptiveTone(const std::
 
 bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath, GfxRenderer& renderer,
                                                     const RenderConfig& config) {
-  LOG_TRC("PNG", "Decoding PNG: %s", imagePath.c_str());
+  FsFile file;
+  if (!Storage.openFileForRead("PNG", imagePath, file)) {
+    LOG_ERR("PNG", "Failed to open PNG: %s", imagePath.c_str());
+    return false;
+  }
+  const bool ok = decodeOpenFile(file, imagePath, renderer, config);
+  file.close();
+  return ok;
+}
+
+bool PngToFramebufferConverter::decodeOpenFile(FsFile& file, const std::string& label, GfxRenderer& renderer,
+                                               const RenderConfig& config) {
+  LOG_TRC("PNG", "Decoding PNG: %s", label.c_str());
+  const std::string& imagePath = label;  // logging only; the stream is the caller's
 
   const size_t freeHeap = ESP.getFreeHeap();
   if (const size_t floor = pngDecodeHeapFloor(); freeHeap < floor) {
@@ -264,23 +277,15 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
     return false;
   }
 
-  FsFile file;
-  if (!Storage.openFileForRead("PNG", imagePath, file)) {
-    LOG_ERR("PNG", "Failed to open PNG: %s", imagePath.c_str());
-    return false;
-  }
-
   auto decoder = std::unique_ptr<PngStreamDecoder>(new (std::nothrow) PngStreamDecoder());
   if (!decoder) {
     LOG_ERR("PNG", "Failed to allocate PNG decoder");
-    file.close();
     return false;
   }
   decoder->setScratchArena(image_scratch::get());
   PngStreamDecoder::Info info;
   if (!decoder->begin(file, info)) {
     LOG_ERR("PNG", "Failed to start PNG decode: %s", imagePath.c_str());
-    file.close();
     return false;
   }
 
@@ -312,7 +317,6 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
   auto grayLine = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[srcWidth]);
   if (!grayLine) {
     LOG_ERR("PNG", "Failed to allocate gray line buffer");
-    file.close();
     return false;
   }
 
@@ -450,7 +454,6 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
   }
 
   decoder->end();
-  file.close();
 
   if (caching) {
     if (ok) {

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.h
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.h
@@ -10,6 +10,15 @@ class PngToFramebufferConverter final : public ImageToFramebufferDecoder {
 
   bool decodeToFramebuffer(const std::string& imagePath, GfxRenderer& renderer, const RenderConfig& config) override;
 
+  // Decode from an ALREADY-OPEN file whose read position is the PNG's first byte. The decoder
+  // only ever reads forward and seeks relatively, so the stream does not have to start at offset
+  // 0 of the file -- which is what lets a PNG stored uncompressed inside an EPUB be decoded in
+  // place, with no extraction to SD first (see Epub::getStoredItemRange).
+  //
+  // `label` names the source in logs only. The caller owns the file and must keep it open for
+  // the whole call; this never closes it.
+  static bool decodeOpenFile(FsFile& file, const std::string& label, GfxRenderer& renderer, const RenderConfig& config);
+
   // Builds a luminance histogram for adaptive tone mapping and returns the derived
   // black/white points, or an inactive result if the image does not need (or cannot
   // support) the correction.

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -63,16 +63,28 @@ constexpr size_t MAX_ANCHORS_PER_CHAPTER = 1024;
 #define EHP_TEXT_LAYOUT_HARD_MIN_MAX_ALLOC (6 * 1024)
 #endif
 
-// Reading an image header straight out of the ZIP (ImageDecoderFactory::getDimensionsFromZipEntry)
-// spins up a ~32 KB inflate ring. That is the ONLY allocation in image handling large enough to
-// threaten a parse, so it is the only thing gated on heap — see the image branch in startElement.
-// Sized ring + slack rather than reusing the text-layout floors, which are far too permissive for
-// a 32 KB request and were never chosen with one in mind.
+// Reading an image header straight out of the ZIP
+// (ImageDecoderFactory::getDimensionsFromZipEntry) — the only allocation in image handling big
+// enough to be worth gating, see the image branch in startElement.
+//
+// 40/34 KB -> 16/8 KB. The old numbers were sized for a ~32 KB inflate ring that this path no
+// longer takes: ZipFile::readBytesFromStat now sizes the ring to the bytes actually wanted
+// (see the comment there, and its own device measurement), which for a 4 KB header read is a
+// 4 KB ring. The gate was never retuned with it, so it went on demanding three times what the
+// operation costs.
+//
+// That was not merely conservative. A refusal drops the image to alt text, and the section is
+// then CACHED that way under an unchanged property hash — nothing ever rebuilds it. Background-B
+// builds with the framebuffer borrowed, which is exactly when the largest free block is small,
+// so on X4 the old gate refused at 50168 free / 30708 contig and baked a missing image into a
+// chapter permanently. What the read actually needs: a 4 KB header buffer, a 512 B read buffer,
+// a ring of up to 4 KB, and (unprimed) a 4 KB EOCD scan window — ~13 KB total, largest single
+// block 4 KB. 16/8 covers that with room to spare and is reachable from a borrowed-buffer build.
 #ifndef EHP_IMAGE_HEADER_MIN_FREE_HEAP
-#define EHP_IMAGE_HEADER_MIN_FREE_HEAP (40 * 1024)
+#define EHP_IMAGE_HEADER_MIN_FREE_HEAP (16 * 1024)
 #endif
 #ifndef EHP_IMAGE_HEADER_MIN_MAX_ALLOC
-#define EHP_IMAGE_HEADER_MIN_MAX_ALLOC (34 * 1024)
+#define EHP_IMAGE_HEADER_MIN_MAX_ALLOC (8 * 1024)
 #endif
 constexpr size_t MIN_FREE_HEAP_FOR_IMAGE_HEADER = EHP_IMAGE_HEADER_MIN_FREE_HEAP;
 constexpr size_t MIN_MAX_ALLOC_FOR_IMAGE_HEADER = EHP_IMAGE_HEADER_MIN_MAX_ALLOC;
@@ -1584,11 +1596,20 @@ void ChapterHtmlSlimParser::startElement(void* userData, const char* name, const
                 dimsOk = true;
               }
             }
-            if (!dimsOk && self->heapAllowsImageHeaderRead()) {
+            if (!dimsOk) {
               // Only reached when neither the tag nor the manifest could supply dimensions. On
               // refusal dimsOk stays false and the code below already falls through to
               // handleImageFallback(), so a tight heap degrades exactly this image and no other.
-              dimsOk = ImageDecoderFactory::getDimensionsFromZipEntry(self->epub->getPath(), resolvedPath, dims);
+              if (self->heapAllowsImageHeaderRead()) {
+                dimsOk = ImageDecoderFactory::getDimensionsFromZipEntry(self->epub->getPath(), resolvedPath, dims);
+              } else {
+                // Latched, because the two ways of arriving at alt text are not the same thing.
+                // An unreadable or unsupported image is alt text for good, and caching that is
+                // correct. A heap refusal is a statement about this moment only — the same image
+                // resolves fine from a build with more headroom — so the result must not be kept.
+                // Background callers discard on this; see Section::isImageHeaderDegraded().
+                self->imageHeaderSkippedForHeap = true;
+              }
             }
             if (dimsOk) {
               LOG_TRC("EHP", "Image dimensions: %dx%d", dims.width, dims.height);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -13,10 +13,29 @@
 #include <cctype>
 
 #include "../../Epub.h"
+#include "../HashUtils.h"
 #include "../Page.h"
 #include "../converters/ImageDecoderFactory.h"
 #include "../converters/ImageToFramebufferDecoder.h"
 #include "../htmlEntities.h"
+
+namespace {
+// Cache filename for an image extracted out of the EPUB, keyed by the archive entry it came from.
+//
+// The entry path is the only thing that identifies these bytes. It is deliberately NOT the parse
+// order: imageCounter used to serve that role, but buildCellImage() bails before incrementing it
+// when an image's dimensions cannot be resolved, and dimension resolution depends on images.bin
+// filling in over time -- so the same document could number its images differently between runs
+// and hand a block the file belonging to a different image. Hashing the entry cannot drift.
+std::string imageCachePathFor(const std::string& imageBasePath, const std::string& resolvedPath) {
+  std::string ext;
+  const size_t extPos = resolvedPath.rfind('.');
+  if (extPos != std::string::npos) ext = resolvedPath.substr(extPos);
+  char hash[17];
+  snprintf(hash, sizeof(hash), "%016llx", static_cast<unsigned long long>(HashUtils::fnvHash64(resolvedPath)));
+  return imageBasePath + hash + ext;
+}
+}  // namespace
 
 const char* HEADER_TAGS[] = {"h1", "h2", "h3", "h4", "h5", "h6"};
 constexpr int NUM_HEADER_TAGS = sizeof(HEADER_TAGS) / sizeof(HEADER_TAGS[0]);
@@ -1569,10 +1588,7 @@ void ChapterHtmlSlimParser::startElement(void* userData, const char* name, const
 
           if (ImageDecoderFactory::isFormatSupported(resolvedPath)) {
             // Determine SD cache path (image will be extracted here lazily at first render).
-            std::string ext;
-            size_t extPos = resolvedPath.rfind('.');
-            if (extPos != std::string::npos) ext = resolvedPath.substr(extPos);
-            std::string cachedImagePath = self->imageBasePath + std::to_string(self->imageCounter++) + ext;
+            const std::string cachedImagePath = imageCachePathFor(self->imageBasePath, resolvedPath);
 
             // Get dimensions, cheapest ring-free source first:
             //  1. explicit width/height on the tag (an SVG cover / sized <img>) — no ZIP read at all;
@@ -3465,10 +3481,7 @@ std::shared_ptr<ImageBlock> ChapterHtmlSlimParser::buildCellImage(const std::str
   const int displayWidth = std::max(1, static_cast<int>(dims.width * scale));
   const int displayHeight = std::max(1, static_cast<int>(dims.height * scale));
 
-  std::string ext;
-  const size_t extPos = resolvedPath.rfind('.');
-  if (extPos != std::string::npos) ext = resolvedPath.substr(extPos);
-  const std::string cachedPath = imageBasePath + std::to_string(imageCounter++) + ext;
+  const std::string cachedPath = imageCachePathFor(imageBasePath, resolvedPath);
 
   return std::make_shared<ImageBlock>(cachedPath, static_cast<int16_t>(displayWidth),
                                       static_cast<int16_t>(displayHeight), alt, epub->getPath(), resolvedPath);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -165,7 +165,6 @@ class ChapterHtmlSlimParser final : public Print {
   uint8_t imageRendering;
   std::string contentBase;
   std::string imageBasePath;
-  int imageCounter = 0;
 
   // Style tracking (replaces depth-based approach)
   struct StyleStackEntry {
@@ -459,7 +458,7 @@ class ChapterHtmlSlimParser final : public Print {
   void streamClosedCell(BufferedTableRow& row);
   // Resolve an image src to a sized ImageBlock (lazy-extracted from the EPUB), scaled to fit
   // maxWidth/maxHeight. Returns nullptr when the image is unsupported or its dimensions
-  // cannot be resolved. Advances imageCounter to allocate a unique cache path.
+  // cannot be resolved. The cache path is derived from the archive entry, not from parse order.
   std::shared_ptr<ImageBlock> buildCellImage(const std::string& src, const std::string& alt, uint16_t maxWidth,
                                              uint16_t maxHeight);
   // Place an already-built ImageBlock as a centered, full-width block element, page-breaking if needed.

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -371,6 +371,8 @@ class ChapterHtmlSlimParser final : public Print {
   int progressStepPercent = 0;
   bool progressUiEnabled = true;
   bool streamFailed = false;
+  // Set when the heap gate refused an image-header read (see imageHeaderDegraded()).
+  bool imageHeaderSkippedForHeap = false;
   uint32_t streamStartTimeMs = 0;
 
   // Footnote link tracking
@@ -529,6 +531,11 @@ class ChapterHtmlSlimParser final : public Print {
   bool setup(size_t totalInflatedSize);
   bool finalize();
   [[nodiscard]] bool streamSucceeded() const { return !streamFailed; }
+  // True when at least one image was dropped to alt text because the heap gate refused its
+  // header read — a transient condition, unlike an unreadable or unsupported image. The pages
+  // are usable but incomplete, and the caller must not keep them: see the latch site in
+  // startElement's image branch.
+  [[nodiscard]] bool imageHeaderDegraded() const { return imageHeaderSkippedForHeap; }
   void setInlineFootnotePreviews(FootnotePreviews::Lookup* lookup) { inlineFootnotePreviews = lookup; }
 
   // Print interface — fed by Epub::readItemContentsToStream.

--- a/lib/GfxRenderer/BufferedPrint.h
+++ b/lib/GfxRenderer/BufferedPrint.h
@@ -46,7 +46,7 @@ class BufferedPrint final : public Print {
       return out_.write(data, n);
     }
     if (fill_ + n > cap_ && !flushBuffer()) return 0;
-    memcpy(buf_.get() + fill_, data, n);
+    memcpy(bufferBase() + fill_, data, n);
     fill_ += n;
     return n;
   }
@@ -60,7 +60,7 @@ class BufferedPrint final : public Print {
     if (fill_ == 0) return true;
     const size_t n = fill_;
     fill_ = 0;  // cleared first: a failing sink must not make every later flush retry the same bytes
-    return out_.write(buf_.get(), n) == n;
+    return out_.write(bufferBase(), n) == n;
   }
 
   // Drop whatever is pending without writing it. For the error paths that close and delete the
@@ -68,6 +68,12 @@ class BufferedPrint final : public Print {
   void discard() { fill_ = 0; }
 
  private:
+  // Explicitly typed, rather than calling buf_.get() at the use sites: cppcheck does not resolve
+  // std::unique_ptr<uint8_t[]>::get() and reads arithmetic on it as void* pointer maths
+  // (arithOperationsOnVoidPointer). Same accessor pattern, for the same reason, as
+  // BufferedFileWriter::bufferBase() in Serialization/BufferedFileIO.h.
+  uint8_t* bufferBase() const { return buf_.get(); }
+
   Print& out_;
   std::unique_ptr<uint8_t[]> buf_;
   size_t cap_ = 0;

--- a/lib/GfxRenderer/BufferedPrint.h
+++ b/lib/GfxRenderer/BufferedPrint.h
@@ -63,6 +63,10 @@ class BufferedPrint final : public Print {
     return out_.write(buf_.get(), n) == n;
   }
 
+  // Drop whatever is pending without writing it. For the error paths that close and delete the
+  // output file: without this the destructor would flush into a closed handle.
+  void discard() { fill_ = 0; }
+
  private:
   Print& out_;
   std::unique_ptr<uint8_t[]> buf_;

--- a/lib/GfxRenderer/BufferedPrint.h
+++ b/lib/GfxRenderer/BufferedPrint.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <Print.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <new>
+
+// Batches small writes before they reach the underlying Print.
+//
+// Every BMP writer here emits one file write per output row, and a row is small: a 1-bit
+// 340x540 cover thumbnail is 44 bytes a row, so it reached the card as 540 separate writes.
+// That is expensive twice over on this stack -- a bare FsFile call costs ~1.5 ms whatever its
+// size (see BufferedFileIO.h, where exactly this arithmetic cost a 1732-spine first-open index
+// ~28 s), and a sub-sector write is worse still because the driver has to read the sector back
+// before it can modify it. Measured on X4 through PixelCache, a 116-byte row write ran ~3.7 ms,
+// which put a pair of cover thumbnails at ~3.4 s of pure call overhead.
+//
+// Wrapping the sink is the whole fix: the converters go on writing a row at a time and the rows
+// coalesce here into 4 KB transfers. Nothing about the bytes changes, only how many calls carry
+// them.
+class BufferedPrint final : public Print {
+ public:
+  static constexpr size_t DEFAULT_BUFFER_BYTES = 4096;
+
+  explicit BufferedPrint(Print& out, const size_t bufferBytes = DEFAULT_BUFFER_BYTES) : out_(out) {
+    // nothrow: a failed allocation degrades to pass-through, which is exactly the old
+    // behaviour, so a tight heap costs speed and never correctness.
+    buf_.reset(new (std::nothrow) uint8_t[bufferBytes]);
+    cap_ = buf_ ? bufferBytes : 0;
+  }
+  ~BufferedPrint() override { flushBuffer(); }
+  BufferedPrint(const BufferedPrint&) = delete;
+  BufferedPrint& operator=(const BufferedPrint&) = delete;
+
+  size_t write(const uint8_t b) override { return write(&b, 1); }
+
+  size_t write(const uint8_t* data, const size_t n) override {
+    if (cap_ == 0) return out_.write(data, n);
+    // A payload that cannot fit is not worth splitting: drain first so ordering holds, then
+    // hand it straight to the sink -- it is already a large write, the kind this exists to make.
+    if (n >= cap_) {
+      if (!flushBuffer()) return 0;
+      return out_.write(data, n);
+    }
+    if (fill_ + n > cap_ && !flushBuffer()) return 0;
+    memcpy(buf_.get() + fill_, data, n);
+    fill_ += n;
+    return n;
+  }
+
+  // Named flushBuffer(), not flush(): Print already declares a `virtual void flush()`, and
+  // silently overriding it with a different return type is a compile error on device and a
+  // trap everywhere else. Callers should call this explicitly and fold the result into their
+  // own success, so a write that fails at the very end is not reported as a complete file;
+  // the destructor call is a best-effort backstop for paths that bail out early.
+  bool flushBuffer() {
+    if (fill_ == 0) return true;
+    const size_t n = fill_;
+    fill_ = 0;  // cleared first: a failing sink must not make every later flush retry the same bytes
+    return out_.write(buf_.get(), n) == n;
+  }
+
+ private:
+  Print& out_;
+  std::unique_ptr<uint8_t[]> buf_;
+  size_t cap_ = 0;
+  size_t fill_ = 0;
+};

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -15,6 +15,7 @@
 #include <new>
 
 #include "BitmapHelpers.h"
+#include "BufferedPrint.h"
 
 // ============================================================================
 // IMAGE PROCESSING OPTIONS - Toggle these to test different configurations
@@ -296,8 +297,10 @@ static bool progressiveBmpOutput(void* user, uint16_t y, const uint8_t* grayscal
   return !ctx->error;
 }
 
-static bool decodeProgressiveJpeg(FsFile& jpegFile, Print& bmpOut, int targetWidth, int targetHeight, bool oneBit,
+static bool decodeProgressiveJpeg(FsFile& jpegFile, Print& sink, int targetWidth, int targetHeight, bool oneBit,
                                   bool crop, const ProgressiveJpegDc::ImageInfo& image, bool eightBit) {
+  // One row per write is one file call per row (see BufferedPrint); coalesce them.
+  BufferedPrint bmpOut(sink);
   constexpr int MAX_IMAGE_WIDTH = 2048;
   constexpr int MAX_IMAGE_HEIGHT = 3072;
   if (image.width == 0 || image.height == 0 || image.width > MAX_IMAGE_WIDTH || image.height > MAX_IMAGE_HEIGHT) {
@@ -379,6 +382,12 @@ static bool decodeProgressiveJpeg(FsFile& jpegFile, Print& bmpOut, int targetWid
     LOG_ERR("JPG", "Progressive JPEG preview failed: %s", ProgressiveJpegDc::resultName(result));
     return false;
   }
+  // Fold the final flush into the result: a write that fails here would otherwise be reported
+  // as a complete BMP, and the caller would cache a truncated file.
+  if (!bmpOut.flushBuffer()) {
+    LOG_ERR("JPG", "Failed to flush buffered BMP output");
+    return false;
+  }
   LOG_DBG("JPG", "Progressive JPEG preview decoded: %ux%u -> %dx%d", image.width, image.height, outWidth, outHeight);
   return true;
 }
@@ -386,8 +395,10 @@ static bool decodeProgressiveJpeg(FsFile& jpegFile, Print& bmpOut, int targetWid
 }  // namespace
 
 // Internal implementation with configurable target size and bit depth
-bool JpegToBmpConverter::jpegFileToBmpStreamInternal(FsFile& jpegFile, Print& bmpOut, int targetWidth, int targetHeight,
+bool JpegToBmpConverter::jpegFileToBmpStreamInternal(FsFile& jpegFile, Print& sink, int targetWidth, int targetHeight,
                                                      bool oneBit, bool crop, bool eightBit) {
+  // One row per write is one file call per row (see BufferedPrint); coalesce them.
+  BufferedPrint bmpOut(sink);
   LOG_DBG("JPG", "Converting JPEG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : (eightBit ? "8-bit" : "2-bit"),
           targetWidth, targetHeight);
 
@@ -611,6 +622,10 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(FsFile& jpegFile, Print& bm
     return false;
   }
 
+  if (!bmpOut.flushBuffer()) {
+    LOG_ERR("JPG", "Failed to flush buffered BMP output");
+    return false;
+  }
   LOG_DBG("JPG", "Successfully converted JPEG to BMP");
   return true;
 }

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -13,6 +13,7 @@
 #include <new>
 
 #include "BitmapHelpers.h"
+#include "BufferedPrint.h"
 
 // ============================================================================
 // IMAGE PROCESSING OPTIONS - Same as JpegToBmpConverter for consistency
@@ -22,8 +23,10 @@ constexpr bool USE_FLOYD_STEINBERG = false;
 constexpr bool USE_PRESCALE = true;
 // ============================================================================
 
-bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
+bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& sink, int targetWidth, int targetHeight,
                                                    bool oneBit, bool crop, bool enforceSizeCap, bool eightBit) {
+  // One row per write is one file call per row (see BufferedPrint); coalesce them.
+  BufferedPrint bmpOut(sink);
   LOG_DBG("PNG", "Converting PNG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : (eightBit ? "8-bit" : "2-bit"),
           targetWidth, targetHeight);
 
@@ -300,6 +303,10 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOu
     }
   }
 
+  if (success && !bmpOut.flushBuffer()) {
+    LOG_ERR("PNG", "Failed to flush buffered BMP output");
+    success = false;
+  }
   if (success) {
     LOG_DBG("PNG", "Successfully converted PNG to BMP");
   }
@@ -311,7 +318,11 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOu
 // ============================================================================
 
 bool PngDecodeSession::begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, int targetHeight, bool crop) {
-  bmpOut_ = &bmpFile;
+  bmpOut_ = makeUniqueNoThrow<BufferedPrint>(bmpFile);
+  if (!bmpOut_) {
+    LOG_ERR("PNG", "Session begin: output buffer alloc failed");
+    return false;
+  }
 
   PngStreamDecoder::Info info;
   if (!decoder_.begin(pngFile, info)) {
@@ -364,7 +375,7 @@ bool PngDecodeSession::begin(FsFile& pngFile, FsFile& bmpFile, int targetWidth, 
   }
 
   // 1-bit BMP header
-  bytesPerRow_ = writeGrayscaleBmpHeader(bmpFile, finalW_, finalH_, 1);
+  bytesPerRow_ = writeGrayscaleBmpHeader(*bmpOut_, finalW_, finalH_, 1);
 
   // Allocate buffers
   grayRow_ = static_cast<uint8_t*>(malloc(width_));
@@ -476,6 +487,11 @@ PngDecodeSession::Status PngDecodeSession::continueRows(uint32_t maxSourceRows) 
     LOG_ERR("PNG", "Session: incomplete — %d/%d output rows written", currentOutY_, outHeight_);
     return Status::Error;
   }
+  // Last chance to surface a write failure: after this the caller treats the file as complete.
+  if (!bmpOut_->flushBuffer()) {
+    LOG_ERR("PNG", "Session: failed to flush buffered BMP output");
+    return Status::Error;
+  }
   LOG_DBG("PNG", "Session: decode complete (%ux%u -> %dx%d)", width_, height_, outWidth_, outHeight_);
   return Status::Done;
 }
@@ -491,6 +507,7 @@ void PngDecodeSession::cleanup() {
   rowCount_ = nullptr;
   delete ditherer_;
   ditherer_ = nullptr;
+  bmpOut_.reset();  // flushes whatever a bailed-out session had pending, then drops the buffer
   decoder_.end();
 }
 

--- a/lib/PngToBmpConverter/PngToBmpConverter.h
+++ b/lib/PngToBmpConverter/PngToBmpConverter.h
@@ -4,8 +4,10 @@
 #include <PngStreamDecoder.h>
 
 #include <cstdint>
+#include <memory>
 
 #include "BitmapHelpers.h"
+#include "BufferedPrint.h"
 
 class Print;
 
@@ -81,8 +83,9 @@ class PngDecodeSession {
   uint16_t* rowCount_ = nullptr;
   Atkinson1BitDitherer* ditherer_ = nullptr;
 
-  // Output sink (borrowed — caller keeps the FsFile alive)
-  Print* bmpOut_ = nullptr;
+  // Output sink (borrowed — caller keeps the FsFile alive), wrapped so the per-row writes
+  // coalesce (see BufferedPrint). Owned because the session spans many loop() ticks.
+  std::unique_ptr<BufferedPrint> bmpOut_;
 };
 
 class PngToBmpConverter {

--- a/lib/Serialization/BufferedFileIO.h
+++ b/lib/Serialization/BufferedFileIO.h
@@ -121,6 +121,15 @@ class BufferedFileWriter {
     base_ = static_cast<uint32_t>(file_.position());
   }
 
+  // Caller-supplied buffer, NOT owned — for paths that already hold scratch worth reusing (the
+  // image extract carves it out of the borrowed framebuffer arena rather than asking a heap that
+  // is, at that exact moment, about to be handed to a decoder). A null buffer degrades to
+  // pass-through exactly as a failed allocation does. The buffer must outlive this writer.
+  BufferedFileWriter(FsFile& file, uint8_t* const buffer, const size_t bufferBytes)
+      : file_(file), external_(buffer), cap_(buffer ? bufferBytes : 0) {
+    base_ = static_cast<uint32_t>(file_.position());
+  }
+
   // Callers are expected to flush() at the end of a write phase (and check its result);
   // the destructor flush is a best-effort backstop only.
   ~BufferedFileWriter() { flush(); }
@@ -139,8 +148,7 @@ class BufferedFileWriter {
       return wrote == n;
     }
     if (fill_ + n > cap_ && !flush()) return false;
-    uint8_t* const base = buf_.get();
-    memcpy(base + fill_, in, n);
+    memcpy(bufferBase() + fill_, in, n);
     fill_ += n;
     return true;
   }
@@ -157,7 +165,7 @@ class BufferedFileWriter {
 
   bool flush() {
     if (fill_ == 0) return true;
-    const size_t wrote = file_.write(buf_.get(), fill_);
+    const size_t wrote = file_.write(bufferBase(), fill_);
     base_ += static_cast<uint32_t>(wrote);
     const bool ok = wrote == fill_;
     fill_ = 0;
@@ -165,8 +173,12 @@ class BufferedFileWriter {
   }
 
  private:
+  // Owned or borrowed, never both: the owning constructor leaves external_ null and vice versa.
+  uint8_t* bufferBase() const { return external_ ? external_ : buf_.get(); }
+
   FsFile& file_;
   std::unique_ptr<uint8_t[]> buf_;
+  uint8_t* external_ = nullptr;
   size_t cap_ = 0;
   size_t fill_ = 0;
   uint32_t base_ = 0;  // file offset the buffer starts at

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -8,6 +8,7 @@
 #include "Xtc.h"
 
 #include <Bitmap.h>
+#include <BufferedPrint.h>
 #include <HalStorage.h>
 #include <Logging.h>
 
@@ -317,6 +318,9 @@ bool Xtc::generateCoverBmp() const {
     LOG_DBG("XTC", "Failed to create cover BMP file");
     return false;
   }
+  // The rows below are small (a 1-bit 480px row is 60 bytes) and the header goes out in 2- and
+  // 4-byte fields, so unbuffered this was well over a thousand file calls. See BufferedPrint.
+  BufferedPrint out(coverBmp);
 
   const uint8_t padding[4] = {0, 0, 0, 0};
 
@@ -342,16 +346,16 @@ bool Xtc::generateCoverBmp() const {
 
     auto writeLE16 = [&](uint16_t v) {
       const uint8_t b[2] = {static_cast<uint8_t>(v), static_cast<uint8_t>(v >> 8)};
-      coverBmp.write(b, 2);
+      out.write(b, 2);
     };
     auto writeLE32 = [&](uint32_t v) {
       const uint8_t b[4] = {static_cast<uint8_t>(v), static_cast<uint8_t>(v >> 8), static_cast<uint8_t>(v >> 16),
                             static_cast<uint8_t>(v >> 24)};
-      coverBmp.write(b, 4);
+      out.write(b, 4);
     };
 
     // BITMAPFILEHEADER
-    coverBmp.write(reinterpret_cast<const uint8_t*>("BM"), 2);
+    out.write(reinterpret_cast<const uint8_t*>("BM"), 2);
     writeLE32(offBits + imageSize);  // bfSize
     writeLE16(0);                    // bfReserved1
     writeLE16(0);                    // bfReserved2
@@ -371,12 +375,13 @@ bool Xtc::generateCoverBmp() const {
     // Palette: black, dark gray, light gray, white (BGRA)
     const uint8_t palette[16] = {0x00, 0x00, 0x00, 0x00, 0x55, 0x55, 0x55, 0x00,
                                  0xAA, 0xAA, 0xAA, 0x00, 0xFF, 0xFF, 0xFF, 0x00};
-    coverBmp.write(palette, sizeof(palette));
+    out.write(palette, sizeof(palette));
 
     // Stream the column-major page through a row-major transpose (small RAM band +
     // temp file) instead of holding the whole page in heap.
     XthRowTranspose xth(mutParser, 0, pageInfo.width, pageInfo.height, cachePath + "/cover.t2bit");
     if (!xth.ok) {
+      out.discard();  // the file is about to be deleted; do not flush into it
       coverBmp.close();
       Storage.remove(getCoverBmpPath().c_str());
       return false;
@@ -388,6 +393,7 @@ bool Xtc::generateCoverBmp() const {
       LOG_ERR("XTC", "OOM cover row buffers (%d + %u bytes)", xth.packedRowBytes, (unsigned)dstRowSize);
       free(packedRow);
       free(rowBuffer);
+      out.discard();  // the file is about to be deleted; do not flush into it
       coverBmp.close();
       Storage.remove(getCoverBmpPath().c_str());
       return false;
@@ -404,12 +410,13 @@ bool Xtc::generateCoverBmp() const {
         const uint8_t bmpVal = kXthToBmp[packedPixel(packedRow, x)];
         rowBuffer[(x * 2) / 8] |= static_cast<uint8_t>(bmpVal << (6 - ((x * 2) % 8)));
       }
-      coverBmp.write(rowBuffer, dstRowSize);
-      if (paddingSize > 0) coverBmp.write(padding, paddingSize);
+      out.write(rowBuffer, dstRowSize);
+      if (paddingSize > 0) out.write(padding, paddingSize);
     }
     free(packedRow);
     free(rowBuffer);
     if (failed) {
+      out.discard();  // the file is about to be deleted; do not flush into it
       coverBmp.close();
       Storage.remove(getCoverBmpPath().c_str());
       return false;
@@ -418,7 +425,7 @@ bool Xtc::generateCoverBmp() const {
     // 1-bit source: write a 1-bit BMP header and stream source rows straight to it.
     BmpHeader bmpHeader;
     createBmpHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
-    coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
+    out.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
 
     const uint32_t rowSize = ((pageInfo.width + 31) / 32) * 4;
     const size_t srcRowSize = (pageInfo.width + 7) / 8;  // packed 1-bit source/dest row
@@ -427,6 +434,7 @@ bool Xtc::generateCoverBmp() const {
     uint8_t* rowBuffer = static_cast<uint8_t*>(malloc(srcRowSize));  // freed before every return below
     if (!rowBuffer) {
       LOG_ERR("XTC", "OOM cover row buffer (%u bytes)", (unsigned)srcRowSize);
+      out.discard();  // the file is about to be deleted; do not flush into it
       coverBmp.close();
       Storage.remove(getCoverBmpPath().c_str());
       return false;
@@ -438,18 +446,27 @@ bool Xtc::generateCoverBmp() const {
         failed = true;
         break;
       }
-      coverBmp.write(rowBuffer, srcRowSize);
-      if (paddingSize > 0) coverBmp.write(padding, paddingSize);
+      out.write(rowBuffer, srcRowSize);
+      if (paddingSize > 0) out.write(padding, paddingSize);
     }
     mutParser->endPageRange();
     free(rowBuffer);
     if (failed) {
+      out.discard();  // the file is about to be deleted; do not flush into it
       coverBmp.close();
       Storage.remove(getCoverBmpPath().c_str());
       return false;
     }
   }
 
+  // Flush before the close, so the destructor never writes into a closed handle -- and so a
+  // write that fails at the very end is not reported as a complete cover.
+  if (!out.flushBuffer()) {
+    LOG_ERR("XTC", "Failed to flush buffered cover BMP");
+    coverBmp.close();
+    Storage.remove(getCoverBmpPath().c_str());
+    return false;
+  }
   coverBmp.close();
   LOG_DBG("XTC", "Generated cover BMP: %s", getCoverBmpPath().c_str());
   return true;

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -171,6 +171,23 @@ bool ZipFile::loadFileStatSlim(const char* filename, FileStatSlim* fileStat) {
   return found;
 }
 
+bool ZipFile::getStoredEntryRange(const char* filename, uint32_t* offset, uint32_t* size) {
+  if (!offset || !size) return false;
+  const ScopedOpenClose zip{*this};
+  if (!zip) return false;
+
+  FileStatSlim fileStat = {};
+  if (!loadFileStatSlim(filename, &fileStat)) return false;
+  if (fileStat.method != ZIP_METHOD_STORED) return false;
+
+  const long dataOffset = getDataOffset(fileStat);
+  if (dataOffset < 0) return false;
+
+  *offset = static_cast<uint32_t>(dataOffset);
+  *size = fileStat.uncompressedSize;  // identical to compressedSize for a stored entry
+  return true;
+}
+
 long ZipFile::getDataOffset(const FileStatSlim& fileStat) {
   const ScopedOpenClose zip{*this};
   if (!zip) return -1;

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -76,6 +76,14 @@ class ZipFile {
   bool open();
   bool close();
   bool getInflatedFileSize(const char* filename, size_t* size);
+
+  // Absolute byte offset and length of an entry's data within the archive, and true, ONLY when
+  // that entry is STORED (method 0). A caller can then read the entry straight out of the .zip
+  // with no decompression and no temporary copy.
+  //
+  // False for a deflated entry -- there is no such range: those bytes are a DEFLATE stream, not
+  // the file. Also false if the entry is missing or its local header does not check out.
+  bool getStoredEntryRange(const char* filename, uint32_t* offset, uint32_t* size);
   // Batch lookup: scan ZIP central dir once and fill sizes for matching targets.
   // targets must be sorted by (hash, len). sizes[target.index] receives uncompressedSize.
   // Returns number of targets matched. Deques, not vectors: a 1700-spine book needs ~28 KB of

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -722,6 +722,8 @@ void HomeActivity::onEnter() {
 }
 
 void HomeActivity::onExit() {
+  // The cover-loading burst is over; release the one book's metadata the memo still holds.
+  Epub::clearCoverMetadataMemo();
   Activity::onExit();
   statsLoad_.reset();
   freeCoverBuffer();

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -235,6 +235,8 @@ void RecentBooksActivity::onEnter() {
 }
 
 void RecentBooksActivity::onExit() {
+  // The cover-loading burst is over; release the one book's metadata the memo still holds.
+  Epub::clearCoverMetadataMemo();
   Activity::onExit();
   recentBooks.clear();
   bookProgress.clear();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1519,15 +1519,20 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
       backgroundBuildPercent_ = -1;
       if (step == Section::BuildStep::Done) {
         if (backgroundSection_->isTruncatedCache() || backgroundSection_->isCssLowHeapDegraded() ||
-            backgroundSection_->isFootnotePreviewsUnresolved()) {
+            backgroundSection_->isFootnotePreviewsUnresolved() || backgroundSection_->isImageHeaderDegraded()) {
           // Memory ran short mid-parse: pages are missing (truncated), CSS lookups were skipped
-          // (styles silently absent from the cached pages), or the footnote resolve could not
-          // complete (markers left plain in a cache keyed "previews on"). Don't hand any of them
-          // to the foreground: its blocking path runs with the secondary buffer released (~52 KB
-          // more headroom) and will likely build it clean.
-          const char* reason = backgroundSection_->isTruncatedCache()       ? "truncated"
-                               : backgroundSection_->isCssLowHeapDegraded() ? "css-degraded"
-                                                                            : "footnotes unresolved";
+          // (styles silently absent from the cached pages), the footnote resolve could not
+          // complete (markers left plain in a cache keyed "previews on"), or an image was dropped
+          // to alt text because its header read was refused. Don't hand any of them to the
+          // foreground: its blocking path runs with the secondary buffer released (~52 KB more
+          // headroom) and will likely build it clean.
+          //
+          // B is the caller most exposed to the last two: it builds with the framebuffer
+          // borrowed, which is exactly when the largest free block is small.
+          const char* reason = backgroundSection_->isTruncatedCache()               ? "truncated"
+                               : backgroundSection_->isCssLowHeapDegraded()         ? "css-degraded"
+                               : backgroundSection_->isFootnotePreviewsUnresolved() ? "footnotes unresolved"
+                                                                                    : "image degraded";
           LOG_INF("ERS", "Background build spine=%d %s; discarding for foreground rebuild", targetSpine, reason);
           backgroundSection_->clearCache();
           backgroundSection_.reset();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -493,7 +493,7 @@ void EpubReaderActivity::onEnter() {
   // non-incremental entry in buildSection). Also clear any stale post-popup HALF left armed if the
   // previous reader session was abandoned mid-build.
   coldOpenHalfRefreshArmed_ = true;
-  forceCleanRefreshAfterPopup_ = false;
+  forceHalfRefreshAfterPopup_ = false;
   // Start the refresh cadence at the configured frequency so the first page uses a fast
   // differential. RED RAM is valid: the previous activity's last displayBuffer() called
   // syncRedRamFromFrameBuffer(). If the previous activity set a HALF_REFRESH override via
@@ -2283,7 +2283,7 @@ void EpubReaderActivity::applyBookReaderOverrides(
   // arrived via the full-screen selector, the extra menu/submenu/selector redraws leave the FAST
   // baseline out of sync and the popup box ghosts. Arm a one-shot HALF so drawPopup() establishes a
   // clean baseline — the same deliberate-transition signal the chapter/percent/footnote jumps use
-  // (hasRefreshOverridePending() at the popup then also arms forceCleanRefreshAfterPopup_ for the
+  // (hasRefreshOverridePending() at the popup then also arms forceHalfRefreshAfterPopup_ for the
   // first content page). Reached only when something actually changed (early-out above), so routine
   // no-op reopens of the menu don't pay for it.
   ReaderUtils::enforceExitFullRefresh(renderer);
@@ -2711,7 +2711,7 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   // so it doesn't reintroduce the "every section traversal pays a slow refresh" cost. X3's fast
   // differential reads the controller's DTM1 (drawPopup updated it correctly), so it never ghosts.
   if (!renderer.isX3() && buildingPopupShown_) {
-    forceCleanRefreshAfterPopup_ = true;
+    forceHalfRefreshAfterPopup_ = true;
   }
 
   auto logPageTurnWindowIfReady = [this]() {
@@ -3487,7 +3487,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
       //     to a FAST diff against the popup frame and ghost its outline.
       const bool dramaticTransition = coldOpenHalfRefreshArmed_ || renderer.hasRefreshOverridePending();
       coldOpenHalfRefreshArmed_ = false;
-      // X4: the dramatic-transition HALF belongs on the first CONTENT page (forceCleanRefreshAfterPopup_
+      // X4: the dramatic-transition HALF belongs on the first CONTENT page (forceHalfRefreshAfterPopup_
       // below), not the popup. The popup is a transient box over the already-correct current page, so a
       // FAST overlay is clean and instant — drop the pending HALF override here so drawPopup() doesn't
       // spend a second ~1.7s HALF on the popup itself. On X3 the popup's own refresh IS the baseline
@@ -3569,7 +3569,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
       // there is pure unnecessary cost. A routine forward-reading crossing into a still-building
       // Background-B section is NOT dramatic (neither signal is set), so it keeps the fast cadence.
       if (!renderer.isX3() && dramaticTransition) {
-        forceCleanRefreshAfterPopup_ = true;
+        forceHalfRefreshAfterPopup_ = true;
       }
       renderer.clearFontAccumulation();
       readerPhase_ = ReaderPhase::PRECOMPILING;
@@ -4293,32 +4293,25 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   // trigger blocks through the waveform exactly as before.
   HalDisplay::RefreshMode pageRefreshMode;
   if (secondaryBufferDegraded_) {
-    // FULL_REFRESH already gives a clean baseline, same goal as forceCleanRefreshAfterPopup_;
+    // FULL_REFRESH already gives a clean baseline, same goal as forceHalfRefreshAfterPopup_;
     // consume it here too so it doesn't carry over and force an unrelated later page to HALF.
-    forceCleanRefreshAfterPopup_ = false;
+    forceHalfRefreshAfterPopup_ = false;
     pageRefreshMode = HalDisplay::FULL_REFRESH;
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
   } else if (forceRefreshModeNextRender_ >= 0) {
     // Manual force-refresh button: apply the requested mode for this one render. A manual refresh
     // gives its own clean baseline, so consume any armed post-popup HALF too rather than letting it
     // carry over and force an unrelated later page to HALF.
-    forceCleanRefreshAfterPopup_ = false;
+    forceHalfRefreshAfterPopup_ = false;
     pageRefreshMode = static_cast<HalDisplay::RefreshMode>(forceRefreshModeNextRender_);
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
     forceRefreshModeNextRender_ = -1;
-  } else if (forceCleanRefreshAfterPopup_) {
+  } else if (forceHalfRefreshAfterPopup_) {
     // First real page after the indexing popup, shown directly here because the build finished
     // in a single slice (e.g. a one-page cover) and never went through displayBuildPage(). See
-    // forceCleanRefreshAfterPopup_.
-    //
-    // FAST, not HALF: the HALF that used to sit here was the single largest cost of opening a
-    // cover. Device-measured on X4 (Men at Arms, spine 0), the page's own work was ~100 ms
-    // (prewarm 43 + bw 31 + display 26) against a 1691 ms HALF waveform — 94% of a 1997 ms
-    // "render". The trade is deliberate: a FAST diff across the popup -> content transition can
-    // leave a ghost outline of the popup box until the next full-refresh cycle. Reverting is
-    // this constant and the twin in displayBuildPage().
-    forceCleanRefreshAfterPopup_ = false;
-    pageRefreshMode = HalDisplay::FAST_REFRESH;
+    // forceHalfRefreshAfterPopup_.
+    forceHalfRefreshAfterPopup_ = false;
+    pageRefreshMode = HalDisplay::HALF_REFRESH;
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
   } else if (forceHalfRefreshThisPage) {
     pageRefreshMode = HalDisplay::HALF_REFRESH;
@@ -4504,14 +4497,11 @@ void EpubReaderActivity::displayBuildPage(RenderLock& lock, const Page& page, co
   page.render(renderer, getEffectiveReaderFontId(), layout.marginLeft, contentTop, /*forceLoadLargeImages=*/false,
               /*monochromeOutput=*/true);
   renderStatusBar();
-  if (forceCleanRefreshAfterPopup_) {
-    // First real page after the indexing popup. FAST rather than HALF for the reason given at
-    // the twin site in renderContents(): the HALF waveform dominated the wall-clock cost of
-    // landing this page, and a popup-box ghost until the next full refresh is the accepted
-    // trade. Both sites must move together or the multi-slice and single-slice builds would
-    // disagree on how the same transition looks.
-    forceCleanRefreshAfterPopup_ = false;
-    renderer.triggerDisplay(HalDisplay::FAST_REFRESH);
+  if (forceHalfRefreshAfterPopup_) {
+    // First real page after the indexing popup: establish a clean baseline (see
+    // forceHalfRefreshAfterPopup_) instead of compounding onto the popup's FAST refresh.
+    forceHalfRefreshAfterPopup_ = false;
+    renderer.triggerDisplay(HalDisplay::HALF_REFRESH);
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
   } else {
     ReaderUtils::triggerWithRefreshCycle(renderer, pagesUntilFullRefresh);
@@ -5211,7 +5201,7 @@ void EpubReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION 
       // Deliberate chapter jump: arm a HALF refresh for the next displayed screen, exactly like the
       // other deliberate jumps (percent / TOC / footnote / reader exit). The indexing popup consumes
       // this override so hasRefreshOverridePending() reads true there, which arms
-      // forceCleanRefreshAfterPopup_; the first page of the target chapter then paints HALF instead of
+      // forceHalfRefreshAfterPopup_; the first page of the target chapter then paints HALF instead of
       // a FAST differential. Without it, the dramatic previous-chapter -> new-chapter transition
       // under-drives on X4 and the previous chapter's text ghosts through the new page.
       ReaderUtils::enforceExitFullRefresh(renderer);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3474,11 +3474,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
             cacheHit ? 1 : 0, cssFallbackRebuild ? 1 : 0, resumeBackgroundBuild ? 1 : 0);
 
     if (incremental) {
-      // Draw the popup BEFORE any secondary-buffer release. drawPopup() overlays the box on the
-      // on-screen frame via syncWriteBufferFromDisplayed(), which copies from frameBufferActive —
-      // once the secondary buffer is released that copy is gone (the call no-ops) and the box would
-      // be composited onto the stale two-refreshes-ago write buffer, ghosting the previous page
-      // under the popup. Capture the "dramatic transition" signal first, because the popup's own
+      // Capture the "dramatic transition" signal before anything can display, because a popup's
       // refresh would otherwise consume the pending exit-full-refresh override:
       //   - cold open of this book (coldOpenHalfRefreshArmed_), or
       //   - a pending exit-full-refresh override left by a deliberate jump (chapter/percent/footnote)
@@ -3487,16 +3483,34 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
       //     to a FAST diff against the popup frame and ghost its outline.
       const bool dramaticTransition = coldOpenHalfRefreshArmed_ || renderer.hasRefreshOverridePending();
       coldOpenHalfRefreshArmed_ = false;
-      // X4: the dramatic-transition HALF belongs on the first CONTENT page (forceHalfRefreshAfterPopup_
-      // below), not the popup. The popup is a transient box over the already-correct current page, so a
-      // FAST overlay is clean and instant — drop the pending HALF override here so drawPopup() doesn't
-      // spend a second ~1.7s HALF on the popup itself. On X3 the popup's own refresh IS the baseline
-      // step (its displayBuffer updates DTM1, which the following FAST content page diffs against), so
-      // leave the override for drawPopup() to consume there.
-      if (!renderer.isX3() && dramaticTransition) {
-        renderer.clearRefreshOverride();  // discard the armed HALF -> popup paints FAST
+
+      // Whether the popup has to be painted before the build starts, or can wait until the first
+      // slice proves the build is actually long enough to need one.
+      //
+      // A RELEASED build has no choice: drawPopup() composites via syncWriteBufferFromDisplayed(),
+      // which reads frameBufferActive, and the release below takes that copy away — and the
+      // released path then seeds RED RAM *from the popup frame* so its mid-build FAST refreshes
+      // have a baseline to diff against. Both depend on the popup already being on screen.
+      //
+      // A RESIDENT build keeps the buffer, so neither applies and the popup can be deferred. That
+      // matters because the kickoff slice below frequently finishes the whole section: a one-page
+      // cover measured 309 ms start-to-finish on X4, and every millisecond of the popup it painted
+      // first (a ~540 ms FAST refresh) was spent on a frame the very next render replaced. Worse,
+      // the popup is what makes the replacing page expensive — it is a dark box the content page
+      // must then diff against, which is the entire reason for the ~1.7 s HALF armed below.
+      const bool popupBeforeBuild = (mode == SectionBuildMode::IncrementalReleased);
+      if (popupBeforeBuild) {
+        // X4: the dramatic-transition HALF belongs on the first CONTENT page
+        // (forceHalfRefreshAfterPopup_ below), not the popup. The popup is a transient box over the
+        // already-correct current page, so a FAST overlay is clean and instant — drop the pending
+        // HALF override here so drawPopup() doesn't spend a second ~1.7s HALF on the popup itself.
+        // On X3 the popup's own refresh IS the baseline step (its displayBuffer updates DTM1, which
+        // the following FAST content page diffs against), so leave the override for drawPopup().
+        if (!renderer.isX3() && dramaticTransition) {
+          renderer.clearRefreshOverride();  // discard the armed HALF -> popup paints FAST
+        }
+        GUI.drawPopup(renderer, tr(STR_INDEXING));  // immediate feedback before the first page lands
       }
-      GUI.drawPopup(renderer, tr(STR_INDEXING));  // immediate feedback before the first page lands
 
       if (mode == SectionBuildMode::IncrementalReleased) {
         // Tight heap: free the secondary buffer (~48–52 KB) for the build. AA is off until the
@@ -3568,7 +3582,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
       // call already updated correctly — no host-side baseline gap to paper over, so forcing HALF
       // there is pure unnecessary cost. A routine forward-reading crossing into a still-building
       // Background-B section is NOT dramatic (neither signal is set), so it keeps the fast cadence.
-      if (!renderer.isX3() && dramaticTransition) {
+      if (!renderer.isX3() && dramaticTransition && popupBeforeBuild) {
         forceHalfRefreshAfterPopup_ = true;
       }
       renderer.clearFontAccumulation();
@@ -3578,7 +3592,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
       // build completes and the position is resolved, so the exact value doesn't matter there.
       section->currentPage = (navTarget.kind == NavigationTarget::Kind::Page) ? navTarget.page : 0;
       buildDisplayedPage_ = -1;
-      buildingPopupShown_ = true;
+      buildingPopupShown_ = popupBeforeBuild;
       // Kick the build off so hasActiveBuild() is true (a resumed B build already is). One slice
       // may already finish a tiny section, in which case we fall through to a normal render.
       Section::BuildStep step = Section::BuildStep::More;
@@ -3586,9 +3600,21 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
         step = section->stepSectionBuild(makeSectionBuildParams(), BG_BUILD_BUDGET_MS);
       }
       if (step == Section::BuildStep::More) {
+        // The deferred case, now resolved: the build needs more slices, so a popup IS warranted.
+        // renderSectionBuildingPass() paints it on the next pass (its `if (!buildingPopupShown_)`
+        // branch), which is also where the reader would otherwise sit with no feedback. Arm the
+        // same transition handling the up-front path arms, so a popup drawn late is followed by
+        // the same clean content refresh as one drawn early.
+        if (!popupBeforeBuild && !renderer.isX3() && dramaticTransition) {
+          renderer.clearRefreshOverride();
+          forceHalfRefreshAfterPopup_ = true;
+        }
         requestUpdate();  // SectionBuilding pass + stepCurrentSectionBuild() take over
         return false;
       }
+      // Fell through: the kickoff finished the section. On the deferred path no popup was ever
+      // painted, so there is no box for the content page to ghost against and no armed HALF --
+      // the page lands on the normal refresh cadence.
       readerPhase_ = ReaderPhase::READING;
       if (step == Section::BuildStep::Failed) {
         LOG_ERR("ERS", "Background-C kickoff failed for spine %d; using blocking path", currentSpineIndex);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -493,7 +493,7 @@ void EpubReaderActivity::onEnter() {
   // non-incremental entry in buildSection). Also clear any stale post-popup HALF left armed if the
   // previous reader session was abandoned mid-build.
   coldOpenHalfRefreshArmed_ = true;
-  forceHalfRefreshAfterPopup_ = false;
+  forceCleanRefreshAfterPopup_ = false;
   // Start the refresh cadence at the configured frequency so the first page uses a fast
   // differential. RED RAM is valid: the previous activity's last displayBuffer() called
   // syncRedRamFromFrameBuffer(). If the previous activity set a HALF_REFRESH override via
@@ -2283,7 +2283,7 @@ void EpubReaderActivity::applyBookReaderOverrides(
   // arrived via the full-screen selector, the extra menu/submenu/selector redraws leave the FAST
   // baseline out of sync and the popup box ghosts. Arm a one-shot HALF so drawPopup() establishes a
   // clean baseline — the same deliberate-transition signal the chapter/percent/footnote jumps use
-  // (hasRefreshOverridePending() at the popup then also arms forceHalfRefreshAfterPopup_ for the
+  // (hasRefreshOverridePending() at the popup then also arms forceCleanRefreshAfterPopup_ for the
   // first content page). Reached only when something actually changed (early-out above), so routine
   // no-op reopens of the menu don't pay for it.
   ReaderUtils::enforceExitFullRefresh(renderer);
@@ -2711,7 +2711,7 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   // so it doesn't reintroduce the "every section traversal pays a slow refresh" cost. X3's fast
   // differential reads the controller's DTM1 (drawPopup updated it correctly), so it never ghosts.
   if (!renderer.isX3() && buildingPopupShown_) {
-    forceHalfRefreshAfterPopup_ = true;
+    forceCleanRefreshAfterPopup_ = true;
   }
 
   auto logPageTurnWindowIfReady = [this]() {
@@ -3487,7 +3487,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
       //     to a FAST diff against the popup frame and ghost its outline.
       const bool dramaticTransition = coldOpenHalfRefreshArmed_ || renderer.hasRefreshOverridePending();
       coldOpenHalfRefreshArmed_ = false;
-      // X4: the dramatic-transition HALF belongs on the first CONTENT page (forceHalfRefreshAfterPopup_
+      // X4: the dramatic-transition HALF belongs on the first CONTENT page (forceCleanRefreshAfterPopup_
       // below), not the popup. The popup is a transient box over the already-correct current page, so a
       // FAST overlay is clean and instant — drop the pending HALF override here so drawPopup() doesn't
       // spend a second ~1.7s HALF on the popup itself. On X3 the popup's own refresh IS the baseline
@@ -3569,7 +3569,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
       // there is pure unnecessary cost. A routine forward-reading crossing into a still-building
       // Background-B section is NOT dramatic (neither signal is set), so it keeps the fast cadence.
       if (!renderer.isX3() && dramaticTransition) {
-        forceHalfRefreshAfterPopup_ = true;
+        forceCleanRefreshAfterPopup_ = true;
       }
       renderer.clearFontAccumulation();
       readerPhase_ = ReaderPhase::PRECOMPILING;
@@ -4293,25 +4293,32 @@ void EpubReaderActivity::renderContents(RenderLock& lock, std::unique_ptr<Page> 
   // trigger blocks through the waveform exactly as before.
   HalDisplay::RefreshMode pageRefreshMode;
   if (secondaryBufferDegraded_) {
-    // FULL_REFRESH already gives a clean baseline, same goal as forceHalfRefreshAfterPopup_;
+    // FULL_REFRESH already gives a clean baseline, same goal as forceCleanRefreshAfterPopup_;
     // consume it here too so it doesn't carry over and force an unrelated later page to HALF.
-    forceHalfRefreshAfterPopup_ = false;
+    forceCleanRefreshAfterPopup_ = false;
     pageRefreshMode = HalDisplay::FULL_REFRESH;
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
   } else if (forceRefreshModeNextRender_ >= 0) {
     // Manual force-refresh button: apply the requested mode for this one render. A manual refresh
     // gives its own clean baseline, so consume any armed post-popup HALF too rather than letting it
     // carry over and force an unrelated later page to HALF.
-    forceHalfRefreshAfterPopup_ = false;
+    forceCleanRefreshAfterPopup_ = false;
     pageRefreshMode = static_cast<HalDisplay::RefreshMode>(forceRefreshModeNextRender_);
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
     forceRefreshModeNextRender_ = -1;
-  } else if (forceHalfRefreshAfterPopup_) {
+  } else if (forceCleanRefreshAfterPopup_) {
     // First real page after the indexing popup, shown directly here because the build finished
     // in a single slice (e.g. a one-page cover) and never went through displayBuildPage(). See
-    // forceHalfRefreshAfterPopup_.
-    forceHalfRefreshAfterPopup_ = false;
-    pageRefreshMode = HalDisplay::HALF_REFRESH;
+    // forceCleanRefreshAfterPopup_.
+    //
+    // FAST, not HALF: the HALF that used to sit here was the single largest cost of opening a
+    // cover. Device-measured on X4 (Men at Arms, spine 0), the page's own work was ~100 ms
+    // (prewarm 43 + bw 31 + display 26) against a 1691 ms HALF waveform — 94% of a 1997 ms
+    // "render". The trade is deliberate: a FAST diff across the popup -> content transition can
+    // leave a ghost outline of the popup box until the next full-refresh cycle. Reverting is
+    // this constant and the twin in displayBuildPage().
+    forceCleanRefreshAfterPopup_ = false;
+    pageRefreshMode = HalDisplay::FAST_REFRESH;
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
   } else if (forceHalfRefreshThisPage) {
     pageRefreshMode = HalDisplay::HALF_REFRESH;
@@ -4497,11 +4504,14 @@ void EpubReaderActivity::displayBuildPage(RenderLock& lock, const Page& page, co
   page.render(renderer, getEffectiveReaderFontId(), layout.marginLeft, contentTop, /*forceLoadLargeImages=*/false,
               /*monochromeOutput=*/true);
   renderStatusBar();
-  if (forceHalfRefreshAfterPopup_) {
-    // First real page after the indexing popup: establish a clean baseline (see
-    // forceHalfRefreshAfterPopup_) instead of compounding onto the popup's FAST refresh.
-    forceHalfRefreshAfterPopup_ = false;
-    renderer.triggerDisplay(HalDisplay::HALF_REFRESH);
+  if (forceCleanRefreshAfterPopup_) {
+    // First real page after the indexing popup. FAST rather than HALF for the reason given at
+    // the twin site in renderContents(): the HALF waveform dominated the wall-clock cost of
+    // landing this page, and a popup-box ghost until the next full refresh is the accepted
+    // trade. Both sites must move together or the multi-slice and single-slice builds would
+    // disagree on how the same transition looks.
+    forceCleanRefreshAfterPopup_ = false;
+    renderer.triggerDisplay(HalDisplay::FAST_REFRESH);
     pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
   } else {
     ReaderUtils::triggerWithRefreshCycle(renderer, pagesUntilFullRefresh);
@@ -5201,7 +5211,7 @@ void EpubReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION 
       // Deliberate chapter jump: arm a HALF refresh for the next displayed screen, exactly like the
       // other deliberate jumps (percent / TOC / footnote / reader exit). The indexing popup consumes
       // this override so hasRefreshOverridePending() reads true there, which arms
-      // forceHalfRefreshAfterPopup_; the first page of the target chapter then paints HALF instead of
+      // forceCleanRefreshAfterPopup_; the first page of the target chapter then paints HALF instead of
       // a FAST differential. Without it, the dramatic previous-chapter -> new-chapter transition
       // under-drives on X4 and the previous chapter's text ghosts through the new page.
       ReaderUtils::enforceExitFullRefresh(renderer);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -500,28 +500,6 @@ void EpubReaderActivity::onEnter() {
   // enforceExitFullRefresh(), consumeRefreshOverride() will honour it on the first display call.
   pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
 
-  // Publish the image tone filter for lib/Epub, which must not read settings itself.
-  // Set here rather than per-render so every path that derives a pixel-cache name agrees
-  // (renderContents, the section-index warm pass, the pre-reboot warm). Reuses the sleep
-  // screen's filter setting rather than adding a second one: it is the same tone curve,
-  // and a separate inline-image toggle is display surface the reader does not need.
-  //
-  // Only the two tone-curve values carry over. The others are sleep-screen compositing
-  // modes (Contrast picks the BW plane, Inverted flips the whole screen) with no meaning
-  // for an image sitting inside a page of text.
-  switch (SETTINGS.sleepScreenCoverFilter) {
-    case CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::ADAPTIVE_TONE:
-      image_tone::setFilter(CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::ADAPTIVE_TONE, adaptive_tone::Mode::Stretch);
-      break;
-    case CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::EQUALIZE_TONE:
-      image_tone::setFilter(CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::EQUALIZE_TONE,
-                            adaptive_tone::Mode::Equalize);
-      break;
-    default:
-      image_tone::setFilter(0, adaptive_tone::Mode::Stretch);
-      break;
-  }
-
   // Drop any input events that arrived from the activity that launched us (e.g. a wake-up power
   // button hold) before they reach the page-turn handling — see ReaderUtils::InputDrainGuard.
   inputDrainGuard.arm();

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -251,7 +251,7 @@ class EpubReaderActivity final : public Activity {
   // stepBackgroundSectionBuild() and stepCurrentSectionBuild() before they start any
   // heap-hungry work.
   bool imageProcessingActive_ = false;
-  // Arms forceHalfRefreshAfterPopup_ for the NEXT incremental section build, marking that build's
+  // Arms forceCleanRefreshAfterPopup_ for the NEXT incremental section build, marking that build's
   // popup -> content transition as "dramatic" and worth a clean HALF baseline (vs. the routine,
   // frequent forward-reading crossing into a still-building Background-B section, where forcing
   // HALF made every section traversal pay a slow refresh). Two dramatic cases set it:
@@ -265,12 +265,17 @@ class EpubReaderActivity final : public Activity {
   //     too, so the override paints the popup and the flag paints the content — both clean.
   bool coldOpenHalfRefreshArmed_ = true;
   // True after the "Indexing..." popup is drawn for a build flagged as a dramatic transition (see
-  // coldOpenHalfRefreshArmed_), until the first real page replaces it on screen. That first page is
-  // forced to HALF_REFRESH instead of the normal FAST cadence, establishing a clean baseline for the
-  // popup -> content transition. Consumed by whichever path shows the first real page:
-  // displayBuildPage() for a multi-slice build, or renderContents() directly when the build finishes
-  // in a single slice (e.g. a one-page cover) and never goes through displayBuildPage at all.
-  bool forceHalfRefreshAfterPopup_ = false;
+  // coldOpenHalfRefreshArmed_), until the first real page replaces it on screen. Consumed by
+  // whichever path shows that page: displayBuildPage() for a multi-slice build, or renderContents()
+  // directly when the build finishes in a single slice (e.g. a one-page cover) and never goes
+  // through displayBuildPage at all.
+  //
+  // That page used to be forced to HALF_REFRESH for a clean popup -> content baseline. It is now
+  // FAST: the HALF was measured at 1691 ms against ~100 ms of actual page work, i.e. 94% of the
+  // time to open a cover, and it fired on every cold open whether or not the page had images. The
+  // cost of the trade is a possible ghost outline of the popup box until the next full refresh.
+  // Both consumption sites carry the same note and must change together.
+  bool forceCleanRefreshAfterPopup_ = false;
   // When true, large images on the current page are decoded instead of shown as placeholders.
   // Reset to false on every page turn so the next image page starts with a placeholder again.
   bool forceLoadLargeImages = false;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -251,7 +251,7 @@ class EpubReaderActivity final : public Activity {
   // stepBackgroundSectionBuild() and stepCurrentSectionBuild() before they start any
   // heap-hungry work.
   bool imageProcessingActive_ = false;
-  // Arms forceCleanRefreshAfterPopup_ for the NEXT incremental section build, marking that build's
+  // Arms forceHalfRefreshAfterPopup_ for the NEXT incremental section build, marking that build's
   // popup -> content transition as "dramatic" and worth a clean HALF baseline (vs. the routine,
   // frequent forward-reading crossing into a still-building Background-B section, where forcing
   // HALF made every section traversal pay a slow refresh). Two dramatic cases set it:
@@ -265,17 +265,12 @@ class EpubReaderActivity final : public Activity {
   //     too, so the override paints the popup and the flag paints the content — both clean.
   bool coldOpenHalfRefreshArmed_ = true;
   // True after the "Indexing..." popup is drawn for a build flagged as a dramatic transition (see
-  // coldOpenHalfRefreshArmed_), until the first real page replaces it on screen. Consumed by
-  // whichever path shows that page: displayBuildPage() for a multi-slice build, or renderContents()
-  // directly when the build finishes in a single slice (e.g. a one-page cover) and never goes
-  // through displayBuildPage at all.
-  //
-  // That page used to be forced to HALF_REFRESH for a clean popup -> content baseline. It is now
-  // FAST: the HALF was measured at 1691 ms against ~100 ms of actual page work, i.e. 94% of the
-  // time to open a cover, and it fired on every cold open whether or not the page had images. The
-  // cost of the trade is a possible ghost outline of the popup box until the next full refresh.
-  // Both consumption sites carry the same note and must change together.
-  bool forceCleanRefreshAfterPopup_ = false;
+  // coldOpenHalfRefreshArmed_), until the first real page replaces it on screen. That first page is
+  // forced to HALF_REFRESH instead of the normal FAST cadence, establishing a clean baseline for the
+  // popup -> content transition. Consumed by whichever path shows the first real page:
+  // displayBuildPage() for a multi-slice build, or renderContents() directly when the build finishes
+  // in a single slice (e.g. a one-page cover) and never goes through displayBuildPage at all.
+  bool forceHalfRefreshAfterPopup_ = false;
   // When true, large images on the current page are decoded instead of shown as placeholders.
   // Reset to false on every page turn so the next image page starts with a placeholder again.
   bool forceLoadLargeImages = false;

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -77,18 +77,36 @@ ReaderActivity::CoverExtractSession::Status ReaderActivity::CoverExtractSession:
   if (!reader_ || !reader_->isOpen()) return Status::Error;
 
   if (!buf_ || chunkBytes_ != chunkBytes) {
+    // Halve the request rather than abandon the cover. Device-observed on X4: a 16 KB chunk
+    // failed with ~74 KB free — plenty of heap, just not that much of it contiguous after a
+    // carousel's worth of cover work — and the book silently lost its thumbnail for the whole
+    // session. A smaller chunk only costs more inflate steps, which are sliced across ticks
+    // anyway, so degrading beats failing. 1 KB is still 400+ SD writes for a 450 KB cover, which
+    // is slow but finishes; below that the extract is not worth starting.
+    constexpr size_t MIN_CHUNK_BYTES = 1024;
     free(buf_);
-    buf_ = static_cast<uint8_t*>(malloc(chunkBytes));
+    buf_ = nullptr;
+    size_t want = chunkBytes;
+    while (!buf_ && want >= MIN_CHUNK_BYTES) {
+      buf_ = static_cast<uint8_t*>(malloc(want));
+      if (!buf_) want /= 2;
+    }
     if (!buf_) {
-      LOG_ERR("CEX", "OOM allocating %zu byte chunk buffer", chunkBytes);
+      LOG_ERR("CEX", "OOM allocating chunk buffer (wanted %zu, gave up below %zu)", chunkBytes, MIN_CHUNK_BYTES);
+      chunkBytes_ = 0;
       return Status::Error;
     }
-    chunkBytes_ = chunkBytes;
+    if (want != chunkBytes) {
+      LOG_DBG("CEX", "Chunk buffer degraded %zu -> %zu bytes (heap too fragmented for the full size)", chunkBytes,
+              want);
+    }
+    chunkBytes_ = want;
   }
 
   size_t produced = 0;
   bool done = false;
-  if (!reader_->step(buf_, chunkBytes, &produced, &done)) {
+  // chunkBytes_ , not chunkBytes: the allocation above may have degraded to a smaller buffer.
+  if (!reader_->step(buf_, chunkBytes_, &produced, &done)) {
     LOG_ERR("CEX", "ZIP inflate error at %zu/%zu bytes", reader_->bytesProduced(), reader_->inflatedSize());
     dst_.close();
     Storage.remove(destPath_.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1094,7 +1094,7 @@ void setup() {
       // covers the routes where a ReaderResume boot lands on Home instead: Back held at boot,
       // readerActivityLoadCount > 0 after a reader crash, or a quick-resume sleep whose frame file
       // is missing. On the cache-miss path the indexing popup clears it on X4 and re-arms
-      // forceHalfRefreshAfterPopup_ for the content page, which is the intended handoff.
+      // forceCleanRefreshAfterPopup_ for the content page, which is the intended handoff.
       renderer.setNextDisplayRefreshMode(HalDisplay::HALF_REFRESH);
       break;
     case BootResume::Splash:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1094,7 +1094,7 @@ void setup() {
       // covers the routes where a ReaderResume boot lands on Home instead: Back held at boot,
       // readerActivityLoadCount > 0 after a reader crash, or a quick-resume sleep whose frame file
       // is missing. On the cache-miss path the indexing popup clears it on X4 and re-arms
-      // forceCleanRefreshAfterPopup_ for the content page, which is the intended handoff.
+      // forceHalfRefreshAfterPopup_ for the content page, which is the intended handoff.
       renderer.setNextDisplayRefreshMode(HalDisplay::HALF_REFRESH);
       break;
     case BootResume::Splash:

--- a/test/epub_pipeline/BufferedPrintTest.cpp
+++ b/test/epub_pipeline/BufferedPrintTest.cpp
@@ -1,0 +1,110 @@
+// BufferedPrint: the BMP writers emit one file write per output row, and rows are small (a
+// 1-bit 340x540 thumbnail is 44 bytes), so they used to reach the card as hundreds of separate
+// calls. This batches them.
+//
+// Batching changes call COUNT, never bytes -- so that is what these pin: the sink must receive
+// exactly the same stream, and it must receive materially fewer calls.
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "BufferedPrint.h"
+
+namespace {
+
+// Records everything written and how many calls carried it.
+struct CountingSink : Print {
+  std::vector<uint8_t> bytes;
+  int calls = 0;
+  bool failNext = false;
+
+  size_t write(uint8_t b) override { return write(&b, 1); }
+  size_t write(const uint8_t* data, size_t n) override {
+    if (failNext) return 0;
+    calls++;
+    bytes.insert(bytes.end(), data, data + n);
+    return n;
+  }
+};
+
+std::vector<uint8_t> rowPattern(size_t n, uint8_t seed) {
+  std::vector<uint8_t> row(n);
+  for (size_t i = 0; i < n; i++) row[i] = static_cast<uint8_t>(seed + i);
+  return row;
+}
+
+// The real shape: a 340x540 1-bit thumbnail, 44 bytes a row.
+TEST(BufferedPrintTest, ThumbnailRowsCoalesceWithoutChangingBytes) {
+  CountingSink sink;
+  std::vector<uint8_t> expected;
+  {
+    BufferedPrint out(sink);
+    for (int row = 0; row < 540; row++) {
+      const auto data = rowPattern(44, static_cast<uint8_t>(row));
+      EXPECT_EQ(out.write(data.data(), data.size()), data.size());
+      expected.insert(expected.end(), data.begin(), data.end());
+    }
+    EXPECT_TRUE(out.flushBuffer());
+  }
+  EXPECT_EQ(sink.bytes, expected);
+  // 540 * 44 = 23760 bytes through a 4 KB buffer: single digits, not 540.
+  EXPECT_LE(sink.calls, 10) << "rows should be batched, got " << sink.calls << " calls";
+}
+
+// The destructor is the backstop for paths that bail out without flushing.
+TEST(BufferedPrintTest, DestructorFlushesPendingBytes) {
+  CountingSink sink;
+  {
+    BufferedPrint out(sink);
+    const uint8_t data[] = {1, 2, 3};
+    out.write(data, sizeof(data));
+    EXPECT_TRUE(sink.bytes.empty()) << "nothing should reach the sink until it has to";
+  }
+  EXPECT_EQ(sink.bytes, (std::vector<uint8_t>{1, 2, 3}));
+}
+
+// A payload larger than the buffer is not worth splitting -- but it must not jump the queue.
+TEST(BufferedPrintTest, OversizePayloadPreservesOrdering) {
+  CountingSink sink;
+  const std::vector<uint8_t> small = rowPattern(10, 1);
+  const std::vector<uint8_t> big = rowPattern(9000, 7);
+  {
+    BufferedPrint out(sink, 128);
+    out.write(small.data(), small.size());
+    out.write(big.data(), big.size());
+    EXPECT_TRUE(out.flushBuffer());
+  }
+  std::vector<uint8_t> expected = small;
+  expected.insert(expected.end(), big.begin(), big.end());
+  EXPECT_EQ(sink.bytes, expected);
+}
+
+// Single-byte writes go through the same buffer (Print's char-at-a-time API).
+TEST(BufferedPrintTest, ByteWritesAreBufferedToo) {
+  CountingSink sink;
+  {
+    BufferedPrint out(sink);
+    for (int i = 0; i < 500; i++) out.write(static_cast<uint8_t>(i));
+    EXPECT_TRUE(out.flushBuffer());
+  }
+  EXPECT_EQ(sink.bytes.size(), 500u);
+  EXPECT_LE(sink.calls, 2);
+}
+
+// A failing sink must be reported, not swallowed -- the caller folds this into its own result
+// so a truncated BMP is never cached as complete.
+TEST(BufferedPrintTest, FlushReportsSinkFailure) {
+  CountingSink sink;
+  BufferedPrint out(sink);
+  const uint8_t data[] = {9, 9, 9};
+  out.write(data, sizeof(data));
+  sink.failNext = true;
+  EXPECT_FALSE(out.flushBuffer());
+  // And it must not keep retrying the same bytes on every later flush.
+  sink.failNext = false;
+  EXPECT_TRUE(out.flushBuffer());
+  EXPECT_TRUE(sink.bytes.empty());
+}
+
+}  // namespace

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -95,6 +95,7 @@ add_executable(EpubPipelineTest
   ImageExtractionTest.cpp
   CompanionCacheTest.cpp
   StoredEntryDecodeTest.cpp
+  PixelCacheWriteTest.cpp
   # No-op HeapTrack: PipelineRunner brackets the dump read-back with pause/resume, and the gtest
   # binary must NOT get the real one (it overrides malloc/free process-wide). The two dump
   # targets pick their own implementation, so this cannot be moved into PIPELINE_SOURCES.

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(EpubPipelineTest
   FootnoteResolveSliceTest.cpp
   ImageExtractionTest.cpp
   CompanionCacheTest.cpp
+  StoredEntryDecodeTest.cpp
   # No-op HeapTrack: PipelineRunner brackets the dump read-back with pause/resume, and the gtest
   # binary must NOT get the real one (it overrides malloc/free process-wide). The two dump
   # targets pick their own implementation, so this cannot be moved into PIPELINE_SOURCES.

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -97,6 +97,7 @@ add_executable(EpubPipelineTest
   StoredEntryDecodeTest.cpp
   PixelCacheWriteTest.cpp
   BufferedPrintTest.cpp
+  CoverPipelineTest.cpp
   # No-op HeapTrack: PipelineRunner brackets the dump read-back with pause/resume, and the gtest
   # binary must NOT get the real one (it overrides malloc/free process-wide). The two dump
   # targets pick their own implementation, so this cannot be moved into PIPELINE_SOURCES.

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(EpubPipelineTest
   FootnotePreviewStoreTest.cpp
   FootnoteResolveSliceTest.cpp
   ImageExtractionTest.cpp
+  CompanionCacheTest.cpp
   # No-op HeapTrack: PipelineRunner brackets the dump read-back with pause/resume, and the gtest
   # binary must NOT get the real one (it overrides malloc/free process-wide). The two dump
   # targets pick their own implementation, so this cannot be moved into PIPELINE_SOURCES.

--- a/test/epub_pipeline/CMakeLists.txt
+++ b/test/epub_pipeline/CMakeLists.txt
@@ -96,6 +96,7 @@ add_executable(EpubPipelineTest
   CompanionCacheTest.cpp
   StoredEntryDecodeTest.cpp
   PixelCacheWriteTest.cpp
+  BufferedPrintTest.cpp
   # No-op HeapTrack: PipelineRunner brackets the dump read-back with pause/resume, and the gtest
   # binary must NOT get the real one (it overrides malloc/free process-wide). The two dump
   # targets pick their own implementation, so this cannot be moved into PIPELINE_SOURCES.

--- a/test/epub_pipeline/CompanionCacheTest.cpp
+++ b/test/epub_pipeline/CompanionCacheTest.cpp
@@ -1,0 +1,136 @@
+// One inflate, two pixel caches (RenderConfig::companionCachePath).
+//
+// The reader needs two .pxc per image — 1-bit Atkinson for the BW plane, 4-level Bayer for the
+// grayscale planes — and used to decode the PNG twice to get them. On an X4 cover that second
+// inflate measured 5.72 s of the 14.93 s an uncached image page cost.
+//
+// The merge is only ever safe as a PURE OPTIMISATION: the bytes it writes must be
+// indistinguishable from the two separate decodes it replaces. That is the whole contract, and
+// it is what these tests pin. It is easy to break in ways nothing else would notice — the two
+// ditherers share a source sample now, so a stray tone application, a diffusion-state update
+// skipped for an off-screen column, or a row advanced on one sink and not the other would all
+// still produce a plausible-looking image while silently changing every cached pixel.
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "Epub.h"
+#include "Epub/blocks/ImageBlock.h"
+#include "Epub/converters/PngToFramebufferConverter.h"
+#include "GfxRenderer.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+const char* kBook = CORPUS_DIR "/test_png_images.epub";
+const char* kEntry = "OEBPS/images/scaling_test.png";
+
+struct CompanionCacheFixture : testing::Test {
+  fs::path work;
+  std::string png;
+  GfxRenderer renderer;
+
+  void SetUp() override {
+    work = fs::temp_directory_path() /
+           (std::string("png_companion_") + testing::UnitTest::GetInstance()->current_test_info()->name());
+    fs::remove_all(work);
+    fs::create_directories(work);
+    const std::string cacheDir = (work / "cache").string();
+    fs::create_directories(cacheDir);
+    png = (work / "source.png").string();
+    Epub epub(kBook, cacheDir);
+    ASSERT_TRUE(epub.extractItemToFile(kEntry, png, nullptr));
+  }
+  void TearDown() override { fs::remove_all(work); }
+
+  // Decode once. `companion`, when set, asks for the other variant in the same pass.
+  bool decode(const char* primaryName, bool monochrome, const char* companionName = nullptr) {
+    RenderConfig config;
+    config.x = 0;
+    config.y = 0;
+    config.maxWidth = 120;
+    config.maxHeight = 160;
+    config.useExactDimensions = true;
+    config.monochromeOutput = monochrome;
+    config.cachePath = (work / primaryName).string();
+    if (companionName) config.companionCachePath = (work / companionName).string();
+    PngToFramebufferConverter converter;
+    return converter.decodeToFramebuffer(png, renderer, config);
+  }
+
+  std::vector<uint8_t> read(const char* name) const {
+    std::ifstream in((work / name).string(), std::ios::binary);
+    return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+  }
+};
+
+// The contract. Two separate decodes vs one merged decode: same four files, byte for byte.
+TEST_F(CompanionCacheFixture, MergedPassMatchesTwoSeparateDecodes) {
+  ASSERT_TRUE(decode("sep_bw.pxc", /*monochrome=*/true));
+  ASSERT_TRUE(decode("sep_grey.pxc", /*monochrome=*/false));
+  ASSERT_TRUE(decode("merged_bw.pxc", /*monochrome=*/true, "merged_grey.pxc"));
+
+  const auto sepBw = read("sep_bw.pxc");
+  const auto sepGrey = read("sep_grey.pxc");
+  ASSERT_FALSE(sepBw.empty());
+  ASSERT_FALSE(sepGrey.empty());
+
+  EXPECT_EQ(read("merged_bw.pxc"), sepBw) << "the drawn variant must not change";
+  EXPECT_EQ(read("merged_grey.pxc"), sepGrey) << "the companion must equal its own separate decode";
+}
+
+// Same guarantee with the roles swapped: a grayscale primary carries a 1-bit companion, which is
+// the direction that actually allocates a second (Atkinson) ditherer.
+TEST_F(CompanionCacheFixture, CompanionWorksWithGrayscalePrimary) {
+  ASSERT_TRUE(decode("sep_bw.pxc", /*monochrome=*/true));
+  ASSERT_TRUE(decode("sep_grey.pxc", /*monochrome=*/false));
+  ASSERT_TRUE(decode("merged_grey.pxc", /*monochrome=*/false, "merged_bw.pxc"));
+
+  EXPECT_EQ(read("merged_grey.pxc"), read("sep_grey.pxc"));
+  EXPECT_EQ(read("merged_bw.pxc"), read("sep_bw.pxc"));
+}
+
+// The two variants are genuinely different renditions. Without this, both assertions above would
+// still pass if the companion simply copied the primary — the exact bug they exist to catch.
+TEST_F(CompanionCacheFixture, TheTwoVariantsAreNotTheSameBytes) {
+  ASSERT_TRUE(decode("bw.pxc", /*monochrome=*/true, "grey.pxc"));
+  const auto bw = read("bw.pxc");
+  const auto grey = read("grey.pxc");
+  ASSERT_FALSE(bw.empty());
+  ASSERT_EQ(bw.size(), grey.size()) << "same 2bpp format and geometry";
+  EXPECT_NE(bw, grey);
+}
+
+// A companion path that cannot be opened must cost the caller nothing but the companion: the
+// primary cache and the return value are unaffected, so warmImageCaches() falls back to the
+// second decode exactly as it did before.
+TEST_F(CompanionCacheFixture, UnwritableCompanionLeavesThePrimaryIntact) {
+  ASSERT_TRUE(decode("sep_bw.pxc", /*monochrome=*/true));
+
+  // A directory sitting where the companion file would go: openFileForWrite cannot succeed,
+  // whatever the platform. (A merely missing parent directory is not enough — the host storage
+  // shim creates one.)
+  const fs::path blocked = work / "companion.pxc";
+  fs::create_directories(blocked);
+
+  RenderConfig config;
+  config.x = 0;
+  config.y = 0;
+  config.maxWidth = 120;
+  config.maxHeight = 160;
+  config.useExactDimensions = true;
+  config.monochromeOutput = true;
+  config.cachePath = (work / "primary.pxc").string();
+  config.companionCachePath = blocked.string();
+  PngToFramebufferConverter converter;
+  EXPECT_TRUE(converter.decodeToFramebuffer(png, renderer, config)) << "a lost companion is not a failed decode";
+
+  EXPECT_EQ(read("primary.pxc"), read("sep_bw.pxc"));
+  EXPECT_TRUE(fs::is_directory(blocked)) << "nothing should have been written over it";
+}
+
+}  // namespace

--- a/test/epub_pipeline/CoverPipelineTest.cpp
+++ b/test/epub_pipeline/CoverPipelineTest.cpp
@@ -1,0 +1,197 @@
+// Two cover-pipeline costs the home screen was paying on every cold start, measured on X4 with a
+// five-book carousel:
+//
+//   ~3.3 s  re-parsing content.opf. loadForCover() parses it whenever book.bin is absent, and the
+//           SAME book is asked three to five times in a row (try the thumb, check cover.img, start
+//           the extract, then once per thumb size). One Cyrillic book paid 5 x 301 ms.
+//   ~6.0 s  copying covers to cover.img before any of them could be decoded -- pure byte-shuffling
+//           whenever the ZIP stores the entry uncompressed.
+//
+// Both fixes are only sound if they change nothing observable, which is what these pin: the memo
+// must never answer for the wrong book, and an in-place decode must produce the same thumbnail as
+// one that went through cover.img.
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "Epub.h"
+#include "StoredZipWriter.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Minimal EPUB whose OPF declares `coverName` as the cover image.
+std::string makeEpub(const fs::path& path, const std::string& coverName, const std::string& coverBytes,
+                     const std::string& title) {
+  const std::string opf =
+      "<?xml version=\"1.0\"?><package version=\"2.0\" xmlns=\"http://www.idpf.org/2007/opf\">"
+      "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:title>" +
+      title +
+      "</dc:title><meta name=\"cover\" content=\"cov\"/></metadata>"
+      "<manifest><item id=\"cov\" href=\"" +
+      coverName +
+      "\" media-type=\"image/png\"/>"
+      "<item id=\"c1\" href=\"c1.xhtml\" media-type=\"application/xhtml+xml\"/></manifest>"
+      "<spine><itemref idref=\"c1\"/></spine></package>";
+  test_zip::StoredZipWriter zip;
+  zip.add("mimetype", "application/epub+zip");
+  zip.add("META-INF/container.xml",
+          "<?xml version=\"1.0\"?><container version=\"1.0\" "
+          "xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\"><rootfiles><rootfile "
+          "full-path=\"content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles></container>");
+  zip.add("content.opf", opf);
+  zip.add(coverName, coverBytes);
+  zip.add("c1.xhtml", "<html><body><p>x</p></body></html>");
+  zip.write(path.string());
+  return path.string();
+}
+
+struct CoverPipelineFixture : testing::Test {
+  fs::path work;
+  std::string cacheDir;
+  std::vector<uint8_t> pngBytes;
+
+  void SetUp() override {
+    work = fs::temp_directory_path() /
+           (std::string("cover_pipe_") + testing::UnitTest::GetInstance()->current_test_info()->name());
+    fs::remove_all(work);
+    fs::create_directories(work);
+    cacheDir = (work / "cache").string();
+    fs::create_directories(cacheDir);
+
+    // A real PNG, pulled out of the corpus book (which deflates it). cache_test_1 rather than
+    // scaling_test: the latter is 1200x1500, above the thumbnail path's MAX_PNG_PIXELS cap, so it
+    // would fail here for a reason that has nothing to do with what is under test.
+    const std::string extracted = (work / "src.png").string();
+    Epub source(CORPUS_DIR "/test_png_images.epub", cacheDir);
+    ASSERT_TRUE(source.extractItemToFile("OEBPS/images/cache_test_1.png", extracted, nullptr));
+    std::ifstream in(extracted, std::ios::binary);
+    pngBytes.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    ASSERT_GT(pngBytes.size(), 500u);
+    Epub::clearCoverMetadataMemo();
+  }
+  void TearDown() override {
+    Epub::clearCoverMetadataMemo();
+    fs::remove_all(work);
+  }
+
+  std::string pngString() const { return std::string(pngBytes.begin(), pngBytes.end()); }
+};
+
+// The memo must not leak one book's cover into another's — the failure that would put the wrong
+// picture on the home screen.
+TEST_F(CoverPipelineFixture, MemoDoesNotAnswerForADifferentBook) {
+  const std::string a = makeEpub(work / "a.epub", "coverA.png", pngString(), "A");
+  const std::string b = makeEpub(work / "b.epub", "coverB.png", pngString() + "padding-to-differ", "B");
+
+  Epub epubA(a, (work / "ca").string());
+  ASSERT_TRUE(epubA.loadForCover());
+  EXPECT_EQ(epubA.getCoverItemHref(), "coverA.png");
+
+  Epub epubB(b, (work / "cb").string());
+  ASSERT_TRUE(epubB.loadForCover());
+  EXPECT_EQ(epubB.getCoverItemHref(), "coverB.png") << "the memo served the previous book";
+
+  // And back again — a replaced entry must not have poisoned the first answer either.
+  Epub epubA2(a, (work / "ca").string());
+  ASSERT_TRUE(epubA2.loadForCover());
+  EXPECT_EQ(epubA2.getCoverItemHref(), "coverA.png");
+}
+
+// Repeat queries for the same book are what the memo exists for.
+TEST_F(CoverPipelineFixture, RepeatedLoadForCoverAgrees) {
+  const std::string a = makeEpub(work / "a.epub", "coverA.png", pngString(), "A");
+  for (int i = 0; i < 5; i++) {
+    Epub epub(a, (work / "ca").string());
+    ASSERT_TRUE(epub.loadForCover()) << "attempt " << i;
+    EXPECT_EQ(epub.getCoverItemHref(), "coverA.png") << "attempt " << i;
+  }
+}
+
+// Same path, different content: the size key must force a re-parse rather than serve the old cover.
+TEST_F(CoverPipelineFixture, ReplacedBookAtTheSamePathIsNotServedStale) {
+  const fs::path path = work / "book.epub";
+  makeEpub(path, "coverA.png", pngString(), "A");
+  {
+    Epub epub(path.string(), (work / "c1").string());
+    ASSERT_TRUE(epub.loadForCover());
+    ASSERT_EQ(epub.getCoverItemHref(), "coverA.png");
+  }
+  fs::remove(path);
+  makeEpub(path, "coverB.png", pngString() + "different-length", "B");
+  {
+    Epub epub(path.string(), (work / "c2").string());
+    ASSERT_TRUE(epub.loadForCover());
+    EXPECT_EQ(epub.getCoverItemHref(), "coverB.png") << "stale memo served after the book changed";
+  }
+}
+
+// A book with no cover is memoized too — the "no cover" answer is exactly what the next three
+// calls would otherwise re-parse the OPF to rediscover.
+TEST_F(CoverPipelineFixture, BookWithoutACoverStaysWithoutOne) {
+  test_zip::StoredZipWriter zip;
+  zip.add("mimetype", "application/epub+zip");
+  zip.add("META-INF/container.xml",
+          "<?xml version=\"1.0\"?><container version=\"1.0\" "
+          "xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\"><rootfiles><rootfile "
+          "full-path=\"content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles></container>");
+  zip.add("content.opf",
+          "<?xml version=\"1.0\"?><package version=\"2.0\" xmlns=\"http://www.idpf.org/2007/opf\">"
+          "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:title>NoCover</dc:title></metadata>"
+          "<manifest><item id=\"c1\" href=\"c1.xhtml\" media-type=\"application/xhtml+xml\"/></manifest>"
+          "<spine><itemref idref=\"c1\"/></spine></package>");
+  zip.add("c1.xhtml", "<html><body><p>x</p></body></html>");
+  const std::string path = (work / "nocover.epub").string();
+  zip.write(path);
+
+  for (int i = 0; i < 3; i++) {
+    Epub epub(path, (work / "cn").string());
+    EXPECT_FALSE(epub.loadForCover()) << "attempt " << i;
+  }
+}
+
+// The in-place decode must produce exactly the thumbnail the extract-then-decode path does.
+TEST_F(CoverPipelineFixture, StoredCoverThumbMatchesTheExtractedPath) {
+  const std::string book = makeEpub(work / "book.epub", "cover.png", pngString(), "T");
+
+  const auto read = [](const std::string& p) {
+    std::ifstream in(p, std::ios::binary);
+    return std::vector<uint8_t>{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+  };
+
+  // Route 1: nothing cached -> the stored entry is decoded straight out of the archive.
+  std::vector<uint8_t> viaInPlace;
+  std::string inPlaceCoverImg;
+  {
+    Epub epub(book, (work / "inplace").string());
+    ASSERT_TRUE(epub.loadForCover());
+    inPlaceCoverImg = epub.getCoverImageCachePath();
+    ASSERT_EQ(epub.generateThumbBmp(120, 160, /*allowExtract=*/false), ThumbResult::Ok)
+        << "a stored cover should need no extraction at all";
+    viaInPlace = read(epub.getThumbBmpPath(120, 160));
+  }
+  ASSERT_FALSE(viaInPlace.empty());
+  EXPECT_FALSE(fs::exists(inPlaceCoverImg)) << "the whole point: no copy of the cover on the card";
+
+  // Route 2: hand it a cover.img first, so the ordinary cached path runs instead.
+  Epub::clearCoverMetadataMemo();
+  {
+    Epub epub(book, (work / "extracted").string());
+    ASSERT_TRUE(epub.loadForCover());
+    const fs::path img = epub.getCoverImageCachePath();
+    fs::create_directories(img.parent_path());
+    {
+      std::ofstream out(img.string(), std::ios::binary);
+      out.write(reinterpret_cast<const char*>(pngBytes.data()), static_cast<std::streamsize>(pngBytes.size()));
+    }
+    ASSERT_EQ(epub.generateThumbBmp(120, 160, /*allowExtract=*/false), ThumbResult::Ok);
+    EXPECT_EQ(read(epub.getThumbBmpPath(120, 160)), viaInPlace)
+        << "decoding in place must be indistinguishable from decoding the extracted copy";
+  }
+}
+
+}  // namespace

--- a/test/epub_pipeline/FootnoteResolveSliceTest.cpp
+++ b/test/epub_pipeline/FootnoteResolveSliceTest.cpp
@@ -26,6 +26,7 @@
 #include "Epub/FootnotePreviews.h"
 #include "Epub/Section.h"
 #include "GfxRenderer.h"
+#include "StoredZipWriter.h"
 
 namespace fs = std::filesystem;
 
@@ -45,102 +46,6 @@ std::string freshDir(const std::string& tag) {
   fs::create_directories(dir);
   return dir.string();
 }
-
-// --- minimal STORED-only zip writer -------------------------------------------------------
-
-class StoredZipWriter {
- public:
-  void add(const std::string& name, const std::string& data) { entries_.push_back({name, data, 0}); }
-
-  void write(const std::string& path) {
-    std::string out;
-    for (Entry& e : entries_) {
-      e.localOffset = static_cast<uint32_t>(out.size());
-      appendLocalHeader(out, e);
-      out += e.data;
-    }
-    const uint32_t centralStart = static_cast<uint32_t>(out.size());
-    for (const Entry& e : entries_) {
-      appendCentralHeader(out, e);
-    }
-    const uint32_t centralSize = static_cast<uint32_t>(out.size()) - centralStart;
-    appendEocd(out, centralStart, centralSize, static_cast<uint16_t>(entries_.size()));
-    std::ofstream f(path, std::ios::binary);
-    f.write(out.data(), static_cast<std::streamsize>(out.size()));
-  }
-
- private:
-  struct Entry {
-    std::string name;
-    std::string data;
-    uint32_t localOffset;
-  };
-
-  static void put16(std::string& out, const uint16_t v) {
-    out.push_back(static_cast<char>(v & 0xFF));
-    out.push_back(static_cast<char>((v >> 8) & 0xFF));
-  }
-  static void put32(std::string& out, const uint32_t v) {
-    for (int i = 0; i < 4; ++i) out.push_back(static_cast<char>((v >> (8 * i)) & 0xFF));
-  }
-  // CRC-32 is checked by nothing on the read path here, but a zero would be a lie in a file we
-  // hand to a real reader, so compute it properly.
-  static uint32_t crc32(const std::string& data) {
-    uint32_t crc = 0xFFFFFFFFu;
-    for (const unsigned char c : data) {
-      crc ^= c;
-      for (int k = 0; k < 8; ++k) crc = (crc >> 1) ^ (0xEDB88320u & (~(crc & 1u) + 1u));
-    }
-    return ~crc;
-  }
-  static void appendLocalHeader(std::string& out, const Entry& e) {
-    put32(out, 0x04034B50);
-    put16(out, 20);  // version needed
-    put16(out, 0);   // flags
-    put16(out, 0);   // method: stored
-    put16(out, 0);   // time
-    put16(out, 0);   // date
-    put32(out, crc32(e.data));
-    put32(out, static_cast<uint32_t>(e.data.size()));
-    put32(out, static_cast<uint32_t>(e.data.size()));
-    put16(out, static_cast<uint16_t>(e.name.size()));
-    put16(out, 0);
-    out += e.name;
-  }
-  static void appendCentralHeader(std::string& out, const Entry& e) {
-    put32(out, 0x02014B50);
-    put16(out, 20);  // version made by
-    put16(out, 20);  // version needed
-    put16(out, 0);
-    put16(out, 0);  // method: stored
-    put16(out, 0);
-    put16(out, 0);
-    put32(out, crc32(e.data));
-    put32(out, static_cast<uint32_t>(e.data.size()));
-    put32(out, static_cast<uint32_t>(e.data.size()));
-    put16(out, static_cast<uint16_t>(e.name.size()));
-    put16(out, 0);  // extra
-    put16(out, 0);  // comment
-    put16(out, 0);  // disk
-    put16(out, 0);  // internal attrs
-    put32(out, 0);  // external attrs
-    put32(out, e.localOffset);
-    out += e.name;
-  }
-  static void appendEocd(std::string& out, const uint32_t centralStart, const uint32_t centralSize,
-                         const uint16_t entryCount) {
-    put32(out, 0x06054B50);
-    put16(out, 0);  // disk number
-    put16(out, 0);  // disk with central dir
-    put16(out, entryCount);
-    put16(out, entryCount);
-    put32(out, centralSize);
-    put32(out, centralStart);
-    put16(out, 0);  // comment length
-  }
-
-  std::vector<Entry> entries_;
-};
 
 // --- fixture generation --------------------------------------------------------------------
 
@@ -192,7 +97,7 @@ std::string makeBook(const std::string& dir, const int noteCount, const size_t c
       "<rootfiles><rootfile full-path=\"content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>\n"
       "</container>\n";
 
-  StoredZipWriter zip;
+  test_zip::StoredZipWriter zip;
   zip.add("mimetype", "application/epub+zip");
   zip.add("META-INF/container.xml", container);
   zip.add("content.opf", opf);
@@ -220,7 +125,7 @@ struct Chapter {
 
 std::string makeSharedNotesBook(const std::string& dir, const std::vector<Chapter>& chapters) {
   const std::string notesDocName = "notes.xhtml";
-  StoredZipWriter zip;
+  test_zip::StoredZipWriter zip;
   std::string manifest;
   std::string spine;
   std::string notesBodies;

--- a/test/epub_pipeline/ImageExtractionTest.cpp
+++ b/test/epub_pipeline/ImageExtractionTest.cpp
@@ -104,6 +104,36 @@ TEST_F(ImageExtractionFixture, TooSmallArenaFallsBackToHeapInsteadOfFailing) {
 
 }  // namespace
 
+// The write buffer is reserved from the arena BEFORE the reader takes its block, because
+// BuildArena is LIFO. Get that order wrong and the release is rejected, leaking the block for
+// the rest of the pass — so assert the arena comes back empty, not just that the bytes are right.
+TEST_F(ImageExtractionFixture, ArenaWriteBufferIsReleasedInOrder) {
+  BuildArena arena(Epub::EXTRACT_ARENA_BYTES + 1024);
+  ASSERT_TRUE(arena.valid());
+  const auto bytes = extract("ordered.png", &arena);
+
+  ASSERT_EQ(bytes.size(), kEntryBytes);
+  EXPECT_EQ(arena.used(), 0u) << "write buffer and reader block must both be released";
+  EXPECT_EQ(arena.failedAllocSize(), 0u);
+  EXPECT_GT(arena.highWater(), 32u * 1024u + Epub::EXTRACT_WRITE_BUFFER_BYTES)
+      << "both the ring and the write buffer should have come from the arena";
+}
+
+// An arena with room for the reader but not the write buffer must still extract correctly — the
+// buffer falls back to the heap, and then to unbuffered pass-through. Slow is a nuisance; a
+// truncated image is a bug.
+TEST_F(ImageExtractionFixture, WriteBufferFallsBackWithoutBreakingTheExtract) {
+  const auto viaHeap = extract("reference.png", nullptr);
+  ASSERT_EQ(viaHeap.size(), kEntryBytes);
+
+  BuildArena arena(33 * 1024 + 1024);  // reader fits, write buffer does not
+  ASSERT_TRUE(arena.valid());
+  const auto bytes = extract("tight.png", &arena);
+
+  EXPECT_EQ(bytes, viaHeap);
+  EXPECT_EQ(arena.used(), 0u);
+}
+
 // --- large-image placeholder gate ------------------------------------------------------------
 //
 // This used to compare ImageBlock's width*height — the DISPLAY dimensions — against 800*600.

--- a/test/epub_pipeline/ImageExtractionTest.cpp
+++ b/test/epub_pipeline/ImageExtractionTest.cpp
@@ -13,6 +13,7 @@
 //      EntryReader itself does NOT fall back once it has been handed one.
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -20,6 +21,7 @@
 
 #include "BuildArena.h"
 #include "Epub.h"
+#include "Epub/blocks/ImageBlock.h"
 
 namespace fs = std::filesystem;
 
@@ -101,3 +103,72 @@ TEST_F(ImageExtractionFixture, TooSmallArenaFallsBackToHeapInsteadOfFailing) {
 }
 
 }  // namespace
+
+// --- large-image placeholder gate ------------------------------------------------------------
+//
+// This used to compare ImageBlock's width*height — the DISPLAY dimensions — against 800*600.
+// The panel is 480x800, and render() rejects anything larger than the screen, so the product
+// could never exceed 384000 and the gate was unreachable: the "show a placeholder for large
+// images" setting did nothing at all, for any book. The tests below pin both halves of the fix —
+// that the decision is made on source bytes, and that display size does not enter into it.
+
+struct LargeImageFixture : ImageExtractionFixture {
+  // A file of `bytes` at the block's imagePath, standing in for an already-extracted image.
+  std::string writeExtracted(const char* name, const size_t bytes) {
+    const std::string path = (work / name).string();
+    std::ofstream out(path, std::ios::binary);
+    const std::vector<char> chunk(1024, '\0');
+    for (size_t written = 0; written < bytes; written += chunk.size()) {
+      out.write(chunk.data(), static_cast<std::streamsize>(std::min(chunk.size(), bytes - written)));
+    }
+    return path;
+  }
+};
+
+TEST_F(LargeImageFixture, DecidesOnSourceBytesNotDisplaySize) {
+  // Tiny on screen, huge on disk: large. This is the case that matters — a full-page cover is
+  // scaled down to fit, so its display size says nothing about what it costs to get there.
+  const std::string big = writeExtracted("big.png", LARGE_IMAGE_SOURCE_BYTES + 1);
+  ImageBlock smallOnScreen(big, 32, 32, "");
+  EXPECT_TRUE(smallOnScreen.isLargeImage());
+
+  // Full screen, small file: not large. Under the old pixel test this was the only shape that
+  // could ever have qualified, and even it could not reach the threshold.
+  const std::string small = writeExtracted("small.png", 8 * 1024);
+  ImageBlock fullScreen(small, 480, 800, "");
+  EXPECT_FALSE(fullScreen.isLargeImage());
+}
+
+TEST_F(LargeImageFixture, ResolvesSizeFromTheArchiveBeforeExtraction) {
+  // Nothing extracted yet: the size has to come from the ZIP entry, which is the state the gate
+  // is actually consulted in (first view, pixel-cache miss, image not yet on SD).
+  const std::string notExtracted = (work / "never_written.png").string();
+  ASSERT_FALSE(fs::exists(notExtracted));
+
+  static_assert(kEntryBytes < LARGE_IMAGE_SOURCE_BYTES, "fixture entry must be under the threshold");
+  ImageBlock block(notExtracted, 100, 100, "", kBook, kEntry);
+  EXPECT_FALSE(block.isLargeImage()) << kEntryBytes << " bytes is under the threshold";
+  EXPECT_FALSE(fs::exists(notExtracted)) << "asking the size must not extract anything";
+
+  // The corpus has no entry above the threshold, so the archive path's TRUE case is not covered
+  // here — a failed lookup and a small entry both answer false, and there is no way to tell them
+  // apart from outside. What is pinned is that the lookup neither extracts nor throws.
+}
+
+TEST_F(LargeImageFixture, UnknownSizeRendersRatherThanHides) {
+  // No archive reference and no file on disk: nothing can be learned. Fall to "not large", so the
+  // image is attempted rather than replaced by a placeholder that would never resolve.
+  ImageBlock orphan((work / "missing.png").string(), 400, 600, "");
+  EXPECT_FALSE(orphan.isLargeImage());
+}
+
+TEST_F(LargeImageFixture, PlaceholderIsSuppressedByForceLoad) {
+  const std::string big = writeExtracted("forced.png", LARGE_IMAGE_SOURCE_BYTES + 1);
+  ImageBlock block(big, 400, 600, "");
+
+  EXPECT_TRUE(block.wouldShowPlaceholder(/*forceLoad=*/false, /*monochromeOutput=*/true));
+  EXPECT_FALSE(block.wouldShowPlaceholder(/*forceLoad=*/true, /*monochromeOutput=*/true))
+      << "the user asked for it explicitly";
+  // (The other suppressor — an existing .pxc pixel cache — is not reachable from here: the cache
+  // path is derived internally from the tone filter id and is not exposed for a test to create.)
+}

--- a/test/epub_pipeline/ImageExtractionTest.cpp
+++ b/test/epub_pipeline/ImageExtractionTest.cpp
@@ -21,7 +21,10 @@
 
 #include "BuildArena.h"
 #include "Epub.h"
+#include "Epub/Section.h"
 #include "Epub/blocks/ImageBlock.h"
+#include "GfxRenderer.h"
+#include "StoredZipWriter.h"
 
 namespace fs = std::filesystem;
 
@@ -201,4 +204,114 @@ TEST_F(LargeImageFixture, PlaceholderIsSuppressedByForceLoad) {
       << "the user asked for it explicitly";
   // (The other suppressor — an existing .pxc pixel cache — is not reachable from here: the cache
   // path is derived internally from the tone filter id and is not exposed for a test to create.)
+}
+
+// --- heap-degraded image headers -------------------------------------------------------------
+//
+// When neither the img tag nor the manifest can supply an image's dimensions, the parser reads
+// the header straight out of the ZIP — behind a heap gate. A refusal drops the image to alt text
+// and the section is then CACHED that way, under the same property hash a complete build would
+// use, so the missing image is permanent. Background-B is the caller most exposed to it: it
+// builds with the framebuffer borrowed, which is exactly when the largest free block is small.
+//
+// The distinction that matters is that the same VISIBLE outcome (alt text) has two causes. An
+// unreadable or absent image is alt text for good and caching that is right; a heap refusal is a
+// statement about one moment and must not be kept. These tests pin both sides.
+
+struct ImageHeapGateFixture : testing::Test {
+  fs::path work;
+  std::string cacheDir;
+  uint32_t savedHeap = 0;
+
+  void SetUp() override {
+    work = fs::temp_directory_path() /
+           (std::string("epub_imgheap_") + testing::UnitTest::GetInstance()->current_test_info()->name());
+    fs::remove_all(work);
+    fs::create_directories(work);
+    cacheDir = (work / "cache").string();
+    fs::create_directories(cacheDir);
+    savedHeap = ESP.getFreeHeap();
+  }
+  void TearDown() override {
+    ESP.setFreeHeap(savedHeap);
+    fs::remove_all(work);
+  }
+
+  // A one-chapter book whose <img> has no width/height and points at an entry that is NOT in the
+  // archive. That is the only shape which reaches the heap gate on the host: an image the
+  // manifest can resolve never gets there, and the manifest resolves anything whose header sits
+  // in the first 4 KB.
+  std::string makeBookWithUnresolvableImage() {
+    test_zip::StoredZipWriter zip;
+    zip.add("mimetype", "application/epub+zip");
+    zip.add("META-INF/container.xml",
+            "<?xml version=\"1.0\"?>\n<container version=\"1.0\" "
+            "xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">\n<rootfiles><rootfile "
+            "full-path=\"content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>\n</container>\n");
+    zip.add("content.opf",
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<package xmlns=\"http://www.idpf.org/2007/opf\" "
+            "version=\"3.0\" unique-identifier=\"id\">\n<metadata "
+            "xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><dc:identifier id=\"id\">img</dc:identifier>"
+            "<dc:title>Img</dc:title><dc:language>en</dc:language></metadata>\n<manifest>\n<item id=\"c\" "
+            "href=\"chapter.xhtml\" media-type=\"application/xhtml+xml\"/>\n</manifest>\n<spine><itemref "
+            "idref=\"c\"/></spine>\n</package>\n");
+    zip.add("chapter.xhtml",
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">"
+            "<head><title>C</title></head><body>\n<p>Before the image.</p>\n"
+            "<img src=\"absent.png\" alt=\"alt text stands in\"/>\n<p>After the image.</p>\n</body></html>\n");
+    const std::string path = (work / "img.epub").string();
+    zip.write(path);
+    return path;
+  }
+
+  bool buildAndReportDegraded(const std::string& bookPath, const std::string& cache) {
+    auto epub = std::make_shared<Epub>(bookPath, cache);
+    EXPECT_TRUE(epub->load(true));
+    Section::BuildParams params;
+    params.viewportWidth = 480;
+    params.viewportHeight = 800;
+    params.lineCompression = 1.0f;
+    GfxRenderer renderer;
+    Section section(epub, 0, renderer);
+    EXPECT_TRUE(section.createSectionFile(params, {}, /*skipEviction=*/true));
+    return section.isImageHeaderDegraded();
+  }
+};
+
+TEST_F(ImageHeapGateFixture, HeapRefusalIsLatchedSoTheCacheCanBeDiscarded) {
+  const std::string book = makeBookWithUnresolvableImage();
+
+  // Between the text-layout hard abort (9 KB, below which the parse gives up entirely) and
+  // EHP_IMAGE_HEADER_MIN_FREE_HEAP (16 KB): the parse runs to completion, and the header read is
+  // refused before it is attempted. That ordering is the point of the ladder — an image is given
+  // up long before the chapter is.
+  ESP.setFreeHeap(12 * 1024);
+  EXPECT_TRUE(buildAndReportDegraded(book, (work / "lowheap").string()))
+      << "a heap refusal must be latched, or the alt-text page is cached forever";
+}
+
+TEST_F(ImageHeapGateFixture, AnImageThatSimplyCannotBeReadIsNotLatched) {
+  const std::string book = makeBookWithUnresolvableImage();
+
+  // Ample heap: the read is attempted and fails on its own merits (the entry does not exist).
+  // Same alt text on screen, but nothing transient about it — caching that is correct, so the
+  // build must NOT be flagged for discard or the spine would rebuild forever.
+  ESP.setFreeHeap(200 * 1024);
+  EXPECT_FALSE(buildAndReportDegraded(book, (work / "fullheap").string()))
+      << "an unreadable image is alt text for good; flagging it would cause endless rebuilds";
+}
+
+TEST_F(ImageHeapGateFixture, AResolvableImageIsNeverFlagged) {
+  ESP.setFreeHeap(200 * 1024);
+  auto epub = std::make_shared<Epub>(std::string(CORPUS_DIR) + "/test_png_images.epub", cacheDir);
+  ASSERT_TRUE(epub->load(true));
+  Section::BuildParams params;
+  params.viewportWidth = 480;
+  params.viewportHeight = 800;
+  params.lineCompression = 1.0f;
+  GfxRenderer renderer;
+  Section section(epub, 5, renderer);  // chapter with an <img> carrying no dimensions
+  ASSERT_TRUE(section.createSectionFile(params, {}, /*skipEviction=*/true));
+  EXPECT_FALSE(section.isImageHeaderDegraded());
+  EXPECT_GT(section.pageCount, 0);
 }

--- a/test/epub_pipeline/PixelCacheWriteTest.cpp
+++ b/test/epub_pipeline/PixelCacheWriteTest.cpp
@@ -1,0 +1,118 @@
+// PixelCache's on-disk bytes, and the batching that produces them.
+//
+// The cache is written through a small band buffer, and it used to flush one row per
+// file.write(): a 464x618 cache went out as 618 separate 116-byte writes. Device-measured on
+// X4 that was ~2.3 s per cache -- about 40% of a whole PNG decode, and why adding a second
+// cache to the same decode pass cost 2274 ms despite its dither and packing being nearly free.
+// Rows now accumulate and go out a band at a time.
+//
+// Batching changes WHEN bytes are written, so what has to be pinned is that it changes nothing
+// about WHICH bytes: the file must be byte-identical to the naive row-at-a-time writer,
+// including the fill used for rows a decode never covered.
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "Epub/converters/PixelCache.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct PixelCacheFixture : testing::Test {
+  fs::path work;
+
+  void SetUp() override {
+    work = fs::temp_directory_path() /
+           (std::string("pxc_") + testing::UnitTest::GetInstance()->current_test_info()->name());
+    fs::remove_all(work);
+    fs::create_directories(work);
+  }
+  void TearDown() override { fs::remove_all(work); }
+
+  std::vector<uint8_t> readFile(const std::string& p) const {
+    std::ifstream in(p, std::ios::binary);
+    return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+  }
+
+  // What the file must contain: the header, then every row, with uncovered rows at FILL_BYTE.
+  // Written out independently of PixelCache so the two cannot drift together.
+  static std::vector<uint8_t> expected(int w, int h, int coveredRows, uint8_t value) {
+    const int bytesPerRow = (w + 3) / 4;
+    std::vector<uint8_t> out;
+    const uint16_t magic = PixelCache::PXC_MAGIC;
+    const uint16_t w16 = static_cast<uint16_t>(w);
+    const uint16_t h16 = static_cast<uint16_t>(h);
+    for (uint16_t v : {magic, w16, h16}) {
+      out.push_back(static_cast<uint8_t>(v & 0xFF));
+      out.push_back(static_cast<uint8_t>(v >> 8));
+    }
+    uint8_t packed = 0;
+    for (int i = 0; i < 4; i++) packed = static_cast<uint8_t>((packed << 2) | (value & 0x03));
+    for (int r = 0; r < h; r++) {
+      const uint8_t fill = (r < coveredRows) ? packed : PixelCache::FILL_BYTE;
+      out.insert(out.end(), static_cast<size_t>(bytesPerRow), fill);
+    }
+    return out;
+  }
+
+  // Drive the cache exactly the way PngToFramebufferConverter does: advanceTo(row) per row,
+  // then paint that row. `coveredRows` short of `h` mimics a decode clipped by the screen.
+  std::string writeCache(int w, int h, int coveredRows, uint8_t value, int maxBlockRows = 1) {
+    const std::string path = (work / "out.pxc").string();
+    PixelCache cache;
+    EXPECT_TRUE(cache.begin(path, w, h, 0, 0, maxBlockRows));
+    const int bytesPerRow = (w + 3) / 4;
+    for (int row = 0; row < coveredRows; row++) {
+      EXPECT_TRUE(cache.advanceTo(row));
+      uint8_t* rowPtr = cache.buffer + static_cast<size_t>(row - cache.bandStart) * bytesPerRow;
+      for (int b = 0; b < bytesPerRow; b++) {
+        uint8_t packed = 0;
+        for (int i = 0; i < 4; i++) packed = static_cast<uint8_t>((packed << 2) | (value & 0x03));
+        rowPtr[b] = packed;
+      }
+    }
+    EXPECT_TRUE(cache.finalize());
+    return path;
+  }
+};
+
+// The band is 16 rows, so this crosses it many times -- the case the batching is for.
+TEST_F(PixelCacheFixture, FullyCoveredImageMatchesRowByRowOutput) {
+  const std::string path = writeCache(64, 100, 100, 2);
+  EXPECT_EQ(readFile(path), expected(64, 100, 100, 2));
+}
+
+// Fewer rows than the box: the tail must come out as FILL_BYTE, or a short decode replays as a
+// black band under the picture on every later view (the bug FILL_BYTE was introduced for).
+TEST_F(PixelCacheFixture, UncoveredTailIsFilledNotLeftShort) {
+  const std::string path = writeCache(64, 100, 37, 1);
+  const auto bytes = readFile(path);
+  EXPECT_EQ(bytes, expected(64, 100, 37, 1));
+  EXPECT_EQ(bytes.size(), PixelCache::PXC_HEADER_BYTES + 16u * 100u);
+}
+
+// Nothing decoded at all: still a complete, all-white file rather than a truncated one.
+TEST_F(PixelCacheFixture, NoRowsCoveredStillWritesEveryRow) {
+  const std::string path = writeCache(64, 40, 0, 0);
+  EXPECT_EQ(readFile(path), expected(64, 40, 0, 0));
+}
+
+// An image shorter than one band never triggers a mid-stream flush; finalize() alone must
+// produce the whole file.
+TEST_F(PixelCacheFixture, ImageShorterThanTheBand) {
+  const std::string path = writeCache(64, 5, 5, 3);
+  EXPECT_EQ(readFile(path), expected(64, 5, 5, 3));
+}
+
+// A block-at-a-time decoder (JPEG MCU rows) reserves headroom: rows written after an
+// advanceTo() must still land inside the band, so the flush cannot be deferred as far.
+TEST_F(PixelCacheFixture, BlockDecoderHeadroomIsRespected) {
+  const std::string path = writeCache(64, 100, 100, 2, /*maxBlockRows=*/8);
+  EXPECT_EQ(readFile(path), expected(64, 100, 100, 2));
+}
+
+}  // namespace

--- a/test/epub_pipeline/StoredEntryDecodeTest.cpp
+++ b/test/epub_pipeline/StoredEntryDecodeTest.cpp
@@ -1,0 +1,164 @@
+// Decoding a PNG in place, straight out of the EPUB, when the ZIP stores it uncompressed.
+//
+// The extraction this replaces is pure copying, and on device it dominated: 857 KB at ~255 KB/s
+// = 3.36 s of the 14.93 s an uncached cover page cost, plus 857 KB written to the card. Nothing
+// has to be inflated to reach a stored entry, so the decoder can read the archive directly.
+//
+// What has to hold:
+//   1. A stored entry's reported range really is the file (offset and length both right).
+//   2. A deflated entry reports NO range -- those bytes are a DEFLATE stream, and handing them
+//      to a PNG decoder would be reading garbage.
+//   3. Decoding in place produces exactly the pixels that decoding the extracted copy does.
+//   4. ImageBlock actually takes the shortcut: the image renders and is cached WITHOUT the
+//      extracted file ever appearing on disk.
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "Epub.h"
+#include "Epub/blocks/ImageBlock.h"
+#include "Epub/converters/PngToFramebufferConverter.h"
+#include "GfxRenderer.h"
+#include "StoredZipWriter.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// The corpus book deflates every image (verified: method 8 throughout), which is exactly why it
+// cannot serve as the fixture here -- it is reused only as a convenient source of a real PNG.
+const char* kDeflatedBook = CORPUS_DIR "/test_png_images.epub";
+const char* kEntry = "OEBPS/images/scaling_test.png";
+
+struct StoredEntryFixture : testing::Test {
+  fs::path work;
+  std::string storedBook;
+  std::string cacheDir;
+  std::vector<uint8_t> pngBytes;
+  GfxRenderer renderer;
+
+  void SetUp() override {
+    work = fs::temp_directory_path() /
+           (std::string("png_stored_") + testing::UnitTest::GetInstance()->current_test_info()->name());
+    fs::remove_all(work);
+    fs::create_directories(work);
+    cacheDir = (work / "cache").string();
+    fs::create_directories(cacheDir);
+
+    // Pull a real PNG out of the (deflated) corpus book, then repack it STORED.
+    const std::string extracted = (work / "extracted.png").string();
+    Epub source(kDeflatedBook, cacheDir);
+    ASSERT_TRUE(source.extractItemToFile(kEntry, extracted, nullptr));
+    std::ifstream in(extracted, std::ios::binary);
+    pngBytes.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    ASSERT_GT(pngBytes.size(), 1000u);
+
+    test_zip::StoredZipWriter zip;
+    zip.add("mimetype", "application/epub+zip");
+    zip.add(kEntry, std::string(pngBytes.begin(), pngBytes.end()));
+    storedBook = (work / "stored.epub").string();
+    zip.write(storedBook);
+  }
+  void TearDown() override { fs::remove_all(work); }
+
+  RenderConfig configFor(const std::string& cachePath) const {
+    RenderConfig config;
+    config.x = 0;
+    config.y = 0;
+    config.maxWidth = 120;
+    config.maxHeight = 160;
+    config.useExactDimensions = true;
+    config.monochromeOutput = true;
+    config.cachePath = cachePath;
+    return config;
+  }
+
+  std::vector<uint8_t> readFile(const fs::path& p) const {
+    std::ifstream in(p.string(), std::ios::binary);
+    return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+  }
+};
+
+TEST_F(StoredEntryFixture, StoredRangePointsAtTheEntryBytes) {
+  Epub epub(storedBook, cacheDir);
+  uint32_t offset = 0;
+  uint32_t size = 0;
+  ASSERT_TRUE(epub.getStoredItemRange(kEntry, &offset, &size));
+  EXPECT_EQ(size, pngBytes.size());
+
+  std::ifstream in(storedBook, std::ios::binary);
+  in.seekg(offset);
+  std::vector<uint8_t> raw(size);
+  in.read(reinterpret_cast<char*>(raw.data()), size);
+  EXPECT_EQ(raw, pngBytes) << "the range must be the file, not a header or a neighbour";
+}
+
+// The guard that keeps this from ever being wrong: a deflated entry has no such range.
+TEST_F(StoredEntryFixture, DeflatedEntryReportsNoRange) {
+  Epub epub(kDeflatedBook, cacheDir);
+  uint32_t offset = 0;
+  uint32_t size = 0;
+  EXPECT_FALSE(epub.getStoredItemRange(kEntry, &offset, &size));
+}
+
+TEST_F(StoredEntryFixture, MissingEntryReportsNoRange) {
+  Epub epub(storedBook, cacheDir);
+  uint32_t offset = 0;
+  uint32_t size = 0;
+  EXPECT_FALSE(epub.getStoredItemRange("OEBPS/images/not_here.png", &offset, &size));
+}
+
+// The contract: reading the archive in place is indistinguishable from reading a copy of it.
+TEST_F(StoredEntryFixture, InPlaceDecodeMatchesDecodingTheExtractedCopy) {
+  const std::string standalone = (work / "standalone.png").string();
+  {
+    std::ofstream out(standalone, std::ios::binary);
+    out.write(reinterpret_cast<const char*>(pngBytes.data()), static_cast<std::streamsize>(pngBytes.size()));
+  }
+  PngToFramebufferConverter converter;
+  ASSERT_TRUE(converter.decodeToFramebuffer(standalone, renderer, configFor((work / "from_file.pxc").string())));
+
+  Epub epub(storedBook, cacheDir);
+  uint32_t offset = 0;
+  uint32_t size = 0;
+  ASSERT_TRUE(epub.getStoredItemRange(kEntry, &offset, &size));
+  FsFile archive;
+  ASSERT_TRUE(Storage.openFileForRead("TST", storedBook, archive));
+  ASSERT_TRUE(archive.seekSet(offset));
+  EXPECT_TRUE(PngToFramebufferConverter::decodeOpenFile(archive, kEntry, renderer,
+                                                        configFor((work / "in_place.pxc").string())));
+  archive.close();
+
+  const auto fromFile = readFile(work / "from_file.pxc");
+  ASSERT_FALSE(fromFile.empty());
+  EXPECT_EQ(readFile(work / "in_place.pxc"), fromFile);
+}
+
+// End to end through the caller that decides: the image must render and cache with the extracted
+// file never being created at all. That absence IS the optimisation.
+TEST_F(StoredEntryFixture, ImageBlockSkipsExtractionEntirely) {
+  const fs::path target = work / "img_lazy.png";
+  ASSERT_FALSE(fs::exists(target));
+
+  ImageBlock block(target.string(), 120, 160, "", storedBook, kEntry);
+  block.render(renderer, 0, 0, /*forceLoad=*/true, /*monochromeOutput=*/true, /*alsoCacheOtherVariant=*/true);
+
+  EXPECT_TRUE(block.hasPixelCache()) << "the BW cache should have been written";
+  EXPECT_TRUE(block.hasGrayscaleCache()) << "and the companion alongside it, from the same pass";
+  EXPECT_FALSE(fs::exists(target)) << "the whole point: no copy of the image on the card";
+}
+
+// A book that deflates the entry still works -- it just extracts, exactly as before.
+TEST_F(StoredEntryFixture, DeflatedEntryStillRendersViaExtraction) {
+  const fs::path target = work / "img_deflated.png";
+  ImageBlock block(target.string(), 120, 160, "", kDeflatedBook, kEntry);
+  block.render(renderer, 0, 0, /*forceLoad=*/true, /*monochromeOutput=*/true);
+
+  EXPECT_TRUE(block.hasPixelCache());
+  EXPECT_TRUE(fs::exists(target)) << "the fallback path must still extract";
+}
+
+}  // namespace

--- a/test/epub_pipeline/StoredZipWriter.h
+++ b/test/epub_pipeline/StoredZipWriter.h
@@ -1,0 +1,113 @@
+#pragma once
+
+// Minimal STORED-only zip writer for tests that need a purpose-shaped EPUB.
+//
+// Generated rather than checked in: several tests care about a book's SHAPE (spine sizes, note
+// counts, a reference to an entry that does not exist) and a fixture per case would be a pile of
+// binaries no one can diff. ZipFile reads method 0, so no deflater is needed here; the tests that
+// specifically need the inflate path use the corpus books instead.
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace test_zip {
+
+// --- minimal STORED-only zip writer -------------------------------------------------------
+
+class StoredZipWriter {
+ public:
+  void add(const std::string& name, const std::string& data) { entries_.push_back({name, data, 0}); }
+
+  void write(const std::string& path) {
+    std::string out;
+    for (Entry& e : entries_) {
+      e.localOffset = static_cast<uint32_t>(out.size());
+      appendLocalHeader(out, e);
+      out += e.data;
+    }
+    const uint32_t centralStart = static_cast<uint32_t>(out.size());
+    for (const Entry& e : entries_) {
+      appendCentralHeader(out, e);
+    }
+    const uint32_t centralSize = static_cast<uint32_t>(out.size()) - centralStart;
+    appendEocd(out, centralStart, centralSize, static_cast<uint16_t>(entries_.size()));
+    std::ofstream f(path, std::ios::binary);
+    f.write(out.data(), static_cast<std::streamsize>(out.size()));
+  }
+
+ private:
+  struct Entry {
+    std::string name;
+    std::string data;
+    uint32_t localOffset;
+  };
+
+  static void put16(std::string& out, const uint16_t v) {
+    out.push_back(static_cast<char>(v & 0xFF));
+    out.push_back(static_cast<char>((v >> 8) & 0xFF));
+  }
+  static void put32(std::string& out, const uint32_t v) {
+    for (int i = 0; i < 4; ++i) out.push_back(static_cast<char>((v >> (8 * i)) & 0xFF));
+  }
+  // CRC-32 is checked by nothing on the read path here, but a zero would be a lie in a file we
+  // hand to a real reader, so compute it properly.
+  static uint32_t crc32(const std::string& data) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (const unsigned char c : data) {
+      crc ^= c;
+      for (int k = 0; k < 8; ++k) crc = (crc >> 1) ^ (0xEDB88320u & (~(crc & 1u) + 1u));
+    }
+    return ~crc;
+  }
+  static void appendLocalHeader(std::string& out, const Entry& e) {
+    put32(out, 0x04034B50);
+    put16(out, 20);  // version needed
+    put16(out, 0);   // flags
+    put16(out, 0);   // method: stored
+    put16(out, 0);   // time
+    put16(out, 0);   // date
+    put32(out, crc32(e.data));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put16(out, static_cast<uint16_t>(e.name.size()));
+    put16(out, 0);
+    out += e.name;
+  }
+  static void appendCentralHeader(std::string& out, const Entry& e) {
+    put32(out, 0x02014B50);
+    put16(out, 20);  // version made by
+    put16(out, 20);  // version needed
+    put16(out, 0);
+    put16(out, 0);  // method: stored
+    put16(out, 0);
+    put16(out, 0);
+    put32(out, crc32(e.data));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put32(out, static_cast<uint32_t>(e.data.size()));
+    put16(out, static_cast<uint16_t>(e.name.size()));
+    put16(out, 0);  // extra
+    put16(out, 0);  // comment
+    put16(out, 0);  // disk
+    put16(out, 0);  // internal attrs
+    put32(out, 0);  // external attrs
+    put32(out, e.localOffset);
+    out += e.name;
+  }
+  static void appendEocd(std::string& out, const uint32_t centralStart, const uint32_t centralSize,
+                         const uint16_t entryCount) {
+    put32(out, 0x06054B50);
+    put16(out, 0);  // disk number
+    put16(out, 0);  // disk with central dir
+    put16(out, entryCount);
+    put16(out, entryCount);
+    put32(out, centralSize);
+    put32(out, centralStart);
+    put16(out, 0);  // comment length
+  }
+
+  std::vector<Entry> entries_;
+};
+
+}  // namespace test_zip

--- a/test/epub_pipeline/goldens/test_display_none.golden.txt
+++ b/test/epub_pipeline/goldens/test_display_none.golden.txt
@@ -652,7 +652,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=111 s=0 z=100 t=should
    W x=178 s=0 z=100 t=be
    W x=199 s=0 z=100 t=visible:
-  IMG y=168 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_9_d90fc326_0.png
+  IMG y=168 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_93fa3023e1d69067.png
   LINE y=248 x=0 align=0 mult=1.000 hfid=0 words=8
    W x=18 s=0 z=100 t=If
    W x=51 s=0 z=100 t=you
@@ -815,7 +815,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=0 s=0 z=100 t=It
    W x=25 s=0 z=100 t=SHOULD
    W x=89 s=0 z=100 t=appear:
-  IMG y=236 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_9_d90fc326_1.png
+  IMG y=236 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_de279f00d41522d8.png
   LINE y=316 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=If
    W x=45 s=0 z=100 t=the
@@ -850,7 +850,7 @@ SPINE 10 href=OEBPS/chapter11.xhtml pages=1 truncated=0 cssFallback=0
    W x=18 s=0 z=100 t=Visible
    W x=77 s=0 z=100 t=text
    W x=119 s=0 z=100 t=1
-  IMG y=86 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_10_d90fc326_0.png
+  IMG y=86 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_93fa3023e1d69067.png
   LINE y=166 x=0 align=0 mult=1.000 hfid=0 words=3
    W x=18 s=0 z=100 t=Visible
    W x=77 s=0 z=100 t=text

--- a/test/epub_pipeline/goldens/test_display_none_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_display_none_norm.golden.txt
@@ -652,7 +652,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=111 s=0 z=100 t=should
    W x=178 s=0 z=100 t=be
    W x=199 s=0 z=100 t=visible:
-  IMG y=168 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_9_c5e4922f_0.png
+  IMG y=168 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_93fa3023e1d69067.png
   LINE y=248 x=0 align=0 mult=1.000 hfid=0 words=8
    W x=18 s=0 z=100 t=If
    W x=51 s=0 z=100 t=you
@@ -815,7 +815,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=0 s=0 z=100 t=It
    W x=25 s=0 z=100 t=SHOULD
    W x=89 s=0 z=100 t=appear:
-  IMG y=236 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_9_c5e4922f_1.png
+  IMG y=236 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_de279f00d41522d8.png
   LINE y=316 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=If
    W x=45 s=0 z=100 t=the
@@ -850,7 +850,7 @@ SPINE 10 href=OEBPS/chapter11.xhtml pages=1 truncated=0 cssFallback=0
    W x=18 s=0 z=100 t=Visible
    W x=77 s=0 z=100 t=text
    W x=119 s=0 z=100 t=1
-  IMG y=86 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_10_c5e4922f_0.png
+  IMG y=86 x=170 w=120 h=80 src=<cache>/epub_<hash>/img_93fa3023e1d69067.png
   LINE y=166 x=0 align=0 mult=1.000 hfid=0 words=3
    W x=18 s=0 z=100 t=Visible
    W x=77 s=0 z=100 t=text

--- a/test/epub_pipeline/goldens/test_float_images.golden.txt
+++ b/test/epub_pipeline/goldens/test_float_images.golden.txt
@@ -23,7 +23,7 @@ SPINE 0 href=OEBPS/ch1.xhtml pages=1 truncated=0 cssFallback=0
    W x=93 s=0 z=100 t=full-width
    W x=189 s=0 z=100 t=below
    W x=237 s=0 z=100 t=it.
-  IMG y=82 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_0_d90fc326_0.png
+  IMG y=82 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=82 x=64 align=0 mult=1.000 hfid=0 words=9
    W x=0 s=0 z=100 t=The
    W x=35 s=0 z=100 t=quick
@@ -108,7 +108,7 @@ SPINE 1 href=OEBPS/ch2.xhtml pages=1 truncated=0 cssFallback=0
   LINE y=92 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=0 s=0 z=100 t=image
    W x=54 s=0 z=100 t=height.
-  IMG y=116 x=0 w=60 h=120 src=<cache>/epub_<hash>/img_1_d90fc326_0.png
+  IMG y=116 x=0 w=60 h=120 src=<cache>/epub_<hash>/img_457ac3ad1233ac55.png
   LINE y=116 x=64 align=0 mult=1.000 hfid=0 words=6
    W x=0 s=0 z=100 t=Short
    W x=65 s=0 z=100 t=paragraph
@@ -140,7 +140,7 @@ SPINE 2 href=OEBPS/ch3.xhtml pages=1 truncated=0 cssFallback=0
   LINE y=58 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=0 s=0 z=100 t=beside
    W x=53 s=0 z=100 t=image.
-  IMG y=82 x=400 w=60 h=60 src=<cache>/epub_<hash>/img_2_d90fc326_0.png
+  IMG y=82 x=400 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=82 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=0 s=0 z=100 t=The
    W x=35 s=0 z=100 t=quick
@@ -277,7 +277,7 @@ SPINE 3 href=OEBPS/ch4.xhtml pages=1 truncated=0 cssFallback=0
    W x=225 s=0 z=100 t=the
    W x=262 s=0 z=100 t=lazy
    W x=306 s=0 z=100 t=dog.
-  IMG y=212 x=200 w=60 h=60 src=<cache>/epub_<hash>/img_3_d90fc326_0.png
+  IMG y=212 x=200 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=272 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=Text
    W x=60 s=0 z=100 t=after
@@ -365,7 +365,7 @@ SPINE 4 href=OEBPS/ch5.xhtml pages=1 truncated=0 cssFallback=0
    W x=412 s=0 z=100 t=image
   LINE y=82 x=0 align=0 mult=1.000 hfid=0 words=1
    W x=0 s=0 z=100 t=bottom.
-  IMG y=106 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_4_d90fc326_0.png
+  IMG y=106 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=106 x=64 align=0 mult=1.000 hfid=0 words=5
    W x=0 s=0 z=100 t=Paragraph
    W x=96 s=0 z=100 t=A
@@ -461,7 +461,7 @@ SPINE 5 href=OEBPS/ch6.xhtml pages=1 truncated=0 cssFallback=0
    W x=160 s=0 z=100 t=and
    W x=197 s=0 z=100 t=taller
    W x=260 s=0 z=100 t=(margin-bottom=8).
-  IMG y=116 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_5_d90fc326_0.png
+  IMG y=116 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=116 x=64 align=0 mult=1.000 hfid=0 words=9
    W x=0 s=0 z=100 t=The
    W x=35 s=0 z=100 t=quick
@@ -910,7 +910,7 @@ SPINE 6 href=OEBPS/ch7.xhtml pages=2 truncated=0 cssFallback=0
    W x=96 s=0 z=100 t=the
    W x=133 s=0 z=100 t=lazy
    W x=177 s=0 z=100 t=dog.
-  IMG y=192 x=0 w=60 h=100 src=<cache>/epub_<hash>/img_6_d90fc326_0.png
+  IMG y=192 x=0 w=60 h=100 src=<cache>/epub_<hash>/img_8f6a7b869ca569cf.png
   LINE y=192 x=64 align=0 mult=1.000 hfid=0 words=7
    W x=0 s=0 z=100 t=This
    W x=39 s=0 z=100 t=paragraph

--- a/test/epub_pipeline/goldens/test_float_images_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_float_images_norm.golden.txt
@@ -23,7 +23,7 @@ SPINE 0 href=OEBPS/ch1.xhtml pages=1 truncated=0 cssFallback=0
    W x=93 s=0 z=100 t=full-width
    W x=189 s=0 z=100 t=below
    W x=237 s=0 z=100 t=it.
-  IMG y=82 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_0_c5e4922f_0.png
+  IMG y=82 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=82 x=64 align=0 mult=1.000 hfid=0 words=9
    W x=0 s=0 z=100 t=The
    W x=35 s=0 z=100 t=quick
@@ -108,7 +108,7 @@ SPINE 1 href=OEBPS/ch2.xhtml pages=1 truncated=0 cssFallback=0
   LINE y=92 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=0 s=0 z=100 t=image
    W x=54 s=0 z=100 t=height.
-  IMG y=116 x=0 w=60 h=120 src=<cache>/epub_<hash>/img_1_c5e4922f_0.png
+  IMG y=116 x=0 w=60 h=120 src=<cache>/epub_<hash>/img_457ac3ad1233ac55.png
   LINE y=116 x=64 align=0 mult=1.000 hfid=0 words=6
    W x=0 s=0 z=100 t=Short
    W x=65 s=0 z=100 t=paragraph
@@ -140,7 +140,7 @@ SPINE 2 href=OEBPS/ch3.xhtml pages=1 truncated=0 cssFallback=0
   LINE y=58 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=0 s=0 z=100 t=beside
    W x=53 s=0 z=100 t=image.
-  IMG y=82 x=400 w=60 h=60 src=<cache>/epub_<hash>/img_2_c5e4922f_0.png
+  IMG y=82 x=400 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=82 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=0 s=0 z=100 t=The
    W x=35 s=0 z=100 t=quick
@@ -277,7 +277,7 @@ SPINE 3 href=OEBPS/ch4.xhtml pages=1 truncated=0 cssFallback=0
    W x=225 s=0 z=100 t=the
    W x=262 s=0 z=100 t=lazy
    W x=306 s=0 z=100 t=dog.
-  IMG y=212 x=200 w=60 h=60 src=<cache>/epub_<hash>/img_3_c5e4922f_0.png
+  IMG y=212 x=200 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=272 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=Text
    W x=60 s=0 z=100 t=after
@@ -365,7 +365,7 @@ SPINE 4 href=OEBPS/ch5.xhtml pages=1 truncated=0 cssFallback=0
    W x=412 s=0 z=100 t=image
   LINE y=82 x=0 align=0 mult=1.000 hfid=0 words=1
    W x=0 s=0 z=100 t=bottom.
-  IMG y=106 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_4_c5e4922f_0.png
+  IMG y=106 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=106 x=64 align=0 mult=1.000 hfid=0 words=5
    W x=0 s=0 z=100 t=Paragraph
    W x=96 s=0 z=100 t=A
@@ -461,7 +461,7 @@ SPINE 5 href=OEBPS/ch6.xhtml pages=1 truncated=0 cssFallback=0
    W x=160 s=0 z=100 t=and
    W x=197 s=0 z=100 t=taller
    W x=260 s=0 z=100 t=(margin-bottom=8).
-  IMG y=116 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_5_c5e4922f_0.png
+  IMG y=116 x=0 w=60 h=60 src=<cache>/epub_<hash>/img_23eff0a817c99d9d.png
   LINE y=116 x=64 align=0 mult=1.000 hfid=0 words=9
    W x=0 s=0 z=100 t=The
    W x=35 s=0 z=100 t=quick
@@ -910,7 +910,7 @@ SPINE 6 href=OEBPS/ch7.xhtml pages=2 truncated=0 cssFallback=0
    W x=96 s=0 z=100 t=the
    W x=133 s=0 z=100 t=lazy
    W x=177 s=0 z=100 t=dog.
-  IMG y=192 x=0 w=60 h=100 src=<cache>/epub_<hash>/img_6_c5e4922f_0.png
+  IMG y=192 x=0 w=60 h=100 src=<cache>/epub_<hash>/img_8f6a7b869ca569cf.png
   LINE y=192 x=64 align=0 mult=1.000 hfid=0 words=7
    W x=0 s=0 z=100 t=This
    W x=39 s=0 z=100 t=paragraph

--- a/test/epub_pipeline/goldens/test_jpeg_images.golden.txt
+++ b/test/epub_pipeline/goldens/test_jpeg_images.golden.txt
@@ -70,7 +70,7 @@ SPINE 1 href=OEBPS/chapter2.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=baseline
    W x=232 s=0 z=100 t=JPEG
    W x=276 s=0 z=100 t=encoding.
-  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_1_d90fc326_0.jpg
+  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_8baf343f5e8b08fd.jpg
   LINE y=336 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=If
    W x=43 s=0 z=100 t=the
@@ -101,7 +101,7 @@ SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=86 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_2_d90fc326_0.jpg
+  IMG y=86 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_4dc41aaea588d9dd.jpg
 SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -121,7 +121,7 @@ SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=86 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_3_d90fc326_0.jpg
+  IMG y=86 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_c035d364d19f59d0.jpg
 SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -133,7 +133,7 @@ SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
    W x=127 s=0 z=100 t=is
    W x=148 s=0 z=100 t=centered
    W x=225 s=0 z=100 t=horizontally.
-  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_4_d90fc326_0.jpg
+  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_7d335759789761dd.jpg
 SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=6 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -166,7 +166,7 @@ SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=134 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_5_d90fc326_0.jpg
+  IMG y=134 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_ba6e9d7c0cb676d3.jpg
 SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=7 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=3
@@ -203,7 +203,7 @@ SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=158 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_6_d90fc326_0.jpg
+  IMG y=158 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_5d6843c96ce24d3b.jpg
 SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=5
@@ -221,7 +221,7 @@ SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
    W x=258 s=0 z=100 t=the
    W x=295 s=0 z=100 t=load
    W x=342 s=0 z=100 t=time.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_7_d90fc326_0.jpg
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_d33cb139ebd3c246.jpg
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=7
    W x=18 s=0 z=100 t=Navigate
    W x=103 s=0 z=100 t=to
@@ -243,7 +243,7 @@ SPINE 8 href=OEBPS/chapter9.xhtml pages=1 truncated=0 cssFallback=0
    W x=83 s=0 z=100 t=cache
    W x=136 s=0 z=100 t=test
    W x=180 s=0 z=100 t=page.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_8_d90fc326_0.jpg
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_7824f6217c963bcf.jpg
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=10
    W x=18 s=0 z=100 t=Navigate
    W x=105 s=0 z=100 t=back
@@ -306,7 +306,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=0 s=0 z=100 t=justified,
    W x=90 s=0 z=100 t=not
    W x=129 s=0 z=100 t=centered.
-  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_9_d90fc326_0.jpg
+  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_7d335759789761dd.jpg
   LINE y=582 x=0 align=0 mult=1.000 hfid=0 words=6
    W x=18 s=0 z=100 t=FIRST
    W x=80 s=0 z=100 t=PARAGRAPH

--- a/test/epub_pipeline/goldens/test_jpeg_images_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_jpeg_images_norm.golden.txt
@@ -70,7 +70,7 @@ SPINE 1 href=OEBPS/chapter2.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=baseline
    W x=232 s=0 z=100 t=JPEG
    W x=276 s=0 z=100 t=encoding.
-  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_1_c5e4922f_0.jpg
+  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_8baf343f5e8b08fd.jpg
   LINE y=336 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=If
    W x=43 s=0 z=100 t=the
@@ -101,7 +101,7 @@ SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=86 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_2_c5e4922f_0.jpg
+  IMG y=86 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_4dc41aaea588d9dd.jpg
 SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -121,7 +121,7 @@ SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=86 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_3_c5e4922f_0.jpg
+  IMG y=86 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_c035d364d19f59d0.jpg
 SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -133,7 +133,7 @@ SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
    W x=127 s=0 z=100 t=is
    W x=148 s=0 z=100 t=centered
    W x=225 s=0 z=100 t=horizontally.
-  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_4_c5e4922f_0.jpg
+  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_7d335759789761dd.jpg
 SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=6 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -166,7 +166,7 @@ SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=134 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_5_c5e4922f_0.jpg
+  IMG y=134 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_ba6e9d7c0cb676d3.jpg
 SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=7 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=3
@@ -203,7 +203,7 @@ SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=progressive
    W x=260 s=0 z=100 t=JPEG
    W x=304 s=0 z=100 t=encoding.
-  IMG y=158 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_6_c5e4922f_0.jpg
+  IMG y=158 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_5d6843c96ce24d3b.jpg
 SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=5
@@ -221,7 +221,7 @@ SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
    W x=258 s=0 z=100 t=the
    W x=295 s=0 z=100 t=load
    W x=342 s=0 z=100 t=time.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_7_c5e4922f_0.jpg
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_d33cb139ebd3c246.jpg
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=7
    W x=18 s=0 z=100 t=Navigate
    W x=103 s=0 z=100 t=to
@@ -243,7 +243,7 @@ SPINE 8 href=OEBPS/chapter9.xhtml pages=1 truncated=0 cssFallback=0
    W x=83 s=0 z=100 t=cache
    W x=136 s=0 z=100 t=test
    W x=180 s=0 z=100 t=page.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_8_c5e4922f_0.jpg
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_7824f6217c963bcf.jpg
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=10
    W x=18 s=0 z=100 t=Navigate
    W x=105 s=0 z=100 t=back
@@ -306,7 +306,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=0 s=0 z=100 t=justified,
    W x=90 s=0 z=100 t=not
    W x=129 s=0 z=100 t=centered.
-  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_9_c5e4922f_0.jpg
+  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_7d335759789761dd.jpg
   LINE y=582 x=0 align=0 mult=1.000 hfid=0 words=6
    W x=18 s=0 z=100 t=FIRST
    W x=80 s=0 z=100 t=PARAGRAPH

--- a/test/epub_pipeline/goldens/test_kerning_ligature.golden.txt
+++ b/test/epub_pipeline/goldens/test_kerning_ligature.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Kerning & Ligature Edge Cases lang=en spine=13 toc=11 reliableToc=1
 SPINE 0 href=OEBPS/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_0_d90fc326_0.jpg
+  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_91f282312742c715.jpg
 SPINE 1 href=OEBPS/toc.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=13 footnotes=11
   LINE y=0 x=0 align=2 mult=1.500 hfid=0 words=5

--- a/test/epub_pipeline/goldens/test_kerning_ligature_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_kerning_ligature_norm.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Kerning & Ligature Edge Cases lang=en spine=13 toc=11 reliableToc=1
 SPINE 0 href=OEBPS/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_0_c5e4922f_0.jpg
+  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_91f282312742c715.jpg
 SPINE 1 href=OEBPS/toc.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=13 footnotes=11
   LINE y=0 x=0 align=2 mult=1.500 hfid=0 words=5

--- a/test/epub_pipeline/goldens/test_mixed_images.golden.txt
+++ b/test/epub_pipeline/goldens/test_mixed_images.golden.txt
@@ -46,7 +46,7 @@ SPINE 1 href=OEBPS/chapter2.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=baseline
    W x=232 s=0 z=100 t=JPEG
    W x=276 s=0 z=100 t=encoding.
-  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_1_d90fc326_0.jpg
+  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_8baf343f5e8b08fd.jpg
 SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=4
@@ -60,7 +60,7 @@ SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
    W x=78 s=0 z=100 t=a
    W x=96 s=0 z=100 t=PNG
    W x=125 s=0 z=100 t=image:
-  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_2_d90fc326_0.png
+  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_7c9e21097dc96b96.png
 SPINE 3 href=OEBPS/chapter4.xhtml pages=2 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=5
@@ -73,12 +73,12 @@ SPINE 3 href=OEBPS/chapter4.xhtml pages=2 truncated=0 cssFallback=0
    W x=18 s=0 z=100 t=Progressive
    W x=126 s=0 z=100 t=JPEG
    W x=170 s=0 z=100 t=image:
-  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_3_d90fc326_0.jpg
+  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_4dc41aaea588d9dd.jpg
   LINE y=662 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=18 s=0 z=100 t=PNG
    W x=47 s=0 z=100 t=image:
  PAGE 1 elements=2 footnotes=0
-  IMG y=0 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_3_d90fc326_1.png
+  IMG y=0 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_9190b4ae3b9b566d.png
   LINE y=600 x=0 align=0 mult=1.000 hfid=0 words=6
    W x=18 s=0 z=100 t=Both
    W x=67 s=0 z=100 t=should

--- a/test/epub_pipeline/goldens/test_mixed_images_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_mixed_images_norm.golden.txt
@@ -46,7 +46,7 @@ SPINE 1 href=OEBPS/chapter2.xhtml pages=1 truncated=0 cssFallback=0
    W x=155 s=0 z=100 t=baseline
    W x=232 s=0 z=100 t=JPEG
    W x=276 s=0 z=100 t=encoding.
-  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_1_c5e4922f_0.jpg
+  IMG y=86 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_8baf343f5e8b08fd.jpg
 SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=4
@@ -60,7 +60,7 @@ SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
    W x=78 s=0 z=100 t=a
    W x=96 s=0 z=100 t=PNG
    W x=125 s=0 z=100 t=image:
-  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_2_c5e4922f_0.png
+  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_7c9e21097dc96b96.png
 SPINE 3 href=OEBPS/chapter4.xhtml pages=2 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=5
@@ -73,12 +73,12 @@ SPINE 3 href=OEBPS/chapter4.xhtml pages=2 truncated=0 cssFallback=0
    W x=18 s=0 z=100 t=Progressive
    W x=126 s=0 z=100 t=JPEG
    W x=170 s=0 z=100 t=image:
-  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_3_c5e4922f_0.jpg
+  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_4dc41aaea588d9dd.jpg
   LINE y=662 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=18 s=0 z=100 t=PNG
    W x=47 s=0 z=100 t=image:
  PAGE 1 elements=2 footnotes=0
-  IMG y=0 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_3_c5e4922f_1.png
+  IMG y=0 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_9190b4ae3b9b566d.png
   LINE y=600 x=0 align=0 mult=1.000 hfid=0 words=6
    W x=18 s=0 z=100 t=Both
    W x=67 s=0 z=100 t=should

--- a/test/epub_pipeline/goldens/test_png_images.golden.txt
+++ b/test/epub_pipeline/goldens/test_png_images.golden.txt
@@ -57,7 +57,7 @@ SPINE 1 href=OEBPS/chapter2.xhtml pages=1 truncated=0 cssFallback=0
    W x=67 s=0 z=100 t=PNG
    W x=96 s=0 z=100 t=decoding
    W x=174 s=0 z=100 t=test.
-  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_1_d90fc326_0.png
+  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_7c9e21097dc96b96.png
   LINE y=312 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=If
    W x=51 s=0 z=100 t=the
@@ -86,7 +86,7 @@ SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
    W x=206 s=0 z=100 t=levels
    W x=269 s=0 z=100 t=are
    W x=304 s=0 z=100 t=visible.
-  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_2_d90fc326_0.png
+  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_9190b4ae3b9b566d.png
 SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -99,7 +99,7 @@ SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
    W x=244 s=0 z=100 t=to
    W x=272 s=0 z=100 t=4
    W x=287 s=0 z=100 t=bands.
-  IMG y=62 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_3_d90fc326_0.png
+  IMG y=62 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_f5e7c964f08573fc.png
 SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -111,7 +111,7 @@ SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
    W x=127 s=0 z=100 t=is
    W x=148 s=0 z=100 t=centered
    W x=225 s=0 z=100 t=horizontally.
-  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_4_d90fc326_0.png
+  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_c0fff1590ea9de6d.png
 SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=5 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -137,7 +137,7 @@ SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
    W x=191 s=0 z=100 t=down
    W x=234 s=0 z=100 t=to
    W x=262 s=0 z=100 t=fit.
-  IMG y=110 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_5_d90fc326_0.png
+  IMG y=110 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_76bd337c76bb138b.png
 SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=6 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=3
@@ -167,7 +167,7 @@ SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
   LINE y=110 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=0 s=0 z=100 t=cache
    W x=53 s=0 z=100 t=mismatches.
-  IMG y=134 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_6_d90fc326_0.png
+  IMG y=134 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_7d1fe9c8ee1cf9d3.png
 SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=5
@@ -185,7 +185,7 @@ SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
    W x=258 s=0 z=100 t=the
    W x=295 s=0 z=100 t=load
    W x=342 s=0 z=100 t=time.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_7_d90fc326_0.png
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_2a264b3a1d234812.png
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=7
    W x=18 s=0 z=100 t=Navigate
    W x=103 s=0 z=100 t=to
@@ -207,7 +207,7 @@ SPINE 8 href=OEBPS/chapter9.xhtml pages=1 truncated=0 cssFallback=0
    W x=83 s=0 z=100 t=cache
    W x=136 s=0 z=100 t=test
    W x=180 s=0 z=100 t=page.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_8_d90fc326_0.png
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_21b53c214baddbdf.png
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=10
    W x=18 s=0 z=100 t=Navigate
    W x=105 s=0 z=100 t=back
@@ -270,7 +270,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=0 s=0 z=100 t=justified,
    W x=90 s=0 z=100 t=not
    W x=129 s=0 z=100 t=centered.
-  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_9_d90fc326_0.png
+  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_c0fff1590ea9de6d.png
   LINE y=582 x=0 align=0 mult=1.000 hfid=0 words=6
    W x=18 s=0 z=100 t=FIRST
    W x=80 s=0 z=100 t=PARAGRAPH

--- a/test/epub_pipeline/goldens/test_png_images_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_png_images_norm.golden.txt
@@ -57,7 +57,7 @@ SPINE 1 href=OEBPS/chapter2.xhtml pages=1 truncated=0 cssFallback=0
    W x=67 s=0 z=100 t=PNG
    W x=96 s=0 z=100 t=decoding
    W x=174 s=0 z=100 t=test.
-  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_1_c5e4922f_0.png
+  IMG y=62 x=55 w=350 h=250 src=<cache>/epub_<hash>/img_7c9e21097dc96b96.png
   LINE y=312 x=0 align=0 mult=1.000 hfid=0 words=9
    W x=18 s=0 z=100 t=If
    W x=51 s=0 z=100 t=the
@@ -86,7 +86,7 @@ SPINE 2 href=OEBPS/chapter3.xhtml pages=1 truncated=0 cssFallback=0
    W x=206 s=0 z=100 t=levels
    W x=269 s=0 z=100 t=are
    W x=304 s=0 z=100 t=visible.
-  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_2_c5e4922f_0.png
+  IMG y=62 x=30 w=400 h=600 src=<cache>/epub_<hash>/img_9190b4ae3b9b566d.png
 SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -99,7 +99,7 @@ SPINE 3 href=OEBPS/chapter4.xhtml pages=1 truncated=0 cssFallback=0
    W x=244 s=0 z=100 t=to
    W x=272 s=0 z=100 t=4
    W x=287 s=0 z=100 t=bands.
-  IMG y=62 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_3_c5e4922f_0.png
+  IMG y=62 x=30 w=400 h=500 src=<cache>/epub_<hash>/img_f5e7c964f08573fc.png
 SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=3 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -111,7 +111,7 @@ SPINE 4 href=OEBPS/chapter5.xhtml pages=1 truncated=0 cssFallback=0
    W x=127 s=0 z=100 t=is
    W x=148 s=0 z=100 t=centered
    W x=225 s=0 z=100 t=horizontally.
-  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_4_c5e4922f_0.png
+  IMG y=62 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_c0fff1590ea9de6d.png
 SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=5 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=2
@@ -137,7 +137,7 @@ SPINE 5 href=OEBPS/chapter6.xhtml pages=1 truncated=0 cssFallback=0
    W x=191 s=0 z=100 t=down
    W x=234 s=0 z=100 t=to
    W x=262 s=0 z=100 t=fit.
-  IMG y=110 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_5_c5e4922f_0.png
+  IMG y=110 x=0 w=460 h=575 src=<cache>/epub_<hash>/img_76bd337c76bb138b.png
 SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=6 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=3
@@ -167,7 +167,7 @@ SPINE 6 href=OEBPS/chapter7.xhtml pages=1 truncated=0 cssFallback=0
   LINE y=110 x=0 align=0 mult=1.000 hfid=0 words=2
    W x=0 s=0 z=100 t=cache
    W x=53 s=0 z=100 t=mismatches.
-  IMG y=134 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_6_c5e4922f_0.png
+  IMG y=134 x=0 w=459 h=187 src=<cache>/epub_<hash>/img_7d1fe9c8ee1cf9d3.png
 SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=4 footnotes=0
   LINE y=0 x=0 align=2 mult=1.600 hfid=0 words=5
@@ -185,7 +185,7 @@ SPINE 7 href=OEBPS/chapter8.xhtml pages=1 truncated=0 cssFallback=0
    W x=258 s=0 z=100 t=the
    W x=295 s=0 z=100 t=load
    W x=342 s=0 z=100 t=time.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_7_c5e4922f_0.png
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_2a264b3a1d234812.png
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=7
    W x=18 s=0 z=100 t=Navigate
    W x=103 s=0 z=100 t=to
@@ -207,7 +207,7 @@ SPINE 8 href=OEBPS/chapter9.xhtml pages=1 truncated=0 cssFallback=0
    W x=83 s=0 z=100 t=cache
    W x=136 s=0 z=100 t=test
    W x=180 s=0 z=100 t=page.
-  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_8_c5e4922f_0.png
+  IMG y=62 x=30 w=400 h=300 src=<cache>/epub_<hash>/img_21b53c214baddbdf.png
   LINE y=362 x=0 align=0 mult=1.000 hfid=0 words=10
    W x=18 s=0 z=100 t=Navigate
    W x=105 s=0 z=100 t=back
@@ -270,7 +270,7 @@ SPINE 9 href=OEBPS/chapter10.xhtml pages=2 truncated=0 cssFallback=0
    W x=0 s=0 z=100 t=justified,
    W x=90 s=0 z=100 t=not
    W x=129 s=0 z=100 t=centered.
-  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_9_c5e4922f_0.png
+  IMG y=182 x=55 w=350 h=400 src=<cache>/epub_<hash>/img_c0fff1590ea9de6d.png
   LINE y=582 x=0 align=0 mult=1.000 hfid=0 words=6
    W x=18 s=0 z=100 t=FIRST
    W x=80 s=0 z=100 t=PARAGRAPH

--- a/test/epub_pipeline/goldens/test_spine_toc_edges.golden.txt
+++ b/test/epub_pipeline/goldens/test_spine_toc_edges.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Spine & Anchor: A Nautical Misadventure lang=en spine=14 toc=20 reliableToc=1
 SPINE 0 href=OEBPS/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_0_d90fc326_0.jpg
+  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_91f282312742c715.jpg
 SPINE 1 href=OEBPS/toc.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=21 footnotes=16
   LINE y=0 x=0 align=2 mult=1.500 hfid=0 words=3

--- a/test/epub_pipeline/goldens/test_spine_toc_edges_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_spine_toc_edges_norm.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Spine & Anchor: A Nautical Misadventure lang=en spine=14 toc=20 reliableToc=1
 SPINE 0 href=OEBPS/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_0_c5e4922f_0.jpg
+  IMG y=0 x=0 w=460 h=686 src=<cache>/epub_<hash>/img_91f282312742c715.jpg
 SPINE 1 href=OEBPS/toc.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=21 footnotes=16
   LINE y=0 x=0 align=2 mult=1.500 hfid=0 words=3

--- a/test/epub_pipeline/goldens/test_table_streaming.golden.txt
+++ b/test/epub_pipeline/goldens/test_table_streaming.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Table streaming fallbacks lang=en-US spine=4 toc=2 reliableToc=1
 SPINE 0 href=EPUB/text/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_0_d90fc326_0.png
+  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_07b22faa91ec6d21.png
 SPINE 1 href=EPUB/text/title_page.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=2 footnotes=0
   LINE y=54 x=0 align=2 mult=2.000 hfid=0 words=3

--- a/test/epub_pipeline/goldens/test_table_streaming_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_table_streaming_norm.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Table streaming fallbacks lang=en-US spine=4 toc=2 reliableToc=1
 SPINE 0 href=EPUB/text/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_0_c5e4922f_0.png
+  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_07b22faa91ec6d21.png
 SPINE 1 href=EPUB/text/title_page.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=2 footnotes=0
   LINE y=54 x=0 align=2 mult=2.000 hfid=0 words=3

--- a/test/epub_pipeline/goldens/test_tables.golden.txt
+++ b/test/epub_pipeline/goldens/test_tables.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Tables? In CrossPoint? lang=en-US spine=4 toc=2 reliableToc=1
 SPINE 0 href=EPUB/text/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_0_d90fc326_0.png
+  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_07b22faa91ec6d21.png
 SPINE 1 href=EPUB/text/title_page.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=2 footnotes=0
   LINE y=54 x=0 align=2 mult=2.000 hfid=0 words=3

--- a/test/epub_pipeline/goldens/test_tables_norm.golden.txt
+++ b/test/epub_pipeline/goldens/test_tables_norm.golden.txt
@@ -1,7 +1,7 @@
 BOOK title=Tables? In CrossPoint? lang=en-US spine=4 toc=2 reliableToc=1
 SPINE 0 href=EPUB/text/cover.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=1 footnotes=0
-  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_0_c5e4922f_0.png
+  IMG y=0 x=2 w=456 h=760 src=<cache>/epub_<hash>/img_07b22faa91ec6d21.png
 SPINE 1 href=EPUB/text/title_page.xhtml pages=1 truncated=0 cssFallback=0
  PAGE 0 elements=2 footnotes=0
   LINE y=54 x=0 align=2 mult=2.000 hfid=0 words=3


### PR DESCRIPTION
Opening a cover page took **35 seconds** on X4. Almost none of it was spent decoding anything — it was work the pipeline had already done, or was about to do again, or was doing one file-write at a time. Every number below is device-measured on X4, and each round of measurement changed what the next commit was.

| | before | after |
|---|---|---|
| cover page, first open (placeholder) | 35056 ms | **1983 ms** |
| same cover, forced decode (`prewarmMs`) | 32752 ms | **8501 ms** |
| PNG decode producing both pixel caches | 11573 ms | **5089 ms** |
| cold home screen, 5 books | 27.9 s | **25.2 s** |
| redundant `content.opf` parses per home load | ~3319 ms | **595 ms** |

## Work that was simply being repeated

**The large-image placeholder never fired** (`30ec6b796`). `isLargeImage()` compared **display** dimensions against 800×600, but the panel is 480×800 — the test could not be true in either orientation, for any book. Both the setting's text and the function's own comment said "source pixels". It now answers on source bytes (extracted file, else the ZIP entry), threshold 256 KB.

**Adaptive tone cost a whole extra inflate** (`b627ff122`). In-book images never had their own setting — the reader borrowed `sleepScreenCoverFilter`, so a sleep-screen toggle silently levelled every picture in every book. The curve needs a completed histogram and a PNG cannot be rewound, so that was a second full pass (~4.0 s). Unhooked; the sleep screen keeps the feature and pays it once per wake. This is also what made the next commit possible.

**Both pixel caches now come from one inflate** (`0efd10526`). The reader needs `.1bit.pxc` and `.bayer.pxc`; it used to decode the source twice. Same format, same samples, and — since tone is gone — the same tone, so they differ only in ditherer. The companion sink is nearly free: the 4-level Bayer is stateless, so the cost is one extra `PixelCache` band, ~2 KB.

**The indexing popup was painted for builds that didn't need one** (`5563a5bb1`). `buildSection()` painted it, *then* ran the kickoff slice — which frequently finishes the whole section (309 ms for a one-page cover). The popup cost a ~540 ms refresh for a frame the next render replaced, and it is also what made that render expensive: a dark box the content page must diff against, which is the entire reason for the ~1.7 s HALF armed alongside it. The kickoff now runs first, and `renderSectionBuildingPass()` paints the popup only if more slices are needed — which it already did.

**Cover metadata was re-derived 3-5× per book** (`c0e076a17`). `loadForCover()` parses `content.opf` whenever `book.bin` is absent, and the home screen asks the same book repeatedly: try the thumb, check `cover.img`, start the extract, then once per thumb size. One Cyrillic book paid 5 × 301 ms. A one-entry memo covers it, keyed by path **and** file size so a replaced book can't serve a stale cover.

**Extracted images were keyed by layout** (`3e213390f`). `img_<spine>_<propertyHash>_<n>` put the section's layout hash in the *source* image's filename — but those are the archive entry's bytes; only the `.pxc` depends on layout. So every font-size or margin change re-extracted every image (3.3 s and 857 KB for this cover), with up to five byte-identical copies alive at once. Now keyed on the entry path.

## Small writes, everywhere

The recurring theme, and the one I kept underestimating. `BufferedFileIO.h` already documents a bare `FsFile` call at ~1.5 ms whatever its size; sub-sector writes are worse, because the driver reads the sector back first. Measured through `PixelCache`, a 116-byte write ran **~3.7 ms**.

- **the extract** wrote 512 bytes at a time — 1,675 single-sector writes for an 857 KB cover, ~50 KB/s against ~215 KB/s reading the same file back (`5014c9c2d`). Now 4 KB, from the borrow arena when there is one. **~17 s → ~3.3 s.**
- **`PixelCache`** flushed on every `advanceTo()`, and the PNG decoder calls it once per row: **618 separate 116-byte writes** per cache, plus a band memset each time. Rows now accumulate and go out a band at a time — no extra memory, just 39 calls instead of 618 (`045be9063`). **8123 ms → 5067 ms.**
- **every BMP writer** emitted one write per output row. A 1-bit 340×540 thumbnail is 44 bytes a row, so ~540 calls; both thumbnails every book generates came to ~3.4 s of pure call overhead (`92487975e`, `37f7cfa52`). `BufferedPrint` wraps the sink; the converters are unchanged.

## Robustness

- **A cover was lost to one failed 16 KB allocation** (`499eccdab`) — with ~74 KB free, just not contiguous. The chunk now halves to 1 KB before giving up.
- **A chapter cached with a broken image** (`e8b936df9`): an image that lost its dimensions to low heap was baked into the section cache and replayed forever.
- **Images could be renumbered between runs** (`3e213390f`): `imageCounter` allocated cache names, but `buildCellImage()` returns before incrementing it when dimensions can't resolve — and that depends on `images.bin` filling in over time. A shifted count meant `ensureExtracted()` found the path already present and served **the wrong picture**. Keying on the entry can't drift; `imageCounter` is gone.

## Two things that did not work out

**A reverted commit is in the history on purpose** (`87f3b58b4` / `e51059f89`). I first downgraded the post-popup HALF refresh to FAST. It bought more wall-clock than deferring the popup does, but paid for it with exactly the popup-box ghost the HALF exists to prevent. Deferring the popup removes the artifact instead of tolerating it, so the downgrade was reverted rather than kept alongside.

**Decoding stored entries in place has yet to fire** (`b7fbbd322`, extended to covers in `c0e076a17`). When a ZIP *stores* an entry its bytes are the file, so it can be decoded without extracting — `PngStreamDecoder` needed no change, since it only reads forward. Every image in my test library is deflated, so it has hit zero times on device. It is correct and tested, and I have kept it because already-compressed formats are commonly stored, but it has not yet earned its place on real books. Easy to drop if reviewers would rather.

## Testing

679 host tests pass. New suites: `CompanionCacheTest` (the merged pass must be byte-identical to the two decodes it replaces, in both directions, plus a test that the two variants are *not* identical — or a companion that merely copied the primary would pass), `PixelCacheWriteTest` (expected bytes built independently of `PixelCache` so the two can't drift together), `BufferedPrintTest`, `StoredEntryDecodeTest`, `CoverPipelineTest` (the memo must not answer for a different book).

Goldens regenerated once, in `3e213390f`: **144 changed lines, every one an `IMG src=` filename, zero non-image diffs** — all `y/x/w/h` identical, so layout is provably untouched.

## What is left

The floor on the reader path is now ~3.3 s extract (that entry is deflated; streaming it into the decoder would need two 32 KB uzlib rings at once) plus ~3.6 s of uzlib and reverse-filter CPU over all 600×800 source pixels.

On the home screen, ~10.7 s of the remaining 25 s is cover decoding, inflated because the same cover is decoded once per thumb size. Merging those is the same companion-sink shape, but the two sizes pick different DCT scales (1/2 vs 1/4), so it is a genuine quality trade rather than a free win — deliberately not done here.
