### PR TITLE
fix(home): stop retrying the carousel frame-cache allocation every render

### DIFF
--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -9,6 +9,7 @@
 #include <Logging.h>
 #include <Txt.h>
 #include <Xtc.h>
+#include <esp_system.h>
 
 #include <algorithm>
 #include <cstring>
@@ -142,6 +143,16 @@ int gCachedFrameRegionH = 0;   // region height (logical)
 bool gFrameCacheDirty = false;
 int gCachedFrameCount = 0;
 std::string gCacheKey;
+// Book set whose region allocation already failed. The cached region is ~48 KB, the
+// same order as the secondary framebuffer, and Home's steady-state free heap is
+// smaller than either (measured on X3: 39,276 free vs 49,104 needed) — so while the
+// secondary buffer is resident this malloc CANNOT succeed, and freeFrameCache()
+// clearing gCacheKey made every subsequent render attempt it again. Remember the key
+// that failed and skip the retry until something actually changes: a new book set, an
+// explicit invalidate, or a cover landing on disk (markFrameCacheDirty). That keeps the
+// cold-cache path intact — covers arriving there re-arm this on every decode — while a
+// warm boot stops paying a doomed 48 KB allocation attempt per render.
+std::string gAllocFailedKey;
 
 int findFrameSlot(int bookIdx) {
   for (int i = 0; i < kFrameCount; ++i) {
@@ -170,8 +181,14 @@ void freeFrameCache() {
 // ---------------------------------------------------------------------------
 void LyraCarouselTheme::setPreRenderIndex(int idx) { lastCarouselSelectorIndex = idx; }
 
-void LyraCarouselTheme::invalidateFrameCache() { freeFrameCache(); }
-void LyraCarouselTheme::markFrameCacheDirty() { gFrameCacheDirty = true; }
+void LyraCarouselTheme::invalidateFrameCache() {
+  freeFrameCache();
+  gAllocFailedKey.clear();  // conditions may have changed; allow one more attempt
+}
+void LyraCarouselTheme::markFrameCacheDirty() {
+  gFrameCacheDirty = true;
+  gAllocFailedKey.clear();  // a cover just landed, so the rebuild is worth retrying
+}
 
 void LyraCarouselTheme::onBookWillClose(const std::string& /*path*/, Epub* /*epub*/, Xtc* xtc, Txt* /*txt*/) {
   // EPUB thumbnail generation is handled lazily by HomeActivity (sliced ZIP + PNG decode).
@@ -274,6 +291,9 @@ bool LyraCarouselTheme::tryFastHomeRender(GfxRenderer& renderer, const std::vect
   }
 
   if (newKey != gCacheKey || gCachedFrameCount == 0) {
+    // Already established that this book set does not fit alongside whatever else is
+    // resident; don't re-run the allocation (and its log line) on every render.
+    if (newKey == gAllocFailedKey) return false;
     // Free old cache and allocate fresh region buffers.
     freeFrameCache();
     if (regionBytes == 0) return false;
@@ -284,9 +304,12 @@ bool LyraCarouselTheme::tryFastHomeRender(GfxRenderer& renderer, const std::vect
     for (int i = 0; i < frameCount; ++i) {
       gCachedFrames[i] = static_cast<uint8_t*>(malloc(regionBytes));
       if (!gCachedFrames[i]) {
-        LOG_DBG("CAROUSEL", "tryFastHomeRender: malloc failed for cover region %d (%u bytes) — retrying next render", i,
-                static_cast<unsigned>(regionBytes));
-        freeFrameCache();
+        LOG_DBG("CAROUSEL",
+                "tryFastHomeRender: malloc failed for cover region %d (%u bytes, %u free) — skipping until the book "
+                "set changes or a cover lands",
+                i, static_cast<unsigned>(regionBytes), static_cast<unsigned>(esp_get_free_heap_size()));
+        freeFrameCache();  // clears gCacheKey, so latch AFTER it
+        gAllocFailedKey = newKey;
         return false;
       }
     }
@@ -295,6 +318,7 @@ bool LyraCarouselTheme::tryFastHomeRender(GfxRenderer& renderer, const std::vect
     renderOneCarouselFrame(renderer, recentBooks, initialIdx, 0, metrics);
     gCachedFrameCount = frameCount;
     gCacheKey = newKey;
+    gAllocFailedKey.clear();  // it fits now; forget any earlier failure
   }
 
   const bool inCarouselRow = (selectorIndex < bookCount);


### PR DESCRIPTION
Branches off `master`, independent of the pioarduino work in #239.

## The defect

The carousel's cached cover region is **49,104 bytes** on X3 — the same order as the ~48 KB secondary framebuffer — and Home's steady-state free heap is smaller than *either*. Measured on X3 at Home, settled:

```
[70041] [MEM] Free: 39276 bytes, Total: 262292, Min Free: 36524 bytes
[78071] [CAROUSEL] tryFastHomeRender: malloc failed for cover region 0 (49104 bytes)
```

39,276 free against 49,104 requested. While the secondary buffer is resident, that allocation **cannot** succeed.

What makes it a defect today is the retry. On failure the code called `freeFrameCache()`, which clears `gCacheKey` — so the next render saw `newKey != gCacheKey` and attempted the same doomed 48 KB malloc again. Once per render, for the rest of the session, each with a log line.

## Why it's timing-dependent

The only window where 48 KB is free is inside `loadRecentCovers()`, which releases the secondary framebuffer while decoding and restores it at [HomeActivity.cpp:612](../blob/master/src/activities/home/HomeActivity.cpp#L612).

- **Cold cover cache** — window is seconds long, renders land inside it, cache gets allocated.
- **Warm cover cache** — window is brief, no render falls inside, cache never allocated. Home silently takes the slow path (`clearScreen()` + re-reading covers from SD) on *every* render, for the whole session.

In the log above `Min Free` never dips (36,524), proving no cover decode ran — a warm boot — and the failure still fires 78 s after boot.

## The fix

Remember the book-set key that failed, and skip the rebuild until something actually changes: a new book set, an explicit `invalidateFrameCache()`, or a cover landing on disk (`markFrameCacheDirty()`, called from `yieldAfterDecode` at every early return that wrote a BMP).

Cold-cache behaviour is unchanged — covers arriving there re-arm it on every decode. A warm boot stops paying a guaranteed-to-fail 48 KB allocation per render.

Also logs free heap next to the requested size so the gap is visible rather than inferred, and corrects the header for `esp_get_free_heap_size()` to `esp_system.h` (it was compiling only via a transitive include).

## Deliberately out of scope

This does **not** change which of the two buffers wins. Home still falls back to the slow path when the cache can't be had. Making that trade explicit — keep the frame cache on Home and leave the secondary buffer released until exit, which `setSingleBufferFastDiff()` already supports — is a separate change that needs device validation, since it costs AA/two-buffer refresh while on Home.

