### PR TITLE
feat(sleep): announce a first-time cover build, and overlap its refresh

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1216,9 +1216,11 @@ bool coverBmpComplete(const std::string& path) {
 }
 }  // namespace
 
+bool Epub::coverBmpReady(bool cropped) const { return coverBmpComplete(getCoverBmpPath(cropped)); }
+
 bool Epub::generateCoverBmp(bool cropped) const {
   // Reuse only a COMPLETE cached BMP; a truncated one (interrupted write) must be regenerated.
-  if (coverBmpComplete(getCoverBmpPath(cropped))) return true;
+  if (coverBmpReady(cropped)) return true;
   Storage.remove(getCoverBmpPath(cropped).c_str());  // drop any partial before regenerating
 
   if (!ensureCoverImageCached()) return false;

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -182,6 +182,11 @@ class Epub {
   // True if cover.img is usable now. allowExtract=false never inflates — it only reports
   // whether an already-cached cover.img exists, deferring extraction to a sliced session.
   bool coverImageCachedAndValid(bool allowExtract) const;
+  // True when generateCoverBmp() would return immediately because a usable BMP is already
+  // cached. Needs no load() — the path is derived in the constructor — so a caller can ask
+  // "is this going to be slow?" before committing to the work (the sleep screen decides
+  // whether to put up a popup on that answer).
+  bool coverBmpReady(bool cropped = false) const;
   bool generateCoverBmp(bool cropped = false) const;
   std::string getThumbBmpPath() const;
   std::string getThumbBmpPath(int height) const;

--- a/lib/Txt/Txt.cpp
+++ b/lib/Txt/Txt.cpp
@@ -102,9 +102,11 @@ std::string Txt::findCoverImage() const {
 
 std::string Txt::getCoverBmpPath() const { return cachePath + "/cover.bmp"; }
 
+bool Txt::coverBmpReady() const { return Storage.exists(getCoverBmpPath().c_str()); }
+
 bool Txt::generateCoverBmp() const {
   // Already generated, return true
-  if (Storage.exists(getCoverBmpPath().c_str())) {
+  if (coverBmpReady()) {
     return true;
   }
 

--- a/lib/Txt/Txt.h
+++ b/lib/Txt/Txt.h
@@ -25,6 +25,10 @@ class Txt {
 
   // Cover image support - looks for cover.bmp/jpg/jpeg/png in same folder as txt file
   [[nodiscard]] std::string getCoverBmpPath() const;
+  // True when generateCoverBmp() would return immediately from its cache. Needs no load() —
+  // the path is derived in the constructor — so a caller can ask "is this going to be slow?"
+  // before committing to the work. See Epub::coverBmpReady.
+  [[nodiscard]] bool coverBmpReady() const;
   [[nodiscard]] bool generateCoverBmp() const;
   [[nodiscard]] std::string findCoverImage() const;
 

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -282,9 +282,11 @@ struct XthRowTranspose {
 
 std::string Xtc::getCoverBmpPath() const { return cachePath + "/cover.bmp"; }
 
+bool Xtc::coverBmpReady() const { return Storage.exists(getCoverBmpPath().c_str()); }
+
 bool Xtc::generateCoverBmp() const {
   // Already generated
-  if (Storage.exists(getCoverBmpPath().c_str())) {
+  if (coverBmpReady()) {
     return true;
   }
 

--- a/lib/Xtc/Xtc.h
+++ b/lib/Xtc/Xtc.h
@@ -75,6 +75,10 @@ class Xtc {
 
   // Cover image support (for sleep screen)
   std::string getCoverBmpPath() const;
+  // True when generateCoverBmp() would return immediately from its cache. Needs no load() —
+  // the path is derived in the constructor — so a caller can ask "is this going to be slow?"
+  // before committing to the work. See Epub::coverBmpReady.
+  bool coverBmpReady() const;
   bool generateCoverBmp() const;
   // Thumbnail support (for Continue Reading card)
   std::string getThumbBmpPath() const;

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -26,6 +26,7 @@
 #include "../reader/XtcReaderActivity.h"
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
+#include "components/UITheme.h"
 #include "fontIds.h"
 #include "images/Logo120.h"
 #include "images/MoonIcon.h"
@@ -453,6 +454,21 @@ size_t pickSleepImageIndex(size_t numFiles) {
   return idx;
 }
 
+// True when renderCoverSleepScreen() is about to BUILD this book's sleep cover rather than just
+// stream the one already on the SD card. Constructing the book object only hashes its path (the
+// cache path is derived in the constructor), so this answers before any load() — which is the
+// point: the answer decides whether the user is left staring at an unchanged screen.
+//
+// A book whose cover turns out to be missing altogether answers true as well. Nothing cheaper can
+// tell "this will take seconds" from "this will fail immediately", and announcing an attempt that
+// then falls back to the default sleep screen is the lesser wrong.
+bool sleepCoverNeedsPreparing(const std::string& bookPath, bool cropped) {
+  if (FsHelpers::hasXtcExtension(bookPath)) return !Xtc(bookPath, "/.crosspoint").coverBmpReady();
+  if (FsHelpers::hasTxtExtension(bookPath)) return !Txt(bookPath, "/.crosspoint").coverBmpReady();
+  if (FsHelpers::hasEpubExtension(bookPath)) return !Epub(bookPath, "/.crosspoint").coverBmpReady(cropped);
+  return false;  // not a format with a cover: nothing to prepare, so nothing to announce
+}
+
 }  // namespace
 
 void SleepActivity::onEnter() {
@@ -472,6 +488,8 @@ void SleepActivity::onEnter() {
 
   // No "Entering sleep..." popup here: it shipped a full extra refresh (~500 ms on X3)
   // before the sleep screen's own refresh; the sleep screen appearing is the feedback.
+  // The one exception is a cover that still has to be built — renderCoverSleepScreen()
+  // puts the popup up there, because that path is seconds away from its own refresh.
   // The renderers below all expect portrait: the cover BMP is generated portrait-sized
   // (getDisplayHeight x getDisplayWidth) and the custom/default screens are laid out
   // portrait. A timeout sleep bypasses the reader's onExit() orientation reset, so force
@@ -917,6 +935,18 @@ void SleepActivity::renderCoverSleepScreen() const {
   std::string coverBmpPath;
   const bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
 
+  // onEnter() skips the "going to sleep" popup because the sleep screen itself is the feedback,
+  // one refresh away. That reasoning does not survive a first-time cover: extracting it from the
+  // book and running the full-size PNG/JPEG decoder takes seconds, during which the screen still
+  // shows the last page and the device looks ignored. So announce it — but only then.
+  const bool coverNeedsPreparing = sleepCoverNeedsPreparing(APP_STATE.openEpubPath, cropped);
+  if (coverNeedsPreparing) {
+    // Grab the on-screen frame while it is still reachable: it lives in the secondary buffer, and
+    // the release below frees exactly that. drawPopup() then composes the box onto the copy
+    // (overlayDisplayedFrame = false) instead of doing a sync that would by then be a no-op.
+    renderer.syncWriteBufferFromDisplayed();
+  }
+
   // generateCoverBmp() runs the full-size PNG/JPEG decoder, whose inflate ring and pixel buffers
   // need a large contiguous block; on a big cover (e.g. a 1200x1848 PNG) that malloc fails under
   // sleep-time heap pressure and the cover silently falls back to /sleep.bmp. Free the ~52 KB
@@ -924,6 +954,16 @@ void SleepActivity::renderCoverSleepScreen() const {
   // sleep render below draws via the grayscale planes / controller RAM, not the secondary buffer,
   // and enterDeepSleep() tears everything down (chip reset on wake) immediately after.
   if (renderer.hasSecondaryBuffer()) renderer.releaseSecondaryBuffer();
+
+  if (coverNeedsPreparing) {
+    // Ship the popup without waiting out its waveform. The panel repaints from the controller's
+    // own RAM, and the cover build below is pure SD -> SD streaming that never reads or writes the
+    // framebuffer, so the two overlap: the popup costs the moment it takes to push the frame, not
+    // the ~600 ms it takes to appear. Arming it only AFTER the release is deliberate —
+    // releaseSecondaryBuffer() frees without draining a refresh in flight, and X3 re-reads that
+    // buffer for its post-waveform sync. finishDisplayAsync() below closes the window again.
+    GUI.drawPopup(renderer, tr(STR_ENTERING_SLEEP), /*overlayDisplayedFrame=*/false, PopupShip::Async);
+  }
 
   if (FsHelpers::hasXtcExtension(APP_STATE.openEpubPath)) {
     Xtc lastXtc(APP_STATE.openEpubPath, "/.crosspoint");
@@ -948,6 +988,10 @@ void SleepActivity::renderCoverSleepScreen() const {
       LOG_ERR("SLP", "Failed to load/generate EPUB cover bmp");
     }
   }
+
+  // Everything below writes the framebuffer or drives the panel, so the overlapped popup refresh
+  // has to be finished first.
+  if (coverNeedsPreparing) renderer.finishDisplayAsync();
 
   if (coverBmpPath.empty()) {
     return (this->*renderNoCoverSleepScreen)();

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -997,7 +997,16 @@ void BaseTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   TapTargets::homeMenu().record(menuTargets);
 }
 
-Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message, const bool overlayDisplayedFrame) const {
+void BaseTheme::shipPopup(const GfxRenderer& renderer, const PopupShip ship) {
+  if (ship == PopupShip::Async) {
+    renderer.triggerDisplayAsync();
+  } else {
+    renderer.displayBuffer();
+  }
+}
+
+Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message, const bool overlayDisplayedFrame,
+                          const PopupShip ship) const {
   // Re-seed the write buffer from the frame on screen so the box overlays current content, not the
   // stale two-refreshes-ago frame left by the last buffer swap. Compose-then-popup callers skip this.
   if (overlayDisplayedFrame) renderer.syncWriteBufferFromDisplayed();
@@ -1015,7 +1024,7 @@ Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message, cons
   const int textX = x + (w - textWidth) / 2;
   const int textY = y + margin - 2;
   renderer.drawText(UI_12_FONT_ID, textX, textY, message, true, EpdFontFamily::BOLD);
-  renderer.displayBuffer();
+  shipPopup(renderer, ship);
   return Rect{x, y, w, h};
 }
 

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -22,6 +22,16 @@ struct Rect {
   explicit Rect(int x = 0, int y = 0, int width = 0, int height = 0) : x(x), y(y), width(width), height(height) {}
 };
 
+// How drawPopup() ships the frame it just composed.
+enum class PopupShip : uint8_t {
+  Blocking,  // displayBuffer(): return once the panel has finished painting the box.
+  Async,     // triggerDisplayAsync(): return while the panel is still painting, so the caller can
+             // start the slow work the popup is announcing. The caller then owes the panel a
+             // GfxRenderer::finishDisplayAsync() before it next writes the framebuffer, touches
+             // the display, or frees a framebuffer — releaseSecondaryBuffer() in particular does
+             // NOT drain a refresh in flight, and X3 re-reads the frame after the waveform.
+};
+
 struct TabInfo {
   const char* label;
   bool selected;
@@ -183,7 +193,9 @@ class BaseTheme {
   // Syncing the write buffer from the displayed frame first fixes that. Callers that have already
   // composed a full fresh frame into the write buffer (clearScreen + render, then popup in the same
   // displayBuffer) must pass overlayDisplayedFrame=false so their render is not discarded.
-  virtual Rect drawPopup(const GfxRenderer& renderer, const char* message, bool overlayDisplayedFrame = true) const;
+  // ship=Async returns while the panel paints; see PopupShip for what the caller then owes.
+  virtual Rect drawPopup(const GfxRenderer& renderer, const char* message, bool overlayDisplayedFrame = true,
+                         PopupShip ship = PopupShip::Blocking) const;
   virtual void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const;
   virtual void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage,
                              const int pageCount, std::string title, const int paddingBottom = 0,
@@ -275,4 +287,8 @@ class BaseTheme {
   // Up/down triangles marking that the list continues past the visible rows. Used by themes
   // without a scroll bar.
   static void drawListOverflowArrows(const GfxRenderer& renderer, Rect rect);
+
+  // Ships the frame a drawPopup() override just composed, blocking or not. One place so the two
+  // popup looks cannot drift on the part that isn't a look at all.
+  static void shipPopup(const GfxRenderer& renderer, PopupShip ship);
 };

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -808,7 +808,8 @@ void LyraTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   TapTargets::homeMenu().record(menuTargets);
 }
 
-Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message, const bool overlayDisplayedFrame) const {
+Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message, const bool overlayDisplayedFrame,
+                          const PopupShip ship) const {
   // See BaseTheme::drawPopup: overlay the box on the displayed frame unless the caller composed its
   // own full frame into the write buffer.
   if (overlayDisplayedFrame) renderer.syncWriteBufferFromDisplayed();
@@ -827,7 +828,7 @@ Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message, cons
   const int textX = x + (w - textWidth) / 2;
   const int textY = y + popupMarginY - 2;
   renderer.drawText(UI_12_FONT_ID, textX, textY, message, false, EpdFontFamily::REGULAR);
-  renderer.displayBuffer();
+  shipPopup(renderer, ship);
 
   return Rect{x, y, w, h};
 }

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -69,7 +69,8 @@ class LyraTheme : public BaseTheme {
                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
                            std::function<bool()> storeCoverBuffer) const override;
   void drawEmptyRecents(const GfxRenderer& renderer, const Rect rect) const;
-  Rect drawPopup(const GfxRenderer& renderer, const char* message, bool overlayDisplayedFrame = true) const override;
+  Rect drawPopup(const GfxRenderer& renderer, const char* message, bool overlayDisplayedFrame = true,
+                 PopupShip ship = PopupShip::Blocking) const override;
   void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const override;
   void drawTextField(const GfxRenderer& renderer, Rect rect, const int textWidth, bool cursorMode = false,
                      int contentStartX = 0, int contentWidth = 0) const override;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Give the user feedback when powering off has to *build* the sleep cover for the first time, and make that feedback nearly free.

  Powering off deliberately skips the "Going to sleep" popup: the sleep screen lands one refresh later and is its own feedback. That reasoning does not hold on a first-time cover — extracting it from the book and running the full-size PNG/JPEG decoder takes seconds, during which the screen still shows the last page and the device looks ignored.

* **What changes are included?**

  **1. The popup, only when it is earned.** `coverBmpReady()` on `Epub` / `Txt` / `Xtc` is the cached-file check each `generateCoverBmp()` already ran as its first line, hoisted so `renderCoverSleepScreen()` can ask it *without* a `load()` — the cache path is derived in the constructor, so the probe is a string hash plus one header read. A cached cover behaves exactly as before: no popup, no extra refresh. Cache miss → the popup.

  **2. The refresh runs while the cover builds.** `generateCoverBmp()` streams SD→SD and never reads or writes the framebuffer, making it the one sleep-path step that can genuinely overlap a waveform. `BaseTheme::drawPopup()` gained a `PopupShip` argument; `PopupShip::Async` ships via `triggerDisplayAsync()` instead of `displayBuffer()`, so the popup costs the moment it takes to push the frame rather than the ~600 ms it takes to appear.

  The message reuses `STR_ENTERING_SLEEP`, already translated in all 24 languages and unreferenced since the popup was removed.

## Additional Context

**The ordering around the secondary buffer is load-bearing** and is the part worth reviewing closely:

```
syncWriteBufferFromDisplayed()   // the on-screen frame lives in the secondary buffer
releaseSecondaryBuffer()         // heap headroom for the decoder (pre-existing)
drawPopup(..., PopupShip::Async) // arm the refresh
generateCoverBmp()               // overlaps the waveform; touches no framebuffer
finishDisplayAsync()             // drain before anything renders again
```

`releaseSecondaryBuffer()` frees *without* draining a refresh in flight, and X3 re-reads that frame in its post-waveform DTM1 sync — so arming the refresh before the release would free the buffer out from under it. The popup is therefore composed with `overlayDisplayedFrame=false` onto a copy taken while the secondary buffer still existed.

**Not extended to the PNG sleep-image path, deliberately.** A first-time `.pxc` decode has a similar cost, but it decodes straight into the framebuffer / gray8 canvas — there is no separable prepare step to overlap, and on X3 the framebuffer must stay intact until the refresh finishes. A popup there would *add* ~600 ms rather than hide it. The cover is the only "build a file first, then render it" case in the sleep path.

**Risk:** display sequencing on the sleep path, which is hard to unit-test. Not yet validated on hardware — worth a manual check on X3 and X4 with (a) a book whose cover is already cached and (b) a freshly copied book with a large PNG cover.

**Verification so far**

| | result |
|---|---|
| `env:default` (X3) | SUCCESS — RAM 17.5%, Flash 95.1% |
| `env:x4pro` | SUCCESS — RAM 27.6%, Flash 93.4% |
| host suite (861 tests) | 860 pass; the one failure (`DictionaryTest.ResolveBasePathRejectsEscapesAndMissingFolders`, a `/` vs `\` path-separator comparison) is pre-existing and unrelated |

**Build note for anyone with an existing checkout:** `STR_ENTERING_SLEEP` had been stripped from `I18nKeys.h` because nothing referenced it, and the generator's freshness check only compares its outputs against the translation YAMLs — never against the sources whose `STR_*` references decide the strip. Referencing a previously-stripped key therefore does not trigger a regen. Force it once, or touch a YAML. Fresh clones and CI are unaffected (the generated files are gitignored).

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
