### PR TITLE
feat(sleep): render sleep images at the panel's native grey depth

### DIFF
--- a/lib/Epub/Epub/converters/DirectPixelWriter.h
+++ b/lib/Epub/Epub/converters/DirectPixelWriter.h
@@ -242,3 +242,53 @@ struct DirectCacheWriter {
     rowPtr[byteIdx] = (rowPtr[byteIdx] & ~(0x03 << bitShift)) | ((value & 0x03) << bitShift);
   }
 };
+
+// Direct 8-bit grayscale writer, for panels that resolve more levels than the
+// dual-plane pipeline can express (HalDisplay::getGrayLevels() > 4).
+//
+// The 2-bit path exists because a KW controller selects its waveform from an
+// (old, new) bit pair, so four levels is the entire state space — see
+// Uc8279X4Driver::displayGray. A panel that keeps its own multi-bit frame buffer
+// has no such ceiling, and there the decoder's tone-mapped sample can be stored
+// whole rather than crushed to a quarter of its range on the way out. The panel's
+// own quantiser then runs last, at its native depth, instead of the host dithering
+// to four levels and the panel re-dithering what is left.
+//
+// Coordinates, orientation and clipping come from an embedded DirectPixelWriter:
+// this stores bytes exactly where that stores bits, so the two stay in step by
+// construction rather than by a second copy of the transform. Its framebuffer is
+// never written — only the transform fields are read.
+struct DirectGray8Writer {
+  uint8_t* canvas;
+  int stride;  // bytes per canvas row; may exceed canvasWidth
+  int canvasWidth;
+  int canvasHeight;
+  DirectPixelWriter xf;
+
+  // `gray8Canvas` is the PHYSICAL panel buffer (HalDisplay::borrowGray8Canvas),
+  // so its extent is the panel's, not the oriented screen's.
+  void init(const GfxRenderer& renderer, uint8_t* gray8Canvas, int gray8Stride) {
+    canvas = gray8Canvas;
+    stride = gray8Stride;
+    canvasWidth = renderer.getDisplayWidth();
+    canvasHeight = renderer.getDisplayHeight();
+    xf.init(renderer);
+  }
+
+  inline void beginRow(int logicalY) { xf.beginRow(logicalY); }
+
+  inline void bandColRange(int xBase, int width, int& colStart, int& colEnd) const {
+    xf.bandColRange(xBase, width, colStart, colEnd);
+  }
+
+  // Store one 8-bit sample (0 = black, 255 = white). Must follow beginRow().
+  inline void writePixel(int logicalX, uint8_t gray) const {
+    const int phyX = xf.rowPhyXBase + logicalX * xf.phyXStepX;
+    const int phyY = xf.rowPhyYBase + logicalX * xf.phyYStepX;
+    // One unsigned compare per axis rejects negatives and overruns together —
+    // an image placed at a negative offset, or wider than the panel.
+    if (static_cast<unsigned>(phyX) >= static_cast<unsigned>(canvasWidth)) return;
+    if (static_cast<unsigned>(phyY) >= static_cast<unsigned>(canvasHeight)) return;
+    canvas[static_cast<uint32_t>(phyY) * stride + phyX] = gray;
+  }
+};

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
@@ -8,6 +8,7 @@
 #include "ImageDimensionsGuard.h"
 
 class GfxRenderer;
+struct DirectGray8Writer;
 
 struct ImageDimensions {
   int16_t width;
@@ -87,6 +88,18 @@ struct RenderConfig {
   // Honoured by PngToFramebufferConverter. Other decoders ignore it and write only cachePath;
   // callers must treat the companion as best-effort and check before relying on it.
   std::string companionCachePath;
+  // Native-grayscale sink, for panels that resolve more than four levels
+  // (HalDisplay::getGrayLevels() > 4). When set, the decoder stores the
+  // tone-mapped 8-bit sample here and writes NEITHER the framebuffer nor any
+  // cache: dithering to 2 bits is precisely the loss this path exists to avoid,
+  // and a 2-bit .pxc could not replay a 16-level frame anyway.
+  //
+  // One decode, one output. The three-pass BW/LSB/MSB dance the plane pipeline
+  // needs has no counterpart here — there are no planes to fill.
+  //
+  // Honoured by PngToFramebufferConverter. Other decoders ignore it, so callers
+  // must check getGrayLevels() AND the format before relying on it.
+  DirectGray8Writer* gray8 = nullptr;
 };
 
 class ImageToFramebufferDecoder {

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -320,9 +320,16 @@ bool PngToFramebufferConverter::decodeOpenFile(FsFile& file, const std::string& 
     return false;
   }
 
+  // Native grayscale short-circuits most of the machinery below: no ditherer, no
+  // pixel cache, no companion rendition. All three exist to make 2 bits per pixel
+  // carry as much as they can, and this path is not spending 2 bits per pixel.
+  const bool gray8Out = config.gray8 != nullptr;
+
   DitherState dither;
   dither.config = &config;
-  if (config.monochromeOutput) {
+  if (gray8Out) {
+    // no ditherer
+  } else if (config.monochromeOutput) {
     dither.atkinson1Bit.reset(new (std::nothrow) Atkinson1BitDitherer(dstWidth));
   }
 #ifdef ENABLE_IMAGE_DITHERING_EXTENSION
@@ -342,7 +349,7 @@ bool PngToFramebufferConverter::decodeOpenFile(FsFile& file, const std::string& 
 
   // Stream the 2-bit pixel cache to disk one row band at a time.
   PixelCache cache;
-  bool caching = !config.cachePath.empty();
+  bool caching = !config.cachePath.empty() && !gray8Out;
   if (caching && !cache.begin(config.cachePath, dstWidth, dstHeight, config.x, config.y, 1)) {
     LOG_ERR("PNG", "Failed to start cache stream, continuing without caching");
     caching = false;
@@ -352,7 +359,7 @@ bool PngToFramebufferConverter::decodeOpenFile(FsFile& file, const std::string& 
   // independent of the primary's: losing the companion costs a later second decode, which is
   // exactly the status quo, so it must never take the primary cache or the render down with it.
   CompanionSink companion;
-  if (!config.companionCachePath.empty()) {
+  if (!config.companionCachePath.empty() && !gray8Out) {
     if (!config.monochromeOutput) {
       companion.atkinson1Bit.reset(new (std::nothrow) Atkinson1BitDitherer(dstWidth));
     }
@@ -399,6 +406,7 @@ bool PngToFramebufferConverter::decodeOpenFile(FsFile& file, const std::string& 
     if (!ok) break;
 
     pw.beginRow(outY);
+    if (gray8Out) config.gray8->beginRow(outY);
 
     DirectCacheWriter cw;
     bool rowCaching = caching;
@@ -434,14 +442,21 @@ bool PngToFramebufferConverter::decodeOpenFile(FsFile& file, const std::string& 
       // differ only in dither, never in the tone they were dithered from. Identity when the
       // caller supplied no points (every reader image; only the sleep screen supplies any).
       const uint8_t gray = adaptive_tone::apply(config.adaptiveTone, grayLine[srcX]);
-      const uint8_t value = ditherGray(dither, gray, dstX, outX, outY);
-      // Both ditherers see every destination column, on-screen or not, so their diffusion state
-      // stays in step across the row; only the writes below are bounds-guarded.
-      const uint8_t companionValue = companion.caching ? companion.dither(gray, dstX, outX, outY) : 0;
-      if (outX >= 0 && outX < screenWidth) {
-        pw.writePixel(outX, value);
-        if (rowCaching) cw.writePixel(outX, value);
-        if (companion.rowCaching) companion.writer.writePixel(outX, companionValue);
+      if (gray8Out) {
+        // The tone-mapped sample IS the output; the panel quantises it later at its
+        // own depth. No ditherer runs, so unlike the branch below there is no
+        // diffusion state that has to be advanced across off-screen columns.
+        if (outX >= 0 && outX < screenWidth) config.gray8->writePixel(outX, gray);
+      } else {
+        const uint8_t value = ditherGray(dither, gray, dstX, outX, outY);
+        // Both ditherers see every destination column, on-screen or not, so their diffusion state
+        // stays in step across the row; only the writes below are bounds-guarded.
+        const uint8_t companionValue = companion.caching ? companion.dither(gray, dstX, outX, outY) : 0;
+        if (outX >= 0 && outX < screenWidth) {
+          pw.writePixel(outX, value);
+          if (rowCaching) cw.writePixel(outX, value);
+          if (companion.rowCaching) companion.writer.writePixel(outX, companionValue);
+        }
       }
       error += srcWidth;
       while (error >= dstWidth) {

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -190,7 +190,8 @@ bool PngToFramebufferConverter::getDimensionsStatic(const std::string& imagePath
 }
 
 adaptive_tone::Points PngToFramebufferConverter::analyzeAdaptiveTone(const std::string& imagePath,
-                                                                     const adaptive_tone::Mode mode) {
+                                                                     const adaptive_tone::Mode mode,
+                                                                     const int eqBlendNum) {
   adaptive_tone::Points points;
 
   const size_t freeHeap = ESP.getFreeHeap();
@@ -242,7 +243,7 @@ adaptive_tone::Points PngToFramebufferConverter::analyzeAdaptiveTone(const std::
   file.close();
   if (!ok || sampled == 0) return points;
 
-  points = adaptive_tone::derivePoints(histogram.get(), sampled, mode);
+  points = adaptive_tone::derivePoints(histogram.get(), sampled, mode, eqBlendNum);
   if (points.active) {
     LOG_TRC("PNG", "Adaptive tone (%s) enabled: black=%u white=%u",
             mode == adaptive_tone::Mode::Equalize ? "equalize" : "stretch", (unsigned)points.blackPoint,

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.h
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.h
@@ -27,8 +27,11 @@ class PngToFramebufferConverter final : public ImageToFramebufferDecoder {
   // cheap pre-pass -- inflate must run over every row. Call this once and reuse the
   // result across render passes; do not call it per pass.
   // `mode` selects the endpoint stretch or the CDF equalization; see AdaptiveTone.h.
+  // `eqBlendNum` is the Equalize strength; see adaptive_tone::EQ_BLEND_NUM_DEEP for
+  // when a caller should raise it.
   static adaptive_tone::Points analyzeAdaptiveTone(const std::string& imagePath,
-                                                   adaptive_tone::Mode mode = adaptive_tone::Mode::Stretch);
+                                                   adaptive_tone::Mode mode = adaptive_tone::Mode::Stretch,
+                                                   int eqBlendNum = adaptive_tone::EQ_BLEND_NUM);
 
   bool getDimensions(const std::string& imagePath, ImageDimensions& dims) const override {
     return getDimensionsStatic(imagePath, dims);

--- a/lib/GfxRenderer/AdaptiveTone.h
+++ b/lib/GfxRenderer/AdaptiveTone.h
@@ -112,6 +112,25 @@ inline constexpr uint64_t EQ_CLIP_MULTIPLE = 2;
 inline constexpr int EQ_BLEND_NUM = 1;
 inline constexpr int EQ_BLEND_DEN = 4;
 
+// ...but "visible dither banding" is a statement about a FOUR-level panel, where
+// every tone the curve separates has to be faked out of two rails and two greys.
+// A panel that resolves eleven has far more room before a flattened gradient
+// breaks up, and correspondingly more to gain: the whole point of equalization is
+// to spend output range where the pixels are, and there is only range to spend if
+// the panel has levels to spend it on.
+//
+// Measured on two covers through the T5S3's clean-bank response (11 levels, gamma
+// 2.2), raising the blend improves brightness AND local contrast monotonically --
+// 1/4 -> 3/4 takes a bimodal cover from 54.5%/0.653 to 58.6%/0.726, where the
+// no-filter baseline is 52.4%/0.611. At 1/4 the same cover was reported on
+// hardware as "barely different" from no filter at all.
+//
+// This is a property of the RENDER PATH, not of the device: a deep panel still
+// draws in-book images and covers through the dual-plane path, and those want the
+// conservative value. So it is a parameter, passed by whoever knows which way the
+// image is going out, and not a global set once from the panel.
+inline constexpr int EQ_BLEND_NUM_DEEP = 3;
+
 // --- Where the curve lives -------------------------------------------------------
 // Both modes bake into a 256-entry lookup table rather than being recomputed per pixel:
 // apply() sits in the dither inner loop, so a table read replaces a multiply and a
@@ -156,7 +175,11 @@ struct Points {
 // Returns an inactive result when the image is line art, or (Stretch only) when the
 // useful range is too narrow to be worth stretching. Callers should treat an inactive
 // result as "render exactly as before".
-inline Points derivePoints(const uint32_t* histogram, uint64_t sampleCount, Mode mode = Mode::Stretch) {
+// `eqBlendNum` is the equalization strength out of EQ_BLEND_DEN, for Mode::Equalize
+// only: EQ_BLEND_NUM for a dual-plane target, EQ_BLEND_NUM_DEEP where the output
+// resolves more levels than that. Ignored by Mode::Stretch.
+inline Points derivePoints(const uint32_t* histogram, uint64_t sampleCount, Mode mode = Mode::Stretch,
+                           int eqBlendNum = EQ_BLEND_NUM) {
   Points points;
   if (!histogram || sampleCount == 0) return points;
 
@@ -243,7 +266,7 @@ inline Points derivePoints(const uint32_t* histogram, uint64_t sampleCount, Mode
   for (int i = 0; i < 256; i++) {
     running += (histogram[i] < clipLimit ? histogram[i] : clipLimit) + shared;
     const int equalized = static_cast<int>((running * 255u) / clippedTotal);
-    int adjusted = (i * (EQ_BLEND_DEN - EQ_BLEND_NUM) + equalized * EQ_BLEND_NUM) / EQ_BLEND_DEN;
+    int adjusted = (i * (EQ_BLEND_DEN - eqBlendNum) + equalized * eqBlendNum) / EQ_BLEND_DEN;
     if (i > HIGHLIGHT_FLOOR && adjusted < i) adjusted = i;
     if (adjusted < 0) adjusted = 0;
     if (adjusted > 255) adjusted = 255;

--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -282,7 +282,7 @@ bool Bitmap::analyzeAdaptiveTone() {
 }
 
 // packed 2bpp output, 0 = black, 1 = dark gray, 2 = light gray, 3 = white
-BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer) const {
+BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer, uint8_t* gray8Row) const {
   // Note: rowBuffer should be pre-allocated by the caller to size 'rowBytes'
   if (file.read(rowBuffer, rowBytes) != rowBytes) return BmpReaderError::ShortReadRow;
 
@@ -296,6 +296,14 @@ BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer) const {
   // Helper lambda to pack 2bpp color into the output stream
   auto packPixel = [&](const uint8_t rawLum) {
     const uint8_t lum = applyAdaptiveTone(rawLum);
+    // Capture the sample BEFORE any quantiser sees it. Deliberately computed
+    // alongside rather than shared with the branches below: they each reach
+    // adjustPixel() by their own route, and rewiring that to hand one value to
+    // both outputs would change the 2-bit rendition every existing panel shows.
+    if (gray8Row) {
+      const int adjusted = adjustPixel(lum);
+      gray8Row[currentX] = static_cast<uint8_t>(adjusted < 0 ? 0 : (adjusted > 255 ? 255 : adjusted));
+    }
     uint8_t color;
     if (atkinsonDitherer) {
       color = atkinsonDitherer->processPixel(adjustPixel(lum), currentX);

--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -268,7 +268,7 @@ bool Bitmap::analyzeAdaptiveTone() {
 
   if (sampled == 0) return false;
 
-  adaptiveTonePoints = adaptive_tone::derivePoints(histogram.get(), sampled, toneAnalysisMode(toneMapping));
+  adaptiveTonePoints = adaptive_tone::derivePoints(histogram.get(), sampled, toneAnalysisMode(toneMapping), eqBlendNum);
   if (!adaptiveTonePoints.active) {
     LOG_DBG("BMP", "Adaptive tone (%s) declined: line art or range too narrow",
             toneMapping == BitmapToneMapping::Equalize ? "equalize" : "stretch");

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -78,8 +78,12 @@ class Bitmap {
  public:
   static const char* errorToString(BmpReaderError err);
 
-  explicit Bitmap(FsFile& file, bool dithering = false, BitmapToneMapping toneMapping = BitmapToneMapping::None)
-      : file(file), dithering(dithering), toneMapping(toneMapping) {}
+  // `eqBlendNum` reaches adaptive_tone::derivePoints for Equalize analysis; leave
+  // it defaulted unless the image is bound for a panel that resolves more than the
+  // dual-plane four levels. See EQ_BLEND_NUM_DEEP.
+  explicit Bitmap(FsFile& file, bool dithering = false, BitmapToneMapping toneMapping = BitmapToneMapping::None,
+                  int eqBlendNum = adaptive_tone::EQ_BLEND_NUM)
+      : file(file), dithering(dithering), toneMapping(toneMapping), eqBlendNum(eqBlendNum) {}
   ~Bitmap();
   BmpReaderError parseHeaders();
   // `data` receives the row packed at 2 bits per pixel, as always.
@@ -116,6 +120,7 @@ class Bitmap {
   FsFile& file;
   bool dithering = false;
   BitmapToneMapping toneMapping = BitmapToneMapping::None;
+  int eqBlendNum = adaptive_tone::EQ_BLEND_NUM;
   adaptive_tone::Points adaptiveTonePoints;
   int width = 0;
   int height = 0;

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -82,7 +82,14 @@ class Bitmap {
       : file(file), dithering(dithering), toneMapping(toneMapping) {}
   ~Bitmap();
   BmpReaderError parseHeaders();
-  BmpReaderError readNextRow(uint8_t* data, uint8_t* rowBuffer) const;
+  // `data` receives the row packed at 2 bits per pixel, as always.
+  //
+  // `gray8Row`, when non-null, ALSO receives the tone-mapped 8-bit luminance of
+  // every pixel -- the sample each 2-bit value is quantised from, one byte per
+  // pixel, `width` bytes. Panels that resolve more than four levels consume that
+  // instead and quantise for themselves at their own depth. Purely additive: the
+  // 2-bit output and the dither state are byte-for-byte what they were without it.
+  BmpReaderError readNextRow(uint8_t* data, uint8_t* rowBuffer, uint8_t* gray8Row = nullptr) const;
   BmpReaderError rewindToData() const;
   int getWidth() const { return width; }
   int getHeight() const { return height; }

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2362,8 +2362,18 @@ static void bitmapFastRow(uint8_t* const frameBuffer, const uint8_t* const outpu
   }
 }
 
+void GfxRenderer::drawGray8Pixel(const Gray8Target& gray8, const int x, const int y, const uint8_t gray) const {
+  int phyX = 0;
+  int phyY = 0;
+  const int displayWidth = getDisplayWidth();
+  const int displayHeight = getDisplayHeight();
+  rotateCoordinates(getOrientation(), x, y, &phyX, &phyY, displayWidth, displayHeight);
+  if (phyX < 0 || phyX >= displayWidth || phyY < 0 || phyY >= displayHeight) return;
+  gray8.canvas[static_cast<uint32_t>(phyY) * gray8.stride + phyX] = gray;
+}
+
 void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, const int maxWidth, const int maxHeight,
-                             const float cropX, const float cropY) const {
+                             const float cropX, const float cropY, const Gray8Target* gray8) const {
   if (fontCacheManager_ && fontCacheManager_->isScanning()) return;
   // For 1-bit bitmaps, use optimized 1-bit rendering path (no crop support for 1-bit)
   if (bitmap.is1Bit() && cropX == 0.0f && cropY == 0.0f) {
@@ -2402,11 +2412,16 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
   const int outputRowSize = (bitmap.getWidth() + 3) / 4;
   auto* outputRow = static_cast<uint8_t*>(malloc(outputRowSize));
   auto* rowBytes = static_cast<uint8_t*>(malloc(bitmap.getRowBytes()));
+  // One row of 8-bit samples, only when a canvas is actually being painted.
+  // Stack allocation is not an option: a row is one image width, thousands of
+  // bytes, and the ESP32-C3 stack budget for a call frame is 256.
+  auto* gray8Row = gray8 ? static_cast<uint8_t*>(malloc(bitmap.getWidth())) : nullptr;
 
-  if (!outputRow || !rowBytes) {
+  if (!outputRow || !rowBytes || (gray8 && !gray8Row)) {
     LOG_ERR("GFX", "!! Failed to allocate BMP row buffers");
     free(outputRow);
     free(rowBytes);
+    free(gray8Row);
     return;
   }
 
@@ -2451,10 +2466,11 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
       break;
     }
 
-    if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
+    if (bitmap.readNextRow(outputRow, rowBytes, gray8Row) != BmpReaderError::Ok) {
       LOG_ERR("GFX", "Failed to read row %d from bitmap", bmpY);
       free(outputRow);
       free(rowBytes);
+      free(gray8Row);
       return;
     }
 
@@ -2467,7 +2483,7 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
       continue;
     }
 
-    if (!isScaled && drawMask != 0x00) {
+    if (!gray8 && !isScaled && drawMask != 0x00) {
       // Fast path: write up to 8 pixels per call directly to the framebuffer.
       switch (drawMask) {
         case 0x07:
@@ -2507,6 +2523,12 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
         continue;
       }
 
+      if (gray8) {
+        // The whole point of this path: store the sample, let the panel quantise.
+        drawGray8Pixel(*gray8, screenX, screenY, gray8Row[bmpX]);
+        continue;
+      }
+
       const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
 
       if (renderModeSnapshot == BW && val < 3) {
@@ -2521,6 +2543,7 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
 
   free(outputRow);
   free(rowBytes);
+  free(gray8Row);
 }
 
 void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y, const int maxWidth,
@@ -3258,6 +3281,49 @@ void GfxRenderer::copyGrayscaleMsbBuffers(const uint8_t* plane) const { display.
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }
 
 void GfxRenderer::displayGrayBuffer() const { display.displayGrayBuffer(fadingFix); }
+
+uint8_t GfxRenderer::getGrayLevels() const { return display.getGrayLevels(); }
+
+uint8_t* GfxRenderer::borrowGray8Canvas(uint16_t* stride) const { return display.borrowGray8Canvas(stride); }
+
+void GfxRenderer::displayGray8Canvas() const { display.displayGray8Canvas(HalDisplay::FULL_REFRESH, fadingFix); }
+
+// Bit clear = black is the framebuffer's own convention (see DirectPixelWriter's
+// BW branch, which draws by clearing), and the driver expands it the same way.
+void GfxRenderer::stampBwOntoGray8Canvas(uint8_t* canvas, const uint16_t stride) const {
+  if (!canvas || !frameBuffer) return;
+  const int width = getDisplayWidth();
+  const int height = getDisplayHeight();
+  const int widthBytes = getDisplayWidthBytes();
+  for (int y = 0; y < height; y++) {
+    const uint8_t* src = frameBuffer + static_cast<uint32_t>(y) * widthBytes;
+    uint8_t* dst = canvas + static_cast<uint32_t>(y) * stride;
+    for (int bx = 0; bx < widthBytes; bx++) {
+      const uint8_t bits = src[bx];
+      // The overwhelmingly common case on a text overlay: a fully white byte has
+      // nothing to stamp, so skip the eight-bit unpack entirely.
+      if (bits == 0xFF) continue;
+      const int x0 = bx * 8;
+      for (int bit = 0; bit < 8; bit++) {
+        const int x = x0 + bit;
+        if (x >= width) break;
+        if (!(bits & (0x80 >> bit))) dst[x] = 0x00;
+      }
+    }
+  }
+}
+
+void GfxRenderer::compositeBwRectOntoGray8Canvas(const Gray8Target& gray8, const int x, const int y, const int width,
+                                                 const int height) const {
+  if (!gray8.canvas || !frameBuffer || width <= 0 || height <= 0) return;
+  const int xEnd = std::min(x + width, getScreenWidth());
+  const int yEnd = std::min(y + height, getScreenHeight());
+  for (int row = std::max(0, y); row < yEnd; row++) {
+    for (int col = std::max(0, x); col < xEnd; col++) {
+      drawGray8Pixel(gray8, col, row, getPixel(col, row) ? 0x00 : 0xFF);
+    }
+  }
+}
 
 bool GfxRenderer::supportsGrayFrame() const { return display.supportsGrayFrame(); }
 

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -397,8 +397,25 @@ class GfxRenderer {
   void drawImage(const uint8_t bitmap[], int x, int y, int width, int height) const;
   void drawIcon(const uint8_t bitmap[], int x, int y, int width, int height) const;
   void drawIconInverted(const uint8_t bitmap[], int x, int y, int width, int height) const;
-  void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0,
-                  float cropY = 0) const;
+  // A borrowed 8-bit grayscale canvas (see borrowGray8Canvas): where drawing
+  // routines accept one, they paint bytes into it instead of bits into the
+  // framebuffer, so the panel quantises rather than the host.
+  struct Gray8Target {
+    uint8_t* canvas;
+    uint16_t stride;
+  };
+
+  // When `gray8` is set the bitmap's 8-bit samples are painted there and the
+  // framebuffer is left untouched — the 2-bit dither is skipped entirely rather
+  // than done and discarded. Ignored for 1-bit bitmaps, which have no levels to
+  // preserve. Default nullptr keeps every existing caller on the 2-bit path.
+  void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0, float cropY = 0,
+                  const Gray8Target* gray8 = nullptr) const;
+  // One 8-bit sample at LOGICAL (x, y), rotated onto the canvas exactly as
+  // drawPixel() rotates onto the framebuffer. Silently drops out-of-panel
+  // coordinates, where drawPixel() logs — a scaled image legitimately walks off
+  // the edge, and one log line per pixel would be its own failure.
+  void drawGray8Pixel(const Gray8Target& gray8, int x, int y, uint8_t gray) const;
   void drawBitmap1Bit(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight) const;
   void fillPolygon(const int* xPoints, const int* yPoints, int numPoints, bool state = true) const;
 
@@ -468,6 +485,35 @@ class GfxRenderer {
   void copyGrayscaleLsbBuffers(const uint8_t* plane) const;
   void copyGrayscaleMsbBuffers(const uint8_t* plane) const;
   void displayGrayBuffer() const;
+
+  // --- native grayscale (panels resolving more than the plane pipeline's 4 levels) ---
+  //
+  // Everything above encodes grey as two selector bits per pixel, because that is
+  // all a KW controller can act on. Where the panel keeps a deeper buffer of its
+  // own, a caller can skip the encoding: borrow that buffer, paint 8-bit grey into
+  // it, and let the panel quantise at its native depth. See HalDisplay.
+
+  // 4 on every dual-plane panel, more where the borrow below is backed.
+  uint8_t getGrayLevels() const;
+  // Physical panel layout, one byte per pixel, 0x00 black .. 0xFF white. nullptr
+  // when the panel has no such buffer. Allocates nothing.
+  uint8_t* borrowGray8Canvas(uint16_t* stride) const;
+  // Stamp the framebuffer's BLACK pixels onto a borrowed canvas, leaving every
+  // other canvas byte as painted. This is how 1-bit content — text drawn by the
+  // normal render path — is composited over a grey image without being dithered
+  // down with it. Both buffers are in physical layout, so no orientation applies.
+  void stampBwOntoGray8Canvas(uint8_t* canvas, uint16_t stride) const;
+  // Copy a LOGICAL rectangle of the framebuffer onto a borrowed canvas as solid
+  // black and white, replacing whatever was painted there.
+  //
+  // The difference from stampBwOntoGray8Canvas() is opacity, and it decides which
+  // one a caller wants. Stamping paints only the black pixels, so an image shows
+  // through everywhere else — right for bare text. Content with a BACKGROUND, such
+  // as a filled overlay panel or inverted white-on-black text, needs its whole
+  // rectangle to land or the fill is dropped and the light pixels of the text with
+  // it. Both buffers are 1-bit-derived, so nothing here is dithered.
+  void compositeBwRectOntoGray8Canvas(const Gray8Target& gray8, int x, int y, int width, int height) const;
+  void displayGray8Canvas() const;
 
   // Timing breakdown returned by renderGrayscalePlanesSequential().
   struct GrayscaleTimings {

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -363,6 +363,25 @@ void HalDisplay::displayGrayscaleFrame(const RefreshMode refreshMode, const bool
   lastDisplayModeByte = refreshModeToByte(refreshMode);
 }
 
+uint8_t HalDisplay::getGrayLevels() const { return einkDisplay.grayLevels(); }
+
+uint8_t* HalDisplay::borrowGray8Canvas(uint16_t* stride) {
+  HalSpiBus::Lock spiLock;
+  return einkDisplay.borrowGray8Canvas(stride);
+}
+
+void HalDisplay::displayGray8Canvas(RefreshMode refreshMode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+  LOG_DBG("DISP", "#%lu displayGray8Canvas levels=%u", static_cast<unsigned long>(++panelSeq),
+          static_cast<unsigned>(einkDisplay.grayLevels()));
+  einkDisplay.displayGray8Canvas(convertRefreshMode(refreshMode), turnOffScreen);
+  // Record it like every other display path: the driver substitutes a clean-bank
+  // refresh, so the page summary must not claim whatever mode the caller asked
+  // for. See the note on displayGrayscaleFrame().
+  lastRefreshMode = RefreshMode::FULL_REFRESH;
+  lastDisplayModeByte = refreshModeToByte(RefreshMode::FULL_REFRESH);
+}
+
 void HalDisplay::displayGrayBuffer(bool turnOffScreen) {
   HalSpiBus::Lock spiLock;
   // Give the driver a real BW base when it actually reads one.

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -136,6 +136,27 @@ class HalDisplay {
   // their own beyond deciding whether to stage planes at all.
   void displayGrayscaleFrame(RefreshMode refreshMode, bool turnOffScreen = false);
 
+  // Grey levels this panel resolves in one refresh. 4 on every dual-plane
+  // controller (X3, X4, X4 Pro, M5 Paper Mono) — two selector bits per pixel is
+  // the whole state space, so it is a hard ceiling, not a setting — and 16 on a
+  // panel whose driver keeps a multi-bit buffer of its own (T5S3). Callers that
+  // can render either way branch on this; everyone else keeps the plane path.
+  uint8_t getGrayLevels() const;
+  // Borrow the driver's composition buffer and paint 8-bit grey straight into
+  // it: one byte per pixel (0x00 black, 0xFF white), `stride` bytes per row,
+  // getDisplayHeight() rows, PHYSICAL panel orientation. Costs no heap — the
+  // buffer is the driver's own and already allocated — and returns nullptr
+  // wherever that is not on offer, which is every 4-level panel.
+  //
+  // The loan ends at displayGray8Canvas() or at the next ordinary refresh; a
+  // caller that borrows and then abandons the frame corrupts nothing, because
+  // every normal push rebuilds the buffer from the 1-bpp framebuffer.
+  uint8_t* borrowGray8Canvas(uint16_t* stride);
+  // Quantise the borrowed canvas to the panel's native depth and show it as one
+  // waveform. The driver picks a bank that can land every level, so this may
+  // refresh more thoroughly (and more slowly) than `refreshMode` asked for.
+  void displayGray8Canvas(RefreshMode refreshMode, bool turnOffScreen = false);
+
   // Returns true when the device is an X3 (X4 returns false).
   bool deviceIsX3() const;
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -153,6 +153,14 @@ BitmapToneMapping sleepImageToneMapping() {
   }
 }
 
+// Equalization strength for a sleep image, chosen by how the image will actually
+// reach the panel. The conservative default exists because a four-level target
+// breaks a flattened gradient into dither banding; a target that resolves more
+// has the range to use a stronger curve, and measurably wants one.
+int sleepEqualizeBlend(const GfxRenderer& renderer) {
+  return renderer.getGrayLevels() > 4 ? adaptive_tone::EQ_BLEND_NUM_DEEP : adaptive_tone::EQ_BLEND_NUM;
+}
+
 bool renderPngSleepScreen(const std::string& filename, GfxRenderer& renderer, const BookOverlayInfo& overlayInfo) {
   constexpr size_t MIN_FREE_HEAP = 60 * 1024;  // PNG decoder ~42 KB + overhead
   if (ESP.getFreeHeap() < MIN_FREE_HEAP) {
@@ -216,7 +224,8 @@ bool renderPngSleepScreen(const std::string& filename, GfxRenderer& renderer, co
   // the grey planes layered on top. Skipped entirely on a cache hit.
   const BitmapToneMapping pngToneMapping = sleepImageToneMapping();
   if (!useCache && pngToneMapping != BitmapToneMapping::None) {
-    config.adaptiveTone = PngToFramebufferConverter::analyzeAdaptiveTone(filename, toneAnalysisMode(pngToneMapping));
+    config.adaptiveTone = PngToFramebufferConverter::analyzeAdaptiveTone(filename, toneAnalysisMode(pngToneMapping),
+                                                                         sleepEqualizeBlend(renderer));
   }
   // Write the cache on the decoding pass only; the filter is already part of the
   // cache filename, so no separate invalidation is needed.
@@ -498,7 +507,7 @@ void SleepActivity::renderCustomSleepScreen() const {
   // An explicitly selected custom sleep image should override random images from /.sleep or /sleep.
   FsFile explicitSleepFile;
   if (Storage.openFileForRead("SLP", "/sleep.bmp", explicitSleepFile)) {
-    Bitmap bitmap(explicitSleepFile, true, sleepImageToneMapping());
+    Bitmap bitmap(explicitSleepFile, true, sleepImageToneMapping(), sleepEqualizeBlend(renderer));
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading explicit custom sleep image: /sleep.bmp");
       const BookOverlayInfo resolvedOverlayInfo =
@@ -538,7 +547,7 @@ void SleepActivity::renderCustomSleepScreen() const {
       FsFile file;
       if (Storage.openFileForRead("SLP", filename, file)) {
         delay(100);
-        Bitmap bitmap(file, true, sleepImageToneMapping());
+        Bitmap bitmap(file, true, sleepImageToneMapping(), sleepEqualizeBlend(renderer));
         if (bitmap.parseHeaders() == BmpReaderError::Ok) {
           renderBitmapSleepScreen(bitmap, resolvedOverlayInfo);
           file.close();
@@ -950,7 +959,7 @@ void SleepActivity::renderCoverSleepScreen() const {
     // than at generation time, and the adaptive filter has real tonal data to work
     // with. Covers still cached as 2-bit (or TXT/XTC covers) take the native-palette
     // path inside Bitmap and are unaffected by either flag.
-    Bitmap bitmap(file, /*dithering=*/true, sleepImageToneMapping());
+    Bitmap bitmap(file, /*dithering=*/true, sleepImageToneMapping(), sleepEqualizeBlend(renderer));
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
       const uint8_t overlayMode = SETTINGS.sleepCoverOverlay;

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -17,6 +17,7 @@
 #include <esp_system.h>
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <new>
 
@@ -175,10 +176,16 @@ bool renderPngSleepScreen(const std::string& filename, GfxRenderer& renderer, co
   config.performanceMode = false;
   config.useExactDimensions = false;
 
+  // A panel that resolves more than four levels renders this image natively below,
+  // in one decode with no plane encoding. The .pxc cache is 2 bits per pixel by
+  // construction, so it has nothing to offer that path and is not consulted for it.
+  const bool nativeGray = renderer.getGrayLevels() > 4;
+
   // Mirror the decoder's own output sizing so the cache can be validated against the
   // geometry a fresh decode would produce (see PngToFramebufferConverter: fit to the
   // config box, never upscale).
-  const std::string cachePath = sleepPixelCachePath(filename, SETTINGS.sleepScreenCoverFilter);
+  const std::string cachePath =
+      nativeGray ? std::string() : sleepPixelCachePath(filename, SETTINGS.sleepScreenCoverFilter);
   int cacheW = 0, cacheH = 0, cacheX = 0, cacheY = 0;
   ImageDimensions srcDims{};
   if (!cachePath.empty() && PngToFramebufferConverter::getDimensionsStatic(filename, srcDims) && srcDims.width > 0 &&
@@ -274,6 +281,48 @@ bool renderPngSleepScreen(const std::string& filename, GfxRenderer& renderer, co
   };
 
   PngToFramebufferConverter decoder;
+
+  // Native grayscale: one decode, one push, every level the panel has.
+  //
+  // The three passes below exist only to fill three 1-bit planes. Here the panel
+  // keeps its own deeper buffer, so the decoder's tone-mapped sample is stored
+  // whole and quantised once, by the panel, at its native depth -- no Bayer
+  // dither to four levels on the way out, and no BW carrier for greys to be
+  // layered onto. Falling through costs nothing: every ordinary refresh rebuilds
+  // the canvas from the framebuffer, so a half-painted canvas cannot outlive the
+  // failure that abandoned it.
+  if (nativeGray) {
+    uint16_t canvasStride = 0;
+    if (uint8_t* canvas = renderer.borrowGray8Canvas(&canvasStride)) {
+      // White ground: the image is fitted to the box, not stretched to it, so
+      // whatever it does not cover has to be something rather than stale pixels.
+      for (int row = 0; row < renderer.getDisplayHeight(); row++) {
+        memset(canvas + static_cast<uint32_t>(row) * canvasStride, 0xFF, renderer.getDisplayWidth());
+      }
+
+      DirectGray8Writer gray8;
+      gray8.init(renderer, canvas, canvasStride);
+      RenderConfig nativeConfig = config;
+      nativeConfig.gray8 = &gray8;
+      nativeConfig.cachePath.clear();
+      nativeConfig.companionCachePath.clear();
+
+      renderer.setRenderMode(GfxRenderer::BW);
+      if (decoder.decodeToFramebuffer(filename, renderer, nativeConfig)) {
+        // The overlay is 1-bit text and wants to stay that way: drawn through the
+        // normal render path into a cleared framebuffer, then stamped onto the
+        // canvas as solid black. Dithering it with the image would only soften it.
+        renderer.clearScreen();
+        drawOverlay();
+        renderer.stampBwOntoGray8Canvas(canvas, canvasStride);
+        renderer.displayGray8Canvas();
+        LOG_INF("SLP", "Sleep image rendered at %u levels: %s", static_cast<unsigned>(renderer.getGrayLevels()),
+                filename.c_str());
+        return true;
+      }
+      LOG_DBG("SLP", "Native grayscale sleep decode failed, falling back: %s", filename.c_str());
+    }
+  }
 
   // Pass 1: BW plane — mirrors SleepActivity::renderBitmapSleepScreen so the BW carrier
   // matches the 4-level quantization layered on top via the LSB/MSB planes.
@@ -696,13 +745,32 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const BookOver
        SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::ADAPTIVE_TONE ||
        SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::EQUALIZE_TONE);
 
-  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  // On a panel that resolves more than four levels the image is painted straight
+  // into the panel's own canvas at full depth further down, and this 2-bit pass
+  // would be a whole extra read of the BMP off the SD card for a rendition that is
+  // then discarded. The framebuffer is still wanted -- cleared, carrying the
+  // overlay alone -- so the overlay can be composited over the grey image.
+  //
+  // hasGreyscale gates it for the same reason it gates the plane path below: the
+  // 1-bit and inverted filters have no levels to preserve, and the inversion
+  // immediately below works on the framebuffer this path does not display.
+  const bool nativeGray = hasGreyscale && renderer.getGrayLevels() > 4;
 
-  if (SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
-    renderer.invertScreen();
+  if (!nativeGray) {
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+
+    if (SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
+      renderer.invertScreen();
+    }
   }
 
   const uint8_t overlayMode = SETTINGS.sleepCoverOverlay;
+  // Set by drawOverlay() to the block it actually drew, and left at zero height
+  // when it draws nothing. The native path below composites this rectangle rather
+  // than stamping black pixels, because the block is opaque and its text may be
+  // white -- neither survives a stamp. See compositeBwRectOntoGray8Canvas.
+  int overlayRectY = 0;
+  int overlayRectHeight = 0;
   const auto drawOverlay = [&]() {
     const bool hasTitle = !overlayInfo.title.empty();
     const bool hasProgress = !overlayInfo.progressText.empty();
@@ -732,6 +800,8 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const BookOver
     const int bottomPadding = lineHeight10 * 2 / 3;
     const int overlayHeight = textBlockHeight + topPadding + bottomPadding;
     const int overlayY = pageHeight - overlayHeight;
+    overlayRectY = overlayY;
+    overlayRectHeight = overlayHeight;
 
     if (overlayMode == 2) {
       renderer.fillRectDither(0, overlayY, pageWidth, overlayHeight, Color::LightGray);
@@ -769,6 +839,30 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const BookOver
   };
 
   drawOverlay();
+
+  // Native grayscale: the image goes into the panel's own canvas at full depth,
+  // and the framebuffer -- cleared above, and holding nothing but the overlay
+  // drawOverlay() just drew -- is composited on top of it.
+  if (nativeGray) {
+    uint16_t canvasStride = 0;
+    if (uint8_t* canvas = renderer.borrowGray8Canvas(&canvasStride)) {
+      for (int row = 0; row < renderer.getDisplayHeight(); row++) {
+        memset(canvas + static_cast<uint32_t>(row) * canvasStride, 0xFF, renderer.getDisplayWidth());
+      }
+      const GfxRenderer::Gray8Target target{canvas, canvasStride};
+      bitmap.rewindToData();
+      renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, &target);
+      // Composite the overlay's whole block rather than stamping its dark pixels:
+      // the block is opaque, and in mode 3 it is black with WHITE text, so a
+      // stamp would drop the fill and the text with it.
+      if (overlayRectHeight > 0) {
+        renderer.compositeBwRectOntoGray8Canvas(target, 0, overlayRectY, pageWidth, overlayRectHeight);
+      }
+      renderer.displayGray8Canvas();
+      LOG_INF("SLP", "Sleep bitmap rendered at %u levels", static_cast<unsigned>(renderer.getGrayLevels()));
+      return;
+    }
+  }
 
   if (!hasGreyscale) {
     renderer.displayBuffer(HalDisplay::HALF_REFRESH);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,6 +114,7 @@ add_subdirectory(slider_geometry)
 add_subdirectory(list_row_tap)
 add_subdirectory(default_ignorable)
 add_subdirectory(adaptive_tone)
+add_subdirectory(gray8_writer)
 add_subdirectory(glyph_fallback)
 # After zip_entry_reader: reuses its inflate_reader_host target and HalStorage shim.
 add_subdirectory(dictionary)

--- a/test/adaptive_tone/AdaptiveToneTest.cpp
+++ b/test/adaptive_tone/AdaptiveToneTest.cpp
@@ -341,3 +341,94 @@ TEST(Gray4Quantization, IsMonotonicInBothModes) {
 }
 
 }  // namespace
+
+// --- Equalize strength -------------------------------------------------------
+//
+// The blend was a fixed 1/4, chosen against four-level panels where a flattened
+// gradient breaks into dither banding. A panel resolving eleven levels wants a
+// stronger curve, so the strength became a parameter. These pin the properties
+// the two call sites depend on: that it does something, that it does more of it
+// as it rises, and that leaving it alone still produces the old curve exactly.
+namespace {
+
+// A bimodal cover: most of the mass in a dark band, a bright sliver of title text.
+// Exactly the shape Mode::Stretch cannot help and Equalize exists for.
+Histogram bimodal() {
+  Histogram h{};
+  for (int i = 30; i <= 70; i++) h[static_cast<size_t>(i)] = 900;
+  for (int i = 240; i <= 252; i++) h[static_cast<size_t>(i)] = 60;
+  return h;
+}
+
+// Mean absolute output separation between neighbouring input levels across the
+// band that carries the image -- a stand-in for how much tonal detail survives.
+double spreadAcrossBand(const Points& points, const int lo, const int hi) {
+  double sum = 0;
+  for (int i = lo; i < hi; i++) {
+    sum += std::abs(static_cast<int>(adaptive_tone::apply(points, static_cast<uint8_t>(i + 1))) -
+                    static_cast<int>(adaptive_tone::apply(points, static_cast<uint8_t>(i))));
+  }
+  return sum / (hi - lo);
+}
+
+}  // namespace
+
+TEST(AdaptiveToneEqualizeStrength, DefaultMatchesTheShippedFourLevelBlend) {
+  const Histogram h = bimodal();
+  const Points defaulted = adaptive_tone::derivePoints(h.data(), total(h), Mode::Equalize);
+  std::array<uint8_t, 256> viaDefault{};
+  for (int i = 0; i < 256; i++)
+    viaDefault[static_cast<size_t>(i)] = adaptive_tone::apply(defaulted, static_cast<uint8_t>(i));
+
+  const Points explicitly =
+      adaptive_tone::derivePoints(h.data(), total(h), Mode::Equalize, adaptive_tone::EQ_BLEND_NUM);
+  for (int i = 0; i < 256; i++) {
+    EXPECT_EQ(adaptive_tone::apply(explicitly, static_cast<uint8_t>(i)), viaDefault[static_cast<size_t>(i)])
+        << "omitting the strength must reproduce the four-level curve, at level " << i;
+  }
+}
+
+TEST(AdaptiveToneEqualizeStrength, DeeperBlendSpreadsTheDominantBandFurther) {
+  const Histogram h = bimodal();
+  const Points weak = adaptive_tone::derivePoints(h.data(), total(h), Mode::Equalize, adaptive_tone::EQ_BLEND_NUM);
+  const double weakSpread = spreadAcrossBand(weak, 30, 70);
+  const Points strong =
+      adaptive_tone::derivePoints(h.data(), total(h), Mode::Equalize, adaptive_tone::EQ_BLEND_NUM_DEEP);
+  const double strongSpread = spreadAcrossBand(strong, 30, 70);
+
+  ASSERT_TRUE(weak.active);
+  ASSERT_TRUE(strong.active);
+  // The whole reason for the parameter: the band the image actually occupies must
+  // be given more output range, or a deeper panel has nothing extra to show.
+  EXPECT_GT(strongSpread, weakSpread * 1.5) << "deep blend spread " << strongSpread << " vs shallow " << weakSpread;
+}
+
+TEST(AdaptiveToneEqualizeStrength, StaysMonotonicAndInRangeAtEveryStrength) {
+  const Histogram h = bimodal();
+  for (int num = 0; num <= adaptive_tone::EQ_BLEND_DEN; num++) {
+    const Points p = adaptive_tone::derivePoints(h.data(), total(h), Mode::Equalize, num);
+    int previous = -1;
+    for (int i = 0; i < 256; i++) {
+      const int mapped = adaptive_tone::apply(p, static_cast<uint8_t>(i));
+      EXPECT_GE(mapped, previous) << "curve went backwards at level " << i << ", strength " << num;
+      EXPECT_GE(mapped, 0);
+      EXPECT_LE(mapped, 255);
+      previous = mapped;
+    }
+  }
+}
+
+TEST(AdaptiveToneEqualizeStrength, StrengthDoesNotDisturbStretch) {
+  // Mode::Stretch ignores the parameter; a caller passing the deep value for its
+  // Equalize path must not change what Stretch does on the same histogram.
+  const Histogram h = band(20, 200);
+  const Points shallow = adaptive_tone::derivePoints(h.data(), total(h), Mode::Stretch, adaptive_tone::EQ_BLEND_NUM);
+  const Points deep = adaptive_tone::derivePoints(h.data(), total(h), Mode::Stretch, adaptive_tone::EQ_BLEND_NUM_DEEP);
+  ASSERT_TRUE(deep.active);
+  EXPECT_EQ(shallow.blackPoint, deep.blackPoint);
+  EXPECT_EQ(shallow.whitePoint, deep.whitePoint);
+  for (int i = 0; i < 256; i++) {
+    EXPECT_EQ(adaptive_tone::apply(deep, static_cast<uint8_t>(i)), referenceStretch(deep, static_cast<uint8_t>(i)))
+        << "at level " << i;
+  }
+}

--- a/test/gray8_writer/CMakeLists.txt
+++ b/test/gray8_writer/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(Gray8WriterTest Gray8WriterTest.cpp)
+
+target_include_directories(Gray8WriterTest PRIVATE
+  # Stub GfxRenderer.h / HalDisplay.h must shadow the real device headers.
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${REPO_ROOT}/lib/Epub/Epub/converters
+)
+
+target_link_libraries(Gray8WriterTest PRIVATE GTest::gtest_main)
+
+gtest_discover_tests(Gray8WriterTest)

--- a/test/gray8_writer/GfxRenderer.h
+++ b/test/gray8_writer/GfxRenderer.h
@@ -1,0 +1,53 @@
+#pragma once
+// Configurable host-test GfxRenderer stub for DirectGray8Writer.
+//
+// Unlike the pipeline harness stub, orientation and panel geometry are settable:
+// the whole point of these tests is that the byte writer and the bit writer agree
+// under EVERY orientation, and a stub fixed at Portrait could not show that.
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+enum Color : uint8_t { Clear = 0x00, White = 0x01, LightGray = 0x05, DarkGray = 0x0A, Black = 0x10 };
+
+class GfxRenderer {
+ public:
+  enum RenderMode { BW, GRAYSCALE_LSB, GRAYSCALE_MSB };
+  enum Orientation { Portrait, LandscapeClockwise, PortraitInverted, LandscapeCounterClockwise };
+
+  GfxRenderer(const int panelWidth, const int panelHeight, const Orientation orientation)
+      : width_(panelWidth), height_(panelHeight), orientation_(orientation), widthBytes_((panelWidth + 7) / 8) {
+    frameBuffer_.assign(static_cast<size_t>(widthBytes_) * height_, 0xFF);
+  }
+
+  int getDisplayWidth() const { return width_; }
+  int getDisplayHeight() const { return height_; }
+  uint16_t getDisplayWidthBytes() const { return static_cast<uint16_t>(widthBytes_); }
+  Orientation getOrientation() const { return orientation_; }
+  RenderMode getRenderMode() const { return mode_; }
+  void setRenderMode(const RenderMode mode) { mode_ = mode; }
+  uint8_t* getWriteTarget() const { return const_cast<uint8_t*>(frameBuffer_.data()); }
+  int getWriteOriginY() const { return 0; }
+  int getWriteRows() const { return height_; }
+
+  // Oriented logical surface, mirroring the device renderer's swap on portrait.
+  int getScreenWidth() const {
+    return (orientation_ == Portrait || orientation_ == PortraitInverted) ? height_ : width_;
+  }
+  int getScreenHeight() const {
+    return (orientation_ == Portrait || orientation_ == PortraitInverted) ? width_ : height_;
+  }
+
+  // True where the 1-bpp framebuffer holds a black pixel (bit clear = black).
+  bool isBlackAt(const int x, const int y) const {
+    return (frameBuffer_[static_cast<size_t>(y) * widthBytes_ + (x >> 3)] & (0x80 >> (x & 7))) == 0;
+  }
+
+ private:
+  int width_;
+  int height_;
+  Orientation orientation_;
+  int widthBytes_;
+  RenderMode mode_ = BW;
+  std::vector<uint8_t> frameBuffer_;
+};

--- a/test/gray8_writer/Gray8WriterTest.cpp
+++ b/test/gray8_writer/Gray8WriterTest.cpp
@@ -1,0 +1,147 @@
+// DirectGray8Writer geometry.
+//
+// The byte writer exists so a 16-level panel can be painted without the 2-bit
+// plane encoding, and it borrows DirectPixelWriter's orientation transform to do
+// it. These tests pin that borrowing down: for every orientation, a logical pixel
+// must land on the SAME physical pixel through both writers. A divergence here is
+// a rotated or mirrored sleep screen, and it would only ever be visible on the
+// one board that takes this path.
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "DirectPixelWriter.h"
+
+namespace {
+
+constexpr uint8_t kUnset = 0x7F;
+
+// Paint one logical pixel through both writers and report where each landed.
+// Returns the physical coordinates the byte writer used, or {-1,-1} if it
+// dropped the pixel.
+struct Landing {
+  int x = -1;
+  int y = -1;
+};
+
+Landing gray8Landing(const std::vector<uint8_t>& canvas, const int stride, const int width, const int height) {
+  Landing hit;
+  int found = 0;
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      if (canvas[static_cast<size_t>(y) * stride + x] != kUnset) {
+        hit = {x, y};
+        found++;
+      }
+    }
+  }
+  EXPECT_LE(found, 1) << "a single writePixel must touch at most one canvas byte";
+  return hit;
+}
+
+Landing bwLanding(const GfxRenderer& renderer) {
+  Landing hit;
+  int found = 0;
+  for (int y = 0; y < renderer.getDisplayHeight(); y++) {
+    for (int x = 0; x < renderer.getDisplayWidth(); x++) {
+      if (renderer.isBlackAt(x, y)) {
+        hit = {x, y};
+        found++;
+      }
+    }
+  }
+  EXPECT_LE(found, 1) << "a single writePixel must touch at most one framebuffer bit";
+  return hit;
+}
+
+class OrientationTest : public ::testing::TestWithParam<GfxRenderer::Orientation> {};
+
+TEST_P(OrientationTest, ByteWriterLandsWhereBitWriterDoes) {
+  // Deliberately not square and not a multiple of 8 in both axes, so a
+  // transposed or byte-rounded mapping cannot pass by coincidence.
+  constexpr int kPanelW = 96;
+  constexpr int kPanelH = 40;
+  constexpr int kStride = kPanelW + 5;  // stride > width: the canvas may be padded
+
+  for (int logicalY = 0; logicalY < 40; logicalY += 7) {
+    for (int logicalX = 0; logicalX < 40; logicalX += 5) {
+      GfxRenderer renderer(kPanelW, kPanelH, GetParam());
+      if (logicalX >= renderer.getScreenWidth() || logicalY >= renderer.getScreenHeight()) continue;
+
+      std::vector<uint8_t> canvas(static_cast<size_t>(kStride) * kPanelH, kUnset);
+      DirectGray8Writer g8;
+      g8.init(renderer, canvas.data(), kStride);
+      g8.beginRow(logicalY);
+      g8.writePixel(logicalX, 0x42);
+
+      DirectPixelWriter pw;
+      pw.init(renderer);
+      pw.beginRow(logicalY);
+      pw.writePixel(logicalX, 0);  // value < 3 draws black in BW mode
+
+      const Landing gray = gray8Landing(canvas, kStride, kPanelW, kPanelH);
+      const Landing bw = bwLanding(renderer);
+      EXPECT_EQ(gray.x, bw.x) << "orientation " << GetParam() << " logical (" << logicalX << "," << logicalY << ")";
+      EXPECT_EQ(gray.y, bw.y) << "orientation " << GetParam() << " logical (" << logicalX << "," << logicalY << ")";
+      EXPECT_NE(gray.x, -1) << "pixel dropped at logical (" << logicalX << "," << logicalY << ")";
+      EXPECT_EQ(canvas[static_cast<size_t>(gray.y) * kStride + gray.x], 0x42) << "sample must be stored unquantised";
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllOrientations, OrientationTest,
+                         ::testing::Values(GfxRenderer::Portrait, GfxRenderer::LandscapeClockwise,
+                                           GfxRenderer::PortraitInverted, GfxRenderer::LandscapeCounterClockwise));
+
+TEST(Gray8Writer, StoresTheFullEightBitRange) {
+  // The reason this writer exists: a level the 2-bit path cannot express must
+  // survive to the canvas untouched, for the panel to quantise later.
+  GfxRenderer renderer(64, 8, GfxRenderer::LandscapeCounterClockwise);
+  std::vector<uint8_t> canvas(64 * 8, kUnset);
+  DirectGray8Writer g8;
+  g8.init(renderer, canvas.data(), 64);
+  g8.beginRow(0);
+  for (int x = 0; x < 64; x++) g8.writePixel(x, static_cast<uint8_t>(x * 4));
+  for (int x = 0; x < 64; x++) EXPECT_EQ(canvas[x], static_cast<uint8_t>(x * 4)) << "at x=" << x;
+}
+
+TEST(Gray8Writer, DropsPixelsOutsideThePanel) {
+  GfxRenderer renderer(64, 8, GfxRenderer::LandscapeCounterClockwise);
+  std::vector<uint8_t> canvas(64 * 8, kUnset);
+  DirectGray8Writer g8;
+  g8.init(renderer, canvas.data(), 64);
+
+  g8.beginRow(0);
+  g8.writePixel(-1, 0x00);  // left of the panel
+  g8.writePixel(64, 0x00);  // right of it
+  g8.writePixel(9999, 0x00);
+  g8.beginRow(8);  // below the last row
+  g8.writePixel(0, 0x00);
+  g8.beginRow(-1);  // above the first
+  g8.writePixel(0, 0x00);
+
+  for (const uint8_t byte : canvas) EXPECT_EQ(byte, kUnset);
+}
+
+TEST(Gray8Writer, HonoursStridePaddingBetweenRows) {
+  // A canvas whose stride exceeds its width must not have row N+1 written into
+  // row N's padding -- the panel buffer this borrows is the driver's own.
+  constexpr int kStride = 70;
+  GfxRenderer renderer(64, 4, GfxRenderer::LandscapeCounterClockwise);
+  std::vector<uint8_t> canvas(static_cast<size_t>(kStride) * 4, kUnset);
+  DirectGray8Writer g8;
+  g8.init(renderer, canvas.data(), kStride);
+  for (int y = 0; y < 4; y++) {
+    g8.beginRow(y);
+    for (int x = 0; x < 64; x++) g8.writePixel(x, static_cast<uint8_t>(0x10 + y));
+  }
+  for (int y = 0; y < 4; y++) {
+    EXPECT_EQ(canvas[static_cast<size_t>(y) * kStride], static_cast<uint8_t>(0x10 + y));
+    for (int pad = 64; pad < kStride; pad++) {
+      EXPECT_EQ(canvas[static_cast<size_t>(y) * kStride + pad], kUnset) << "row " << y << " pad " << pad;
+    }
+  }
+}
+
+}  // namespace

--- a/test/gray8_writer/HalDisplay.h
+++ b/test/gray8_writer/HalDisplay.h
@@ -1,0 +1,3 @@
+#pragma once
+// DirectPixelWriter.h includes this; nothing in these tests reads it.
+#include <cstdint>


### PR DESCRIPTION
Sleep images were dithered to four levels on every board. On the T5S3 the panel resolves eleven, and the difference is plainly visible.

Depends on jpirnay/freeink-sdk#4 (submodule bump included).

## The four-level ceiling

The display pipeline encodes grey as two selector bits per pixel. That is a hard ceiling on a KW controller — the `(old, new)` bit pair *is* the state space — but not on a panel keeping a deeper buffer of its own. The SDK PR lends that buffer; this wires the firmware through to it.

## What's here

**`HalDisplay` / `GfxRenderer`** expose `getGrayLevels()`, `borrowGray8Canvas()` and `displayGray8Canvas()`, plus two compositors for putting 1-bit content over a grey image. They differ in *opacity*, and that decides which a caller wants:

- `stampBwOntoGray8Canvas()` paints only the black pixels — right for bare text
- `compositeBwRectOntoGray8Canvas()` lands a whole rectangle — needed for content with a background, such as a filled overlay panel or inverted white-on-black text, where a stamp would drop the fill and the light pixels of the text with it

**`DirectGray8Writer`** stores bytes exactly where `DirectPixelWriter` stores bits, embedding the latter to borrow its orientation transform rather than keeping a second copy that could drift. Tested against it in all four orientations — a divergence there is a rotated sleep screen, visible only on the one board that takes this path.

**The decoders gain an 8-bit sink.** `PngToFramebufferConverter` already computed the tone-mapped sample and then threw six bits away in `ditherGray()`; with a sink set it stores the sample whole and writes neither the framebuffer nor any cache, since a 2-bit `.pxc` cannot replay a deeper frame. `Bitmap::readNextRow()` optionally emits the same sample per pixel — computed *alongside* the existing branches rather than shared with them, so the 2-bit rendition every other panel shows is byte-for-byte unchanged.

**`SleepActivity`** takes the native path when the panel resolves more than four levels: one decode instead of the three-pass BW/LSB/MSB dance, no plane encoding, no pixel cache. Falling through costs nothing — every ordinary refresh rebuilds the canvas from the framebuffer, so a half-painted canvas cannot outlive the failure that abandoned it. The BMP path skips its 2-bit pass entirely rather than drawing and discarding it, which would be a whole extra read of the bitmap off the SD card.

## Equalization strength (second commit)

`adaptive_tone`'s Equalize blend was a fixed 1/4, documented as chosen because *"above 1/4 the smooth background gradients on photographic covers break into visible dither banding"*. That is a statement about a four-level panel. On an eleven-level sleep screen, Equalize at 1/4 was reported on hardware as "barely different" from no filter at all.

Measured on two covers through the T5S3's response, on a bimodal cover — dark ground with white title text, exactly the case `Mode::Stretch` cannot help, where its percentile gain came out at 1.07x:

| | mean | local contrast |
|---|---|---|
| no filter | 52.4% | 0.611 |
| blend 1/4 | 54.5% | 0.653 |
| blend 3/4 | 58.6% | 0.726 |

`derivePoints()` takes the strength as a parameter, defaulting to the existing value so every current caller is unchanged. Gated on the **render path, not the device**: a deep panel still draws in-book images and covers through the dual-plane path, and those want the conservative value.

## Risk to existing boards

Every panel reporting four levels keeps its existing path untouched, and that is all of them but the T5S3. **X4 Pro RAM is unchanged to the byte** (90460, measured against a clean baseline build); its flash grows 2.1 KB.

## Testing

- Device-validated on the LilyGo T5 S3 Pro, over several rounds: a canvas histogram split host-side from panel-side loss, then a synthetic ramp confirmed the panel's real ceiling.
- 790 host tests pass. 7 new in `test/gray8_writer` (byte writer vs bit writer, all four orientations — mutation-checked by inverting the transform and confirming failure); 4 new in `test/adaptive_tone` pinning the blend parameter.
- Builds clean for `lilygo_t5s3`, `x4pro` and the ESP32-C3 `default`.

## Not validated

The equalize-strength change is modelled, not seen on device. The metric behind those numbers cannot see dither banding, which is the exact artifact the 1/4 value was protecting against. If a photographic cover comes back blotchy, `EQ_BLEND_NUM_DEEP` is the dial.