### PR TITLE
fix: resolve correctness defects found by cppcheck 2.20.1

### DIFF
--- a/lib/Xtc/Xtc/XtcPageRowStream.h
+++ b/lib/Xtc/Xtc/XtcPageRowStream.h
@@ -245,7 +245,11 @@ class XtcPageRowStream {
 
     for (int bandY = 0; bandY < m_height && !failed; bandY += BAND_ROWS) {
       const int rowsInBand = (m_height - bandY < BAND_ROWS) ? (m_height - bandY) : BAND_ROWS;
+      // False positive: a failed malloc above sets `failed`, and this loop is
+      // guarded on !failed, so neither band pointer can be null here.
+      // cppcheck-suppress nullPointerOutOfMemory
       memset(bwBand, 0, static_cast<size_t>(rowsInBand) * m_bwRowBytes);
+      // cppcheck-suppress nullPointerOutOfMemory
       memset(grayBand, 0, static_cast<size_t>(rowsInBand) * m_grayRowBytes);
 
       for (int colBase = 0; colBase < m_width && !failed; colBase += COLS_PER_READ) {

--- a/src/activities/MenuListActivity.h
+++ b/src/activities/MenuListActivity.h
@@ -83,7 +83,10 @@ class MenuListActivity : public Activity {
 
   // Process SettingInfo items marked with withSubmenu() into submenu placeholders.
   void prepareSubmenus();
-  void openSubmenu(const SettingInfo& submenuEntry);
+  // Virtual so a subclass can supply its own submenu wiring: toggleCurrentItem()
+  // below dispatches through this, and EpubReaderMenuActivity needs a per-item
+  // value-string override that the plain version has no way to pass.
+  virtual void openSubmenu(const SettingInfo& submenuEntry);
 
   // Handle up/down navigation via buttonNavigator.  Call from loop() if overriding.
   void handleNavigation();

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -247,21 +247,12 @@ bool renderPngSleepScreen(const std::string& filename, GfxRenderer& renderer, co
     int textBlockHeight = 0;
     if (!overlayInfo.title.empty()) {
       textBlockHeight += lineHeight12;
-      if (!overlayInfo.author.empty()) {
-        textBlockHeight += lineSpacing;
-      } else if (!overlayInfo.progressText.empty()) {
-        textBlockHeight += sectionSpacing;
-      }
+      textBlockHeight += overlayInfo.author.empty() ? sectionSpacing : lineSpacing;
     }
     if (!overlayInfo.author.empty()) {
-      textBlockHeight += lineHeight10;
-      if (!overlayInfo.progressText.empty()) {
-        textBlockHeight += sectionSpacing;
-      }
+      textBlockHeight += lineHeight10 + sectionSpacing;
     }
-    if (!overlayInfo.progressText.empty()) {
-      textBlockHeight += lineHeight10;
-    }
+    textBlockHeight += lineHeight10;
 
     const int overlayY = pageHeight - textBlockHeight - (lineHeight12 / 3) - (lineHeight10 * 2 / 3);
     int y = overlayY + (lineHeight12 / 3);
@@ -269,25 +260,15 @@ bool renderPngSleepScreen(const std::string& filename, GfxRenderer& renderer, co
       const std::string title = renderer.truncatedText(BOOKERLY_12_FONT_ID, overlayInfo.title.c_str(), maxTextWidth);
       renderer.drawText(BOOKERLY_12_FONT_ID, 10, y, title.c_str(), true);
       y += lineHeight12;
-      if (!overlayInfo.author.empty()) {
-        y += lineSpacing;
-      } else if (!overlayInfo.progressText.empty()) {
-        y += sectionSpacing;
-      }
+      y += overlayInfo.author.empty() ? sectionSpacing : lineSpacing;
     }
     if (!overlayInfo.author.empty()) {
       const std::string author = renderer.truncatedText(UI_10_FONT_ID, overlayInfo.author.c_str(), maxTextWidth);
       renderer.drawText(UI_10_FONT_ID, 10, y, author.c_str(), true);
-      y += lineHeight10;
-      if (!overlayInfo.progressText.empty()) {
-        y += sectionSpacing;
-      }
+      y += lineHeight10 + sectionSpacing;
     }
-    if (!overlayInfo.progressText.empty()) {
-      const std::string progress =
-          renderer.truncatedText(UI_10_FONT_ID, overlayInfo.progressText.c_str(), maxTextWidth);
-      renderer.drawText(UI_10_FONT_ID, 10, y, progress.c_str(), true);
-    }
+    const std::string progress = renderer.truncatedText(UI_10_FONT_ID, overlayInfo.progressText.c_str(), maxTextWidth);
+    renderer.drawText(UI_10_FONT_ID, 10, y, progress.c_str(), true);
   };
 
   PngToFramebufferConverter decoder;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2818,9 +2818,12 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
     // lock, then re-check the condition under it — the render task may have invalidated the
     // pre-render between the unlocked test above and the lock.
     RenderLock lock;
-    // cppcheck-suppress knownConditionTrueFalse ; render task mutates these concurrently
+    // The single-line form lands on the `if` only; cppcheck reports the sub-expression on the
+    // continuation line below, so the suppression has to span the whole condition.
+    // cppcheck-suppress-begin knownConditionTrueFalse ; render task mutates these concurrently
     if (!(section && preRenderedPage.ready && preRenderedPage.spineIndex == currentSpineIndex &&
           preRenderedPage.pageIndex == section->currentPage + 1)) {
+      // cppcheck-suppress-end knownConditionTrueFalse
       lock.unlock();
       if (!stepPageState(isForwardTurn)) {
         return;
@@ -3643,9 +3646,7 @@ bool EpubReaderActivity::buildSection(const RenderLayout& layout) {
           renderer.clearRefreshOverride();  // discard the armed HALF -> popup paints FAST
         }
         GUI.drawPopup(renderer, tr(STR_INDEXING));  // immediate feedback before the first page lands
-      }
 
-      if (mode == SectionBuildMode::IncrementalReleased) {
         // Tight heap: free the secondary buffer (~48–52 KB) for the build. AA is off until the
         // build ends and recoverSecondaryBufferIfNeeded() reallocates it (marked via
         // secondaryBufferDegraded_); mid-build draws are BW. No display downside on X3 (baseline

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -429,16 +429,6 @@ EpubReaderMenuActivity::MenuAction EpubReaderMenuActivity::actionForNameId(StrId
   }
 }
 
-EpubReaderMenuActivity::MenuAction EpubReaderMenuActivity::actionForSettingAction(SettingAction action) {
-  switch (action) {
-    case SettingAction::None:
-    case SettingAction::Submenu:
-      return MenuAction::NONE;
-    default:
-      return MenuAction::NONE;
-  }
-}
-
 void EpubReaderMenuActivity::finishWithAction(MenuAction action) {
   MenuResult payload{static_cast<int>(action),
                      -1,
@@ -646,14 +636,6 @@ void EpubReaderMenuActivity::openSubmenu(const SettingInfo& submenuEntry) {
                            if (!result.isCancelled) {
                              const auto* menuResult = std::get_if<MenuResult>(&result.data);
                              if (menuResult) {
-                               if (menuResult->action != -1) {
-                                 const auto action =
-                                     actionForSettingAction(static_cast<SettingAction>(menuResult->action));
-                                 if (action != MenuAction::NONE) {
-                                   finishWithAction(action);
-                                   return;
-                                 }
-                               }
                                if (menuResult->nameId != -1) {
                                  const auto action = actionForNameId(static_cast<StrId>(menuResult->nameId));
                                  if (action != MenuAction::NONE) {
@@ -665,25 +647,6 @@ void EpubReaderMenuActivity::openSubmenu(const SettingInfo& submenuEntry) {
                            }
                            requestUpdate();
                          });
-}
-
-void EpubReaderMenuActivity::toggleCurrentItem() {
-  if (selectedIndex < 0 || selectedIndex >= static_cast<int>(menuItems.size())) return;
-  const auto& item = menuItems[selectedIndex];
-  if (item.isSeparator) return;
-
-  if (item.type == SettingType::ACTION) {
-    if (item.action == SettingAction::Submenu) {
-      openSubmenu(item);
-      return;
-    }
-    onActionSelected(selectedIndex);
-    return;
-  }
-
-  menuItems[selectedIndex].toggleValue();
-  onSettingToggled(selectedIndex);
-  requestUpdate();
 }
 
 void EpubReaderMenuActivity::onEnter() { MenuListActivity::onEnter(); }

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -64,12 +64,10 @@ class EpubReaderMenuActivity final : public MenuListActivity {
   void onActionSelected(int index) override;
   void onBackPressed() override;
   void onSettingToggled(int index) override;
-  void toggleCurrentItem() override;
-  void openSubmenu(const SettingInfo& submenuEntry);
+  void openSubmenu(const SettingInfo& submenuEntry) override;
 
   // Map from StrId to MenuAction for result passing
   static MenuAction actionForNameId(StrId nameId);
-  static MenuAction actionForSettingAction(SettingAction action);
 
   // Pending state (mutated locally, returned to parent on finish)
   uint8_t pendingOrientation = 0;

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -245,8 +245,21 @@ std::string ReaderActivity::convertSidecarToBmp(const std::string& cacheDir, con
     if (bmp.parseHeaders() == BmpReaderError::Ok && bmp.getWidth() <= width && bmp.getHeight() <= height &&
         src.seek(0)) {
       uint8_t buffer[1024];
-      while (src.available()) dst.write(buffer, src.read(buffer, sizeof(buffer)));
+      // read() returns int and is NEGATIVE on error; feeding that straight into
+      // write()'s size_t would read ~4 GB off the end of the buffer, and
+      // available() need not drop to 0 on a failing card. Stop on any non-positive
+      // read instead, and report failure so the caller falls back to a placeholder.
       ok = true;
+      while (src.available()) {
+        const int readBytes = src.read(buffer, sizeof(buffer));
+        if (readBytes <= 0) {
+          LOG_DBG("COVER", "Sidecar BMP copy read failed at offset %u: %s", static_cast<unsigned>(src.position()),
+                  sidecarPath.c_str());
+          ok = false;
+          break;
+        }
+        dst.write(buffer, static_cast<size_t>(readBytes));
+      }
     } else {
       LOG_DBG("COVER", "Sidecar BMP unusable for %dx%d slot (must fit 1:1): %s", width, height, sidecarPath.c_str());
     }
@@ -834,6 +847,10 @@ void ReaderActivity::onEnter() {
         // block, and reload on the warm-cache path (~50 ms, needs no released headroom).
         // Field-observed on X3: this exact miss previously cost a heap-recovery restart.
         epub.reset();
+        // Not a repeat of the call above: epub.reset() just freed the block that pinned the
+        // arena, so this attempt sees a different heap. cppcheck treats the identical call as
+        // returning the identical (false) value.
+        // cppcheck-suppress knownConditionTrueFalse
         restored = renderer.reallocSecondaryBuffer();
         LOG_INF("READER", "Dropped ePub to unpin framebuffer block (realloc %s); reloading from warm cache",
                 restored ? "ok" : "still failing");

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -81,7 +81,13 @@ class ReaderActivity final : public Activity {
     size_t bytesProduced() const;
     size_t totalBytes() const;
 
+    CoverExtractSession() = default;
     ~CoverExtractSession();
+    // Owns a malloc'd buf_ and an open destination file, so copying one would
+    // double-free and double-close. Only ever held by unique_ptr; make that a
+    // compile error rather than relying on nobody trying.
+    CoverExtractSession(const CoverExtractSession&) = delete;
+    CoverExtractSession& operator=(const CoverExtractSession&) = delete;
 
    private:
     std::unique_ptr<ZipFile> zip_;

--- a/src/util/DictHtmlNormalize.cpp
+++ b/src/util/DictHtmlNormalize.cpp
@@ -117,7 +117,7 @@ bool writeAttributes(const std::string& html, size_t pos, const size_t end, Sink
       continue;
     }
 
-    char nameBuf[NAME_BUF_BYTES];
+    char nameBuf[NAME_BUF_BYTES] = {};
     size_t nameLen = 0;
     while (pos < end && isNameChar(static_cast<unsigned char>(html[pos]))) {
       if (nameLen < NAME_BUF_BYTES - 1) nameBuf[nameLen++] = toLowerAscii(html[pos]);
@@ -197,7 +197,7 @@ bool normalizeDictionaryHtml(const std::string& html, Print& out) {
 
       const bool closing = html[i + 1] == '/';
       size_t nameEnd = i + (closing ? 2 : 1);
-      char nameBuf[NAME_BUF_BYTES];
+      char nameBuf[NAME_BUF_BYTES] = {};
       size_t nameLen = 0;
       while (nameEnd < j && isNameChar(static_cast<unsigned char>(html[nameEnd]))) {
         if (nameLen < NAME_BUF_BYTES - 1) nameBuf[nameLen++] = toLowerAscii(html[nameEnd]);


### PR DESCRIPTION
Branches off `master`, independent of the pioarduino upgrade in #239.

These defects were surfaced while trialling that upgrade, which carries cppcheck **2.11.0 → 2.20.1**. The defects themselves have nothing to do with the platform bump, so they land on their own. #239 carries the same commit and will need a rebase once this merges.

## Three real defects

**1. Buffer overrun on a failing SD card.** `ReaderActivity::convertSidecarToBmp()` copied a sidecar BMP with:

```cpp
while (src.available()) dst.write(buffer, src.read(buffer, sizeof(buffer)));
```

`FsFile::read()` returns `int` and is **negative on error**, so a read failure fed `-1` into `write()`'s `size_t` — reading ~4 GB past a 1 KB stack buffer. `available()` need not drop to 0 on error either, so the loop could also spin. Now stops on any non-positive read and reports failure, letting the caller fall back to a placeholder.

**2. Dead dispatch path.** `EpubReaderMenuActivity::actionForSettingAction()` returned `MenuAction::NONE` from *every* branch of its switch, so the `finishWithAction()` it guarded could never fire. Removed the function, its declaration, and the dead path.

**3. Six dead branches.** `SleepActivity`'s overlay lambda returns early when `progressText` is empty, then tested `!progressText.empty()` six more times — three in the measure block, three in the matching draw block. cppcheck flagged three; fixing only those would have left half of a symmetric pair, so all six are gone.

## Supporting fixes

- `MenuListActivity::openSubmenu()` is now **virtual** and `EpubReaderMenuActivity` overrides it. The derived class had been hiding a non-virtual base method and duplicating `toggleCurrentItem()` verbatim just to reach its own version — the two bodies were byte-identical, so removing the duplicate and dispatching virtually is behaviour-preserving.
- `CoverExtractSession` owns a `malloc`'d buffer and an open file but had implicit copy operations, so a copy would double-free and double-close. It is only ever held by `unique_ptr`; copies are now deleted.
- Both `DictHtmlNormalize` `nameBuf` buffers are explicitly initialised, matching the fix crosspoint-reader PR #3397 applied to the same construct in their `DictHtmlPages.cpp`.
- A duplicated `SectionBuildMode::IncrementalReleased` condition is merged.

## False positives

Three findings are genuine false positives and carry inline suppressions with stated reasons rather than contorted code: the `XtcPageRowStream` band pointers (guarded by a `failed` flag cppcheck doesn't follow), and the `reallocSecondaryBuffer()` retry in `ReaderActivity` (not a repeat call — `epub.reset()` freed the block that pinned the arena).

A fourth already had an inline suppression that **never applied**: it was written single-line on the `if`, while cppcheck reports the sub-expression on the continuation line. Now block form — that one is a real fix under the current 2.11.0 too, where the suppression is equally inert.

The suppressions only bite under 2.20.1; under 2.11.0 they're inert and covered by the existing `--suppress=unmatchedSuppression`.

## Verification

- `pio run -e default` — SUCCESS (RAM 17.5%, Flash 95.1%)
- Under cppcheck 2.20.1 (on the #239 branch, same changes) `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` reports **No defects found**.
- Host suite 860/861 — the one failure is a pre-existing Windows path-separator mismatch in `DictionaryTest`'s own expectation, and passes on Linux CI.
- **Not device-validated.** The reader, sleep-overlay and Home menu paths are all touched; worth a smoke test before merge.
