### PR TITLE
fix(touch): make list rows tappable again on the T5S3

### DIFF
--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -594,9 +594,12 @@ void ActivityManager::dispatchListTap() {
         LOG_INF("TCH", "list tap (%d,%d): no band recorded", tx, ty);
       } else {
         const int lastBottom = band.count > 0 ? band.top[band.count - 1] + band.height[band.count - 1] : -1;
-        LOG_INF("TCH", "list tap (%d,%d): band x=%d w=%d first=%d count=%d rows y=%d..%d sel=0x%08lX -> item %d", tx,
-                ty, band.x, band.width, band.firstIndex, band.count, band.count > 0 ? band.top[0] : -1, lastBottom,
-                static_cast<unsigned long>(band.selectable), ListTouchBand::hitTestIn(band, tx, ty));
+        // The selectable mask is 64 bits and printed as two 32-bit halves, high first: the
+        // log's printf is the newlib-nano one, which does not carry the `ll` length modifier.
+        LOG_INF("TCH", "list tap (%d,%d): band x=%d w=%d first=%d count=%d rows y=%d..%d sel=0x%08lX%08lX -> item %d",
+                tx, ty, band.x, band.width, band.firstIndex, band.count, band.count > 0 ? band.top[0] : -1, lastBottom,
+                static_cast<unsigned long>(band.selectable >> 32), static_cast<unsigned long>(band.selectable),
+                ListTouchBand::hitTestIn(band, tx, ty));
       }
     }
   }

--- a/src/components/ListLayout.h
+++ b/src/components/ListLayout.h
@@ -16,10 +16,19 @@
 // keep the selection on screen. Cost per frame is O(visible rows), independent of list length.
 namespace ListLayout {
 
-// Cap on rows drawn in one screenful. The shortest theme row is 30 px and the tallest content
-// area is well under 600 px, so this cannot be reached in practice; it exists so a Window is a
-// fixed 100-byte stack object instead of a per-frame heap allocation.
-inline constexpr int kMaxRows = 24;
+// Cap on rows drawn in one screenful. It exists so a Window is a fixed ~132-byte stack object
+// instead of a per-frame heap allocation, which is why this number is kept tight rather than
+// generous: unlike ListTouchBand's capacity it is paid on the render task's stack, twice over
+// (the Window plus ListLayout.cpp's height cache).
+//
+// The bound is the shortest theme row (30 px) into the tallest content area: the LilyGo T5S3's
+// 540x960 portrait frame less the 40 px button-hint strip is 920 px, so 30 rows. 24 was sized
+// for the 800 px panels, where the same sum is 22, and a wrapped list on the T5S3 would stop
+// six rows short of the foot of the screen.
+//
+// Must not exceed ListTouchBand::kMaxRows, or a wrapped list would paint rows the band cannot
+// record and they would answer no tap. ListTouchBandTest asserts that direction.
+inline constexpr int kMaxRows = 32;
 
 struct Window {
   int first = 0;               // index of the first drawn item

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -481,6 +481,12 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   int rowHeight =
       (rowSubtitle != nullptr) ? BaseMetrics::values.listWithSubtitleRowHeight : BaseMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
+  // Never paint more rows than the touch band can register: a painted row past the cap is drawn
+  // but recorded by nothing, so it answers to no tap. That is not hypothetical -- the reader
+  // menu on the T5S3's 540x960 portrait frame fits 28 rows against a cap of 24, and its bottom
+  // four rows were dead. Clamping here costs blank space at the foot of an over-tall list
+  // instead, and keeps "every painted row is a tappable row" true on any future panel.
+  pageItems = std::min(pageItems, ListTouchBand::kMaxRows);
   // A fixed-height list still reports its page size, so Left/Right page by what is really on
   // screen rather than by a guess.
   if (view != nullptr) view->visibleRows = std::min(pageItems, itemCount);

--- a/src/components/themes/ListTouchBand.h
+++ b/src/components/themes/ListTouchBand.h
@@ -29,12 +29,25 @@
 // scrolled path draw a contiguous run, so nothing needs a per-row index.
 namespace ListTouchBand {
 
-// Deliberately equal to ListLayout::kMaxRows, which owns the argument for the number: the
-// shortest theme row is 30 px and the tallest content area is well under 600 px, so a
-// screenful cannot exceed this. Stated here rather than included so this header stays free of
-// everything (it is hit-tested on the host); the static_assert in ListTouchBand.cpp's test
-// keeps the two honest.
-inline constexpr int kMaxRows = 24;
+// How many rows one screenful can publish. This is a CAPACITY, not a layout rule: it has to be
+// larger than any screenful a draw can paint, because a painted row past it is recorded by
+// nothing and answers to no tap. It was 24 -- sized for the 800 px panels, where a full-height
+// list of the shortest theme row (30 px) comes to 22 -- and the T5S3's 540x960 frame overran it
+// by four rows in the reader menu, which is what put the tail of that menu out of reach.
+//
+// Sized from the geometry instead of from a guess: tallest content area / shortest row. Today
+// that is 920 px (960 less the button-hint strip) over 30 px = 30 rows, and 64 leaves room for
+// a taller panel or a shorter row without this needing to be thought about again. The cost is
+// one static Band -- 260-odd bytes of .bss -- and nothing on the heap or on any stack that
+// scales with it.
+//
+// The draws still clamp what they paint to this number, but as a backstop that current geometry
+// cannot reach rather than as something that shapes a layout: past it a list would leave blank
+// space at its foot, which is a visible mistake rather than a silently dead row.
+//
+// Stated here rather than included so this header stays free of everything (it is hit-tested on
+// the host); ListTouchBandTest's static_assert keeps it at or above ListLayout's window.
+inline constexpr int kMaxRows = 64;
 
 struct Band {
   int16_t x = 0;      // left edge of the tappable band
@@ -46,10 +59,10 @@ struct Band {
   // Bit r set = row r is a real, activatable item. Separator rows are drawn but are not
   // selectable -- the draw loop skips them and the navigation skips over them -- so a finger
   // landing on one must do nothing rather than select the heading.
-  uint32_t selectable = 0;
+  uint64_t selectable = 0;
 };
 
-static_assert(kMaxRows <= 32, "selectable is a uint32_t bitmask");
+static_assert(kMaxRows <= 64, "selectable is a uint64_t bitmask");
 
 // Published across tasks: drawList() runs on the render task, the hit test on the loop task.
 // A seqlock rather than a bare valid flag, because a half-written Band would be hit-tested
@@ -107,7 +120,7 @@ inline int hitTestIn(const Band& b, const int px, const int py) {
   if (b.width <= 0 || b.count <= 0) return -1;
   if (px < b.x || px >= b.x + b.width) return -1;
   for (int r = 0; r < b.count && r < kMaxRows; ++r) {
-    if ((b.selectable & (1u << r)) == 0) continue;
+    if ((b.selectable & (1ull << r)) == 0) continue;
     if (py >= b.top[r] && py < b.top[r] + b.height[r]) return b.firstIndex + r;
   }
   return -1;
@@ -141,11 +154,11 @@ struct Builder {
   }
 
   void addRow(const int top, const int height, const bool selectable) {
-    if (band.count >= kMaxRows) return;  // see kMaxRows: unreachable in practice
+    if (band.count >= kMaxRows) return;  // see kMaxRows: the draws clamp to this, so this is a backstop
     const auto r = static_cast<int>(band.count);
     band.top[r] = static_cast<int16_t>(top);
     band.height[r] = static_cast<int16_t>(height);
-    if (selectable) band.selectable |= (1u << r);
+    if (selectable) band.selectable |= (1ull << r);
     band.count = static_cast<int16_t>(r + 1);
   }
 

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -32,6 +32,7 @@
 #include "components/icons/transfer.h"
 #include "components/icons/weather32.h"
 #include "components/icons/wifi.h"
+#include "components/themes/ListTouchBand.h"
 #include "components/themes/TapTargets.h"
 #include "fontIds.h"
 
@@ -678,9 +679,13 @@ void LyraCarouselTheme::drawList(const GfxRenderer& renderer, Rect rect, int ite
 
   const int rowHeight = (rowSubtitle != nullptr) ? LyraCarouselMetrics::values.listWithSubtitleRowHeight
                                                  : LyraCarouselMetrics::values.listRowHeight;
-  const int pageItems = rect.height / rowHeight;
+  // Never paint more rows than the touch band can register — see BaseTheme::drawList.
+  const int pageItems = std::min(rect.height / rowHeight, ListTouchBand::kMaxRows);
   if (view != nullptr) view->visibleRows = std::min(pageItems, itemCount);
-  if (pageItems <= 0 || itemCount <= 0) return;
+  if (pageItems <= 0 || itemCount <= 0 || rowTitle == nullptr) {
+    ListTouchBand::invalidate();
+    return;
+  }
   const int totalPages = (itemCount + pageItems - 1) / pageItems;
 
   if (totalPages > 1) {
@@ -720,6 +725,12 @@ void LyraCarouselTheme::drawList(const GfxRenderer& renderer, Rect rect, int ite
   }
 
   const auto pageStartIndex = selectedIndex / pageItems * pageItems;
+  // Rows published for touch as they are painted — see BaseTheme::drawList. This theme is the
+  // third fixed-height list draw, and the one that shipped without this: every screen drawn
+  // through GUI.drawList was painted correctly and answered no tap at all.
+  ListTouchBand::Builder touchBand;
+  touchBand.begin(rect.x, rect.width, pageStartIndex);
+
   for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
     const int itemY = rect.y + (i % pageItems) * rowHeight;
     const bool sel = (i == selectedIndex);
@@ -735,7 +746,9 @@ void LyraCarouselTheme::drawList(const GfxRenderer& renderer, Rect rect, int ite
     }
 
     auto itemName = rowTitle(i);
-    if (UITheme::isSeparatorTitle(itemName)) {
+    const bool isSeparator = UITheme::isSeparatorTitle(itemName);
+    touchBand.addRow(itemY, rowHeight, !isSeparator);
+    if (isSeparator) {
       itemName = UITheme::stripSeparatorTitle(itemName);
       drawListSeparator(renderer,
                         Rect{rect.x + LyraCarouselMetrics::values.contentSidePadding, itemY,
@@ -774,6 +787,8 @@ void LyraCarouselTheme::drawList(const GfxRenderer& renderer, Rect rect, int ite
                         valueText.c_str(), !sel);
     }
   }
+
+  touchBand.commit();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -7,6 +7,7 @@
 #include <HalStorage.h>
 #include <I18n.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <string>
@@ -298,6 +299,12 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   int rowHeight =
       (rowSubtitle != nullptr) ? LyraMetrics::values.listWithSubtitleRowHeight : LyraMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
+  // Never paint more rows than the touch band can register: a painted row past the cap is drawn
+  // but recorded by nothing, so it answers to no tap. That is not hypothetical -- the reader
+  // menu on the T5S3's 540x960 portrait frame fits 28 rows against a cap of 24, and its bottom
+  // four rows were dead. Clamping here costs blank space at the foot of an over-tall list
+  // instead, and keeps "every painted row is a tappable row" true on any future panel.
+  pageItems = std::min(pageItems, ListTouchBand::kMaxRows);
   if (view != nullptr) view->visibleRows = std::min(pageItems, itemCount);
   if (pageItems <= 0 || itemCount <= 0 || rowTitle == nullptr) {
     ListTouchBand::invalidate();

--- a/test/list_touch_band/ListTouchBandTest.cpp
+++ b/test/list_touch_band/ListTouchBandTest.cpp
@@ -8,10 +8,11 @@ namespace {
 using ListTouchBand::Band;
 using ListTouchBand::Builder;
 
-// The band header states its row cap independently so it stays free of every include. If
-// ListLayout ever grows its window, a wrapped list would silently lose its tail rows here.
-static_assert(ListTouchBand::kMaxRows == ListLayout::kMaxRows,
-              "ListTouchBand::kMaxRows must track ListLayout::kMaxRows");
+// The band header states its row cap independently so it stays free of every include, so the
+// two have to be checked against each other somewhere. The direction matters: the band is a
+// CAPACITY and may be larger, but it must never be smaller than the window a wrapped list can
+// paint, or that list would draw rows the band cannot record and they would answer no tap.
+static_assert(ListLayout::kMaxRows <= ListTouchBand::kMaxRows, "ListLayout's window must fit in a ListTouchBand::Band");
 
 // What BaseTheme::drawList records on a plain X4 settings page: 30px rows filling a 480px
 // content band that starts 60px down, first item on the page is index 0.
@@ -131,6 +132,50 @@ TEST(ListTouchBand, RecordAndSnapshotRoundTrip) {
   ListTouchBand::invalidate();
   EXPECT_FALSE(ListTouchBand::hasBand());
   EXPECT_EQ(-1, ListTouchBand::hitTest(240, 60 + 15));
+}
+
+// Rows in the top half of the mask must stay distinguishable from rows in the bottom half.
+// A 32-bit shift silently wraps (row 32 lands on row 0's bit), which would make a separator in
+// the second half read as selectable and a real row read as a heading.
+TEST(ListTouchBand, SelectabilityIsTrackedAboveTheThirtySecondRow) {
+  ASSERT_GT(ListTouchBand::kMaxRows, 32) << "this test is about the high half of the mask";
+  Builder b;
+  b.begin(0, 480, 0);
+  for (int r = 0; r < ListTouchBand::kMaxRows; ++r) {
+    // Row 0 selectable, row 32 a separator: the pair that collides under a 32-bit shift.
+    b.addRow(r * 20, 20, /*selectable=*/r != 32);
+  }
+  EXPECT_EQ(0, ListTouchBand::hitTestIn(b.band, 240, 10));
+  EXPECT_EQ(-1, ListTouchBand::hitTestIn(b.band, 240, 32 * 20 + 10)) << "separator row 32";
+  EXPECT_EQ(33, ListTouchBand::hitTestIn(b.band, 240, 33 * 20 + 10));
+  EXPECT_EQ(ListTouchBand::kMaxRows - 1,
+            ListTouchBand::hitTestIn(b.band, 240, (ListTouchBand::kMaxRows - 1) * 20 + 10));
+}
+
+// The screenful that overran the old cap of 24: the EPUB reader menu on the LilyGo T5S3.
+// Its portrait frame is 540x960, getContentRect() takes the 40 px hint strip off the bottom and
+// the menu starts its list 75 px down, so BaseTheme::drawList paints (960 - 40 - 75) / 30 = 28
+// rows. Every one of them has to be recordable, or the rows past the cap are painted rows that
+// answer to no tap -- which is exactly how the menu's bottom four rows went dead on that board.
+TEST(ListTouchBand, RecordsAFullReaderMenuScreenfulOnA960PxPanel) {
+  constexpr int kListTop = 75;
+  constexpr int kRowHeight = 30;
+  constexpr int kRows = (960 - 40 - kListTop) / kRowHeight;
+  static_assert(kRows == 28, "T5S3 reader-menu geometry");
+  ASSERT_LE(kRows, ListTouchBand::kMaxRows);
+
+  Builder b;
+  b.begin(/*rectX=*/0, /*rectWidth=*/540, /*firstIndex=*/0);
+  for (int r = 0; r < kRows; ++r) b.addRow(kListTop + r * kRowHeight, kRowHeight, /*selectable=*/true);
+  EXPECT_EQ(kRows, b.band.count);
+
+  // The last row is the one that used to be dead, so name it rather than trusting the loop.
+  EXPECT_EQ(kRows - 1, ListTouchBand::hitTestIn(b.band, 270, kListTop + (kRows - 1) * kRowHeight + 15));
+  for (int r = 0; r < kRows; ++r) {
+    EXPECT_EQ(r, ListTouchBand::hitTestIn(b.band, 270, kListTop + r * kRowHeight + 15)) << "row " << r;
+  }
+  // Below the last row is the gap above the hint strip, and belongs to no row.
+  EXPECT_EQ(-1, ListTouchBand::hitTestIn(b.band, 270, kListTop + kRows * kRowHeight + 5));
 }
 
 TEST(ListTouchBand, ABandOfOnlySeparatorsDoesNotCountAsALiveList) {


### PR DESCRIPTION
On the LilyGo T5S3 no list responded to touch inside the EPUB reader menu, while taps on the button-hint strip still worked. Two independent defects, either of which is enough to leave a row painted and dead.

## 1. The carousel theme published nothing

`ListTouchBand.h` says the band is "recorded by the `drawList` implementations (BaseTheme, LyraTheme)". There are **three**: `LyraCarouselTheme::drawList` is a full second fixed-height list draw that was written without the recording, so on that theme every screen going through `GUI.drawList` — the reader menu, Settings, font selection, the WiFi picker — painted correctly and answered no tap. The hint strip kept working because it is recorded in `drawButtonHints`, which this theme does not override, and that asymmetry is what made it look like touch was half-broken rather than one missing call.

The device trace is what settles it rather than the geometry:

```
[TCH] release: held=170ms tap=1 swipe=0 travel=0,0 px
[GEST] tap-centre -> action=0 (unbound, left to the screen)
[TCH] list tap (334,129): band x=0 w=0 first=0 count=0 rows y=-1..-1 sel=0x00000000 -> item -1
```

The tap arrives and the gesture layer declines it, so everything upstream is fine. A committed band always carries the rect's width, so `w=0` from a *valid* snapshot means the last write was `invalidate()` — the render task's start-of-pass clear — and that nothing recorded after it.

## 2. The row cap was sized for the 800 px boards

`kMaxRows = 24` stated its own reasoning: *"the shortest theme row is 30 px and the tallest content area is well under 600 px"*. On the T5S3's 540×960 portrait frame the content area is 920 px, and the reader menu — the tallest list in the firmware, no header, no tab bar — paints `(960 − 40 − 75) / 30 = 28` rows. `addRow()` dropped the last four silently, so the bottom ~120 px of that menu was painted, reachable by navigation, and dead to touch. On an 800 px panel the same sum is 22, which is why this never surfaced before.

The cap is a capacity, not a layout rule, so it is now sized from geometry (tallest content area ÷ shortest row = 30 today) and rounded to 64 for headroom; `selectable` becomes a `uint64_t`. Cost is one static `Band`, ~270 bytes of `.bss`.

The two caps are also no longer asserted *equal*. That forced `ListLayout`'s window — paid twice on the render task's stack — to track a nearly-free static byte array. It moves 24 → 32 (what the 920 px area actually needs) and the test now asserts the direction that matters: the window must fit **in** the band.

All three fixed-height draws now clamp what they paint to the band's capacity. Nothing reaches it, so it is a backstop: past it a list leaves blank space at its foot — a visible mistake — instead of a row that looks live and is not.

## Testing

- 779/779 host tests. New: the T5S3 reader-menu screenful (28 rows), and one covering the high half of the mask — `1u << 32` wraps onto row 0's bit, so a separator past row 32 would have read as selectable. Verified it fails on the old shift.
- `lilygo_t5s3` and `default` both build; +136 bytes RAM on the S3.
- **DEVICE-VALIDATED on the LilyGo T5S3**: list rows in the EPUB reader menu respond to touch again.

