### PR TITLE
chore(sdk): bring master's SDK pin current, and point the submodule at the fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,22 @@
+# The SDK is pinned to OUR FORK, not to Free-Ink/freeink-sdk.
+#
+# The firmware needs work that is not on upstream main: the LilyGo T5 S3 board
+# support of Free-Ink/freeink-sdk#51 (still open), our fixes on top of it, the
+# pinch classifier (#75), and USB-MSC on the SPI SD path (#74). A build against
+# upstream main does not compile.
+#
+# This used to name the upstream URL, and it resolved anyway: GitHub shares an
+# object store across a fork network, so fetching our fork-only commit by its
+# exact SHA succeeds even through the upstream URL. That is grace, not
+# configuration -- it would end the day the fork left the network, and the
+# failure would surface as an unexplained CI break. Naming the fork makes the
+# pin say what it means.
+#
+# `branch` is our fork branch on purpose. It only matters to
+# `git submodule update --remote`, which is NOT what a normal checkout runs --
+# but when it was `main`, that command silently reset the submodule to upstream
+# and the firmware then failed to build. It now moves to the branch we track.
 [submodule "freeink-sdk"]
 	path = freeink-sdk
-	url = https://github.com/Free-Ink/freeink-sdk.git
-	branch = main
+	url = https://github.com/jpirnay/freeink-sdk.git
+	branch = feat/t5s3-pro-and-pinch


### PR DESCRIPTION
## Summary

Master's SDK pin has not moved since "Pin sdk" and is five commits behind what we have been building against all day. This brings it current and fixes the submodule configuration, which was working by accident.

Five commits, all SDK-facing. No firmware source changes at all.

| commit | what it moves the pin to |
| --- | --- |
| `47e50ef` | adopts `Free-Ink/freeink-sdk#73` — the T5 S3 LoRa chip-select fix |
| `209c295` | folds the upstream-PR review work back into our fork copy |
| `9e6dec3` | merges upstream `main` into our SDK branch |
| `bac0d5a` | fixes the FreeInkUI dangling-reference UAF (sent as `#76`) |
| `e7a397c` | points `.gitmodules` at the fork it is actually pinned to |

## The config fix, and why it mattered

`.gitmodules` named `Free-Ink/freeink-sdk`, while every SHA we pin lives only on `jpirnay/freeink-sdk`. That resolved anyway — GitHub shares an object store across a fork network, and a fetch for an *exact SHA* crosses it, so `actions/checkout` and `git submodule update --init` both found a commit that sits on no branch of the URL they were handed. Every green CI run to date has depended on that.

It is a property of the fork network rather than of our configuration. It ends the day the fork is deleted or detached, and it would surface as submodule checkout failing on a commit nobody can locate, not as an obvious misconfiguration.

`branch` also moves from `main` to `feat/t5s3-pro-and-pinch`, for a sharper reason: it is what `git submodule update --remote` follows, and aiming it at upstream `main` meant that command silently replaced our pinned SDK with one the firmware does not build against. That has cost time before.

Verified with a fresh `git clone --recurse-submodules --shallow-submodules` of this branch: the SDK checks out at `62161fc`. Existing checkouts need `git submodule sync` once.

## What actually changes behaviour — please read this bit

The upstream merge is not inert for boards we ship. `c7986a1` ("Skip e-paper power-off when screen already off") reworks `deepSleep()` in **Ssd1677** (the `default` env — X4/X3) and **Uc8279X4** (`x4pro`).

**That change has not been on a device.** It builds, and building is not the risk — the sleep path on the X4 has a history. If you would rather not carry it on master yet, say so and I will split the merge commit out and land the other four, which are much lower risk: a board fix for a board only you run, a test file plus a comment, a one-line UAF fix in a widget our firmware never instantiates, and the `.gitmodules` change.

Also arriving, unused by us: OnePage ESP32-C61 board support (#68), the OnePage shared-SD-rail fix (#72), FreeInkUI inline list section headings.

## Testing

- `default`, `x4pro` and `lilygo_t5s3` all build against the merged SDK.
- SDK host suites: InputManager gesture math 43 checks / 0 failures; FreeInkUI 2804 checks / 0 failed — the latter did not compile at all before the UAF fix.
- Fresh recursive clone resolves the submodule.
- No device validation. The LilyGo LoRa CS fix and the upstream sleep-path rework are both unexercised on hardware.
