### PR TITLE
fix(serial): don't truncate the screenshot on a short USB-CDC write

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,30 @@ GestureEventManager gestureEventManager(mappedInputManager, renderer);
 // Lets lib-layer long tasks (image decoders) bail out mid-work so a queued button
 // press is serviced on the next main-loop pass. Installed once in setup().
 static bool hasPendingButtonInput() { return mappedInputManager.hasPendingInput(); }
+
+// logSerial.write() returns a SHORT count when the USB-CDC TX ring stays full past
+// HWCDC's ~100 ms tx timeout -- a host that reads in small chunks with work between
+// reads is enough to trigger it. Ignoring the return value silently drops the
+// remainder and truncates the transfer. SerialTransferDevice::writeBytes() already
+// loops for exactly this reason; this is the same guard for the one-shot senders in
+// this file. Yields rather than spinning: a tight loop on the C3 starves the USB-CDC
+// task that we are waiting on. Returns false if the host stopped draining entirely.
+static bool writeAllToSerial(const uint8_t* data, size_t len) {
+  constexpr unsigned long kWriteStallAbortMs = 15000;  // matches SerialTransferDevice
+  size_t sent = 0;
+  unsigned long lastProgressMs = millis();
+  while (sent < len) {
+    const size_t n = logSerial.write(data + sent, len - sent);
+    if (n > 0) {
+      sent += n;
+      lastProgressMs = millis();
+      continue;
+    }
+    if (millis() - lastProgressMs > kWriteStallAbortMs) return false;  // host vanished
+    delay(1);
+  }
+  return true;
+}
 ButtonEventManager& globalButtonEvents() { return buttonEventManager; }
 ActivityManager activityManager(renderer, mappedInputManager);
 FontDecompressor fontDecompressor;
@@ -1444,8 +1468,14 @@ void loop() {
           const uint16_t height = display.getDisplayHeight();
           const uint32_t bufferSize = display.getBufferSize();
           logSerial.printf("SCREENSHOT_START:%d:%d:%d\n", width, height, bufferSize);
-          logSerial.write(buf, bufferSize);
-          logSerial.printf("SCREENSHOT_END\n");
+          // ~52 KB in one go is exactly the sustained write that trips the short-write
+          // behaviour, so the END marker must not be sent if the payload was cut short:
+          // a truncated frame with a valid trailer looks complete to the host.
+          if (writeAllToSerial(buf, bufferSize)) {
+            logSerial.printf("SCREENSHOT_END\n");
+          } else {
+            logSerial.printf("SCREENSHOT_ERROR:transfer stalled\n");
+          }
         } else {
           // Framebuffers are released during the web server session — nothing to send.
           logSerial.printf("SCREENSHOT_ERROR:framebuffer released\n");


### PR DESCRIPTION
Branches off `master`. Addresses the flaw that motivated the pioarduino upgrade in #239, but in our own code and without the platform bump.

## The defect

The `SCREENSHOT` command sent the whole framebuffer (~52 KB on X3) with a single unchecked call:

```cpp
logSerial.write(buf, bufferSize);
```

HWCDC returns a **short count** when the TX ring stays full past its ~100 ms tx timeout — a host that reads in small chunks with work between reads is enough to trigger it. The remainder was silently dropped and the capture arrived truncated.

## Not a new discovery here

[`SerialTransferDevice::writeBytes()`](../blob/master/src/SerialTransferDevice.cpp#L137) already loops over the remainder for exactly this reason, with a comment noting that ignoring the return value "silently dropped the rest, corrupting downloads". The screenshot path is simply the call site that never got the same treatment. This factors that guard into a file-local `writeAllToSerial()` and uses it.

## Two details

- **Yields rather than spins.** The retry uses `delay(1)`; a tight loop on the C3 starves the USB-CDC task that the loop is waiting on.
- **No trailer on failure.** If a stall outlasts the abort window the `SCREENSHOT_END` marker is deliberately *not* sent, and `SCREENSHOT_ERROR:transfer stalled` goes out instead. A truncated payload followed by a valid trailer looks complete to the host — worse than an explicit failure.

## Relationship to #239

The upstream driver fix ([espressif/arduino-esp32#12606](https://github.com/espressif/arduino-esp32/pull/12606), which arrives with pioarduino 55.03.311) is the proper cure for the HWCDC bug itself. This makes the caller resilient either way and works on the current Arduino 3.3.7 — so it stands on its own whether or not #239 lands.

For context on what #239 costs by comparison: ~1.9 KB of heap, ~16.5 KB of flash, and a mandatory short `PLATFORMIO_CORE_DIR` on Windows.

## Verification

- `pio run -e default` — SUCCESS (RAM 17.5%, Flash 95.1%)
- **Not device-validated.** Worth confirming on hardware that `CMD:SCREENSHOT` still round-trips a full-size payload with its `SCREENSHOT_END` marker. Upstream's own validation of the driver fix was 200 consecutive captures with identical SHA-256 payloads, which is a good model if you want to stress it.
