### PR TITLE
fix: address concurrency deadlocks and cross-task races

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -206,7 +206,10 @@ uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(
 
 void HalDisplay::syncWriteBufferFromActive() const { einkDisplay.syncWriteBufferFromActive(); }
 
-void HalDisplay::releaseBuffers() { einkDisplay.releaseBuffers(); }
+void HalDisplay::releaseBuffers() {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.releaseBuffers();
+}
 
 // FBUF: centralized framebuffer-state trace. Every secondary-buffer / RED-RAM / single-buffer
 // transition logs here so a ghosting regression can be tracked to the exact op that left the panel
@@ -333,22 +336,36 @@ HalDisplay::RefreshMode HalDisplay::getLastRefreshMode() const { return lastRefr
 uint8_t HalDisplay::getLastDisplayModeByte() const { return lastDisplayModeByte; }
 
 void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* msbBuffer) {
+  HalSpiBus::Lock spiLock;
   einkDisplay.copyGrayscaleBuffers(lsbBuffer, msbBuffer);
 }
 
-void HalDisplay::copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer) { einkDisplay.copyGrayscaleLsbBuffers(lsbBuffer); }
+void HalDisplay::copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer) {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.copyGrayscaleLsbBuffers(lsbBuffer);
+}
 
-void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { einkDisplay.copyGrayscaleMsbBuffers(msbBuffer); }
+void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.copyGrayscaleMsbBuffers(msbBuffer);
+}
 
 void HalDisplay::syncRedRamFromFrameBuffer() {
+  HalSpiBus::Lock spiLock;
   einkDisplay.syncRedRamFromFrameBuffer();
   LOG_INF("FBUF", "syncRedRamFromFrameBuffer (hasSecondary=%d redSynced=%d)", einkDisplay.hasSecondaryBuffer() ? 1 : 0,
           einkDisplay.isRedRamSynced() ? 1 : 0);
 }
 
-void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.cleanupGrayscaleBuffers(bwBuffer); }
+void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.cleanupGrayscaleBuffers(bwBuffer);
+}
 
-void HalDisplay::cleanupGrayscaleWithPreviousBuffer() { einkDisplay.cleanupGrayscaleWithPreviousBuffer(); }
+void HalDisplay::cleanupGrayscaleWithPreviousBuffer() {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.cleanupGrayscaleWithPreviousBuffer();
+}
 
 bool HalDisplay::supportsGrayFrame() const { return einkDisplay.supportsGrayFrame(); }
 

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -548,18 +548,24 @@ void HalGPIO::sampleOnce() {
 void HalGPIO::samplerTask(void* arg) {
   HalGPIO* self = static_cast<HalGPIO*>(arg);
   TickType_t last = xTaskGetTickCount();
-  while (self->samplerRunning_) {
+  while (self->samplerRunning_.load(std::memory_order_acquire)) {
     vTaskDelayUntil(&last, pdMS_TO_TICKS(10));
     self->sampleOnce();
   }
+  xSemaphoreGive(self->samplerStoppedSemaphore_);
   vTaskDelete(nullptr);  // self-terminate once stopInputSampler() clears the flag
 }
 
 void HalGPIO::startInputSampler() {
-  if (samplerRunning_) {
+  if (samplerRunning_.load(std::memory_order_acquire)) {
     return;
   }
-  samplerRunning_ = true;
+  samplerStoppedSemaphore_ = xSemaphoreCreateBinary();
+  if (samplerStoppedSemaphore_ == nullptr) {
+    LOG_ERR("BTN", "Failed to create input sampler stop semaphore");
+    return;
+  }
+  samplerRunning_.store(true, std::memory_order_release);
   sampleOnce();  // prime so the first loop iteration sees current state
   // Priority above the Arduino loop task (1) so the 10ms cadence holds even while
   // the loop task is busy in a long build slice.
@@ -577,17 +583,27 @@ void HalGPIO::startInputSampler() {
   // runs on real hardware — see docs/touch-input-migration-2026-08-14.md §5.
   // Watch the btnSampler high-water [MEM] line if changed.
   constexpr uint32_t SAMPLER_STACK_BYTES = FREEINK_CAP_TOUCH ? 4096 : 2048;
-  xTaskCreate(&HalGPIO::samplerTask, "btnsample", SAMPLER_STACK_BYTES, this, 2, &samplerTaskHandle_);
+  const BaseType_t created =
+      xTaskCreate(&HalGPIO::samplerTask, "btnsample", SAMPLER_STACK_BYTES, this, 2, &samplerTaskHandle_);
+  if (created != pdPASS || samplerTaskHandle_ == nullptr) {
+    LOG_ERR("BTN", "Failed to create input sampler task");
+    samplerRunning_.store(false, std::memory_order_release);
+    vSemaphoreDelete(samplerStoppedSemaphore_);
+    samplerStoppedSemaphore_ = nullptr;
+  }
 }
 
 void HalGPIO::stopInputSampler() {
-  if (!samplerRunning_) {
+  if (!samplerRunning_.load(std::memory_order_acquire)) {
     return;
   }
   // Signal the task to exit on its next wake and self-delete. Avoids vTaskDelete()
   // tearing it down mid-analogRead (which would leak the ADC driver mutex).
-  samplerRunning_ = false;
+  samplerRunning_.store(false, std::memory_order_release);
+  xSemaphoreTake(samplerStoppedSemaphore_, portMAX_DELAY);
   samplerTaskHandle_ = nullptr;
+  vSemaphoreDelete(samplerStoppedSemaphore_);
+  samplerStoppedSemaphore_ = nullptr;
 }
 
 bool HalGPIO::hasPendingInput() const {
@@ -636,7 +652,7 @@ void HalGPIO::flushButtonEdges() {
 }
 
 void HalGPIO::update() {
-  if (!samplerRunning_) {
+  if (!samplerRunning_.load(std::memory_order_acquire)) {
     // Pre-sampler (early boot): sample synchronously on the calling task.
     sampleOnce();
   }
@@ -722,7 +738,9 @@ bool HalGPIO::isAnyPressed() const { return snapState_ != 0; }
 
 bool HalGPIO::isDebouncePending() const { return inputMgr.isDebouncePending(); }
 
-unsigned long HalGPIO::getHeldTime() const { return samplerRunning_ ? heldTimeSnapshot_ : inputMgr.getHeldTime(); }
+unsigned long HalGPIO::getHeldTime() const {
+  return samplerRunning_.load(std::memory_order_acquire) ? heldTimeSnapshot_ : inputMgr.getHeldTime();
+}
 
 // --- Touch passthrough ------------------------------------------------------
 // Deliberately dumb one-liners: no orientation, no logical pixels, no gesture

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -3,7 +3,10 @@
 #include <Arduino.h>
 #include <InputManager.h>
 #include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 #include <freertos/task.h>
+
+#include <atomic>
 
 // Display SPI pins (custom pins for XteinkX4, not hardware SPI defaults)
 #define EPD_SCLK 8   // SPI Clock
@@ -134,7 +137,8 @@ class HalGPIO {
   // samples + debounces on a fixed ~10ms cadence regardless of loop progress and
   // latches every edge for the loop task to drain.
   TaskHandle_t samplerTaskHandle_ = nullptr;
-  volatile bool samplerRunning_ = false;
+  SemaphoreHandle_t samplerStoppedSemaphore_ = nullptr;
+  std::atomic<bool> samplerRunning_{false};
   portMUX_TYPE inputMux_ = portMUX_INITIALIZER_UNLOCKED;
 
   // Shared sampler→loop state, guarded by inputMux_.

--- a/lib/hal/HalI2cBus.cpp
+++ b/lib/hal/HalI2cBus.cpp
@@ -6,16 +6,6 @@
 
 #if FREEINK_CAP_TOUCH
 
-namespace {
-// A single I2C transaction here is small — a GT911 contact read, an RTC
-// register block, a two-byte gauge read — and the bus runs at 400 kHz, so
-// anything approaching this is a wedged transfer or a lock-order mistake, not
-// contention. Time out, log, and proceed unlocked: a corrupted read is
-// recoverable and visible, a silent hang is neither. Shorter than the SPI
-// timeout because no I2C path here is bulk-transfer sized.
-constexpr TickType_t I2C_LOCK_TIMEOUT_TICKS = pdMS_TO_TICKS(1000);
-}  // namespace
-
 HalI2cBus::HalI2cBus() {
   mutex = xSemaphoreCreateRecursiveMutex();
   if (mutex == nullptr) {
@@ -33,13 +23,11 @@ void HalI2cBus::begin() { (void)getInstance(); }
 HalI2cBus::Lock::Lock() {
   auto& bus = HalI2cBus::getInstance();
   if (bus.mutex == nullptr) {
-    LOG_ERR("I2C", "I2C bus mutex not initialized, proceeding unlocked");
+    LOG_ERR("I2C", "I2C bus mutex not initialized");
+    assert(false && "I2C bus mutex not initialized");
     return;
   }
-  if (xSemaphoreTakeRecursive(bus.mutex, I2C_LOCK_TIMEOUT_TICKS) != pdTRUE) {
-    LOG_ERR("I2C", "Timed out acquiring I2C bus mutex - proceeding unlocked (possible lock-order bug)");
-    return;
-  }
+  xSemaphoreTakeRecursive(bus.mutex, portMAX_DELAY);
   acquired = true;
 }
 

--- a/lib/hal/HalI2cBus.h
+++ b/lib/hal/HalI2cBus.h
@@ -26,10 +26,9 @@
 // (BoardProfile::batteryGauge.i2cBus, moving the gauge to Wire1 on Sticky) does
 // not help here, because the X4 Pro wires all three devices to the same pins.
 //
-// This mirrors HalSpiBus exactly, including the recursive mutex and the
-// timeout-and-proceed policy: a wedged bus should show up as a diagnosable log
-// line, not a frozen device. There is no lock-ordering relationship with
-// HalSpiBus — no path holds one and takes the other.
+// This mirrors HalSpiBus's recursive, fail-closed mutex. There is no
+// lock-ordering relationship with HalSpiBus — no path holds one and takes the
+// other.
 //
 // On a NON-touch board the whole thing compiles away to nothing: the sampler
 // reads the ADC only, and the RTC and gauge are both driven from the loop task,

--- a/lib/hal/HalSpiBus.cpp
+++ b/lib/hal/HalSpiBus.cpp
@@ -2,15 +2,6 @@
 
 #include <Logging.h>
 
-namespace {
-// A single SPI transaction is short (a panel refresh is driven in chunks, an SD
-// transfer is block-sized), so anything past this means a lock-order mistake or
-// a wedged transfer. Waiting forever would turn that into a silent hang; time
-// out, log, and proceed unlocked so the failure is diagnosable in a log rather
-// than presenting as a frozen device.
-constexpr TickType_t SPI_LOCK_TIMEOUT_TICKS = pdMS_TO_TICKS(5000);
-}  // namespace
-
 HalSpiBus::HalSpiBus() {
   mutex = xSemaphoreCreateRecursiveMutex();
   if (mutex == nullptr) {
@@ -28,13 +19,11 @@ void HalSpiBus::begin() { (void)getInstance(); }
 HalSpiBus::Lock::Lock() {
   auto& bus = HalSpiBus::getInstance();
   if (bus.mutex == nullptr) {
-    LOG_ERR("SPI", "SPI bus mutex not initialized, proceeding unlocked");
+    LOG_ERR("SPI", "SPI bus mutex not initialized");
+    assert(false && "SPI bus mutex not initialized");
     return;
   }
-  if (xSemaphoreTakeRecursive(bus.mutex, SPI_LOCK_TIMEOUT_TICKS) != pdTRUE) {
-    LOG_ERR("SPI", "Timed out acquiring SPI bus mutex - proceeding unlocked (possible lock-order bug)");
-    return;
-  }
+  xSemaphoreTakeRecursive(bus.mutex, portMAX_DELAY);
   acquired = true;
 }
 

--- a/lib/hal/HalSpiBus.h
+++ b/lib/hal/HalSpiBus.h
@@ -3,7 +3,8 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
-// Serializes access to the SPI bus shared by the e-ink panel and the SD card.
+// Serializes display-controller access and, on SPI-SD boards, access to the
+// physical SPI bus shared by the e-ink panel and the SD card.
 //
 // The two devices share the physical bus (see SPI_MISO in HalGPIO.h, "shared
 // between SD card and display"). HalStorage already serializes SD access with
@@ -18,15 +19,16 @@
 // corrupted reads or a FreeRTOS panic - a signature easily misfiled as heap
 // corruption.
 //
-// Lock ordering is SPI-outer, storage-inner: HalStorage::StorageLock acquires
-// this lock as its outermost member (construction order guarantees it), and
-// display code takes only this lock, so the global order is consistent and
-// deadlock-free.
+// Lock ordering is SPI-outer, storage-inner: on SPI-SD boards,
+// HalStorage::StorageLock acquires this lock as its outermost member
+// (construction order guarantees it), and display code takes only this lock,
+// so the global order is consistent and deadlock-free. Native-SDMMC boards do
+// not take this lock for storage operations.
 //
 // The mutex is recursive so a storage path that re-enters the bus lock cannot
-// self-deadlock. Note this does NOT make HalStorage's own storageMutex
-// recursive - that one stays plain, because no storage path nests it today
-// (~FsFile calls SdFat's close() directly, not the locking HalFile::close()).
+// self-deadlock. HalStorage's own mutex is recursive as well because replacing
+// a HalFile while already inside StorageLock destroys its previous SdFat handle
+// and that implicit close must remain serialized.
 class HalSpiBus {
  public:
   class Lock {

--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -35,14 +35,22 @@ HalStorage HalStorage::instance;
 
 HalStorage::HalStorage() {}
 
+// True when the SD card really is on the SPI bus the display also uses. Native
+// SDMMC boards (X4 Pro: 1-bit slot 1, CLK41/CMD42/DAT0 40) share nothing with
+// the panel, so serializing their card against panel refreshes is pure
+// contention for no safety benefit.
+static bool sdSharesDisplaySpiBus() { return BoardConfig::ACTIVE.sdmmc.busWidth == 0; }
+
 // begin() and ready() are only called from setup, no need to acquire mutex for them
 
 bool HalStorage::begin() {
   // Create the mutex here rather than in the constructor: HalStorage::instance
   // is a global, and its constructor runs before the FreeRTOS scheduler starts.
-  // Calling xSemaphoreCreateMutex() that early corrupts the TLSF heap metadata.
+  // Calling xSemaphoreCreateRecursiveMutex() that early corrupts the TLSF heap metadata.
+  // Recursive ownership lets HalStorage replace an existing HalFile while it
+  // already holds StorageLock; destroying the replaced SdFat handle may close it.
   if (!storageMutex) {
-    storageMutex = xSemaphoreCreateMutex();
+    storageMutex = xSemaphoreCreateRecursiveMutex();
     assert(storageMutex != nullptr);
   }
   // SD-over-SPI clock ceiling on the S3 boards.
@@ -66,8 +74,9 @@ bool HalStorage::begin() {
 
   {
     // SD init drives the shared bus, so it must be serialized against the
-    // display too - the render task is already running by this point.
-    HalSpiBus::Lock spiLock;
+    // display too when this profile uses SPI. Native SDMMC is independent.
+    const auto spiLock =
+        sdSharesDisplaySpiBus() ? std::optional<HalSpiBus::Lock>(std::in_place) : std::nullopt;
     if (!SDCard.begin()) return false;
   }
   FsDateTime::setCallback([](uint16_t* date, uint16_t* time) {
@@ -95,12 +104,6 @@ void HalStorage::prepareForSleep() { SDCard.prepareForSleep(); }
 
 // For the rest of the methods, we acquire the mutex to ensure thread safety
 
-// True when the SD card really is on the SPI bus the display also uses. Native
-// SDMMC boards (X4 Pro: 1-bit slot 1, CLK41/CMD42/DAT0 40) share nothing with
-// the panel, so serializing their card against panel refreshes is pure
-// contention for no safety benefit.
-static bool sdSharesDisplaySpiBus() { return BoardConfig::ACTIVE.sdmmc.busWidth == 0; }
-
 class HalStorage::StorageLock {
  public:
   StorageLock()
@@ -108,9 +111,9 @@ class HalStorage::StorageLock {
       // still acquired BEFORE storageMutex when it is taken at all — see the
       // ordering note below.
       : spiLock(sdSharesDisplaySpiBus() ? std::optional<HalSpiBus::Lock>(std::in_place) : std::nullopt) {
-    xSemaphoreTake(HalStorage::getInstance().storageMutex, portMAX_DELAY);
+    xSemaphoreTakeRecursive(HalStorage::getInstance().storageMutex, portMAX_DELAY);
   }
-  ~StorageLock() { xSemaphoreGive(HalStorage::getInstance().storageMutex); }
+  ~StorageLock() { xSemaphoreGiveRecursive(HalStorage::getInstance().storageMutex); }
 
  private:
   // Declared first so it is acquired before storageMutex and released after it:
@@ -247,7 +250,7 @@ size_t HalStorage::readFileToBuffer(const char* path, char* buffer, size_t buffe
 // (@itsthisjustin).
 //
 // Composed of already-locked HalStorage/HalFile operations, so it takes no
-// StorageLock of its own - doing so would deadlock on the non-recursive mutex.
+// StorageLock of its own.
 bool HalStorage::readFileToString(const char* moduleName, const std::string& path, size_t cap, std::string& out) {
   out.clear();
   HalFile file;
@@ -292,11 +295,20 @@ HalFile::HalFile() = default;
 
 HalFile::HalFile(std::unique_ptr<Impl> impl) : impl(std::move(impl)) {}
 
-HalFile::~HalFile() = default;
+HalFile::~HalFile() {
+  if (!impl) return;
+  HalStorage::StorageLock lock;
+  impl.reset();
+}
 
 HalFile::HalFile(HalFile&&) = default;
 
-HalFile& HalFile::operator=(HalFile&&) = default;
+HalFile& HalFile::operator=(HalFile&& other) {
+  if (this == &other) return *this;
+  HalStorage::StorageLock lock;
+  impl = std::move(other.impl);
+  return *this;
+}
 
 HalFile HalStorage::open(const char* path, const oflag_t oflag) {
   StorageLock lock;  // ensure thread safety for the duration of this function

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -11,6 +11,7 @@
 #include <esp_mac.h>
 #include <esp_wifi.h>
 
+#include <atomic>
 #include <cstring>
 #include <ctime>
 #include <map>
@@ -23,6 +24,10 @@
 #include "util/QrUtils.h"
 
 namespace {
+
+std::atomic<uint32_t> wifiEventGeneration{0};
+std::atomic<unsigned long> wifiEventConnectionStartMs{0};
+std::atomic<bool> wifiEventAttemptAssociated{false};
 
 void readDeviceBaseMac(uint8_t mac[6]) { esp_efuse_mac_get_default(mac); }
 
@@ -50,23 +55,28 @@ String formatMacCompact(const uint8_t mac[6]) {
 
 void WifiSelectionActivity::onEnter() {
   Activity::onEnter();
+  const uint32_t eventGeneration = wifiEventGeneration.fetch_add(1, std::memory_order_acq_rel) + 1;
 
   // Timing instrumentation: split total connect time into association vs DHCP.
   // STA_CONNECTED = association (auth + 4-way handshake done).
   // STA_GOT_IP    = DHCP done.
   evtIdConnected = WiFi.onEvent(
-      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t info) {
-        currentAttemptAssociated = true;
+      [eventGeneration](WiFiEvent_t /*event*/, WiFiEventInfo_t info) {
+        if (wifiEventGeneration.load(std::memory_order_acquire) != eventGeneration) return;
+        wifiEventAttemptAssociated.store(true, std::memory_order_relaxed);
         // Which AP we landed on, not just when. On a mesh SSID the sorted candidate list is the
         // whole story: pairing this BSSID with the one in the disconnect below says whether a
         // failed attempt cost us a bad node, or whether the same node needed two tries.
-        LOG_DBG("WIFI", "EVT associated at %lu ms: bssid=%s ch=%u", millis() - connectionStartTime,
+        LOG_DBG("WIFI", "EVT associated at %lu ms: bssid=%s ch=%u",
+          millis() - wifiEventConnectionStartMs.load(std::memory_order_relaxed),
                 formatMacDashed(info.wifi_sta_connected.bssid).c_str(), info.wifi_sta_connected.channel);
       },
       ARDUINO_EVENT_WIFI_STA_CONNECTED);
   evtIdGotIp = WiFi.onEvent(
-      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t /*info*/) {
-        LOG_DBG("WIFI", "EVT got_ip at %lu ms", millis() - connectionStartTime);
+      [eventGeneration](WiFiEvent_t /*event*/, WiFiEventInfo_t /*info*/) {
+        if (wifiEventGeneration.load(std::memory_order_acquire) != eventGeneration) return;
+        LOG_DBG("WIFI", "EVT got_ip at %lu ms",
+                millis() - wifiEventConnectionStartMs.load(std::memory_order_relaxed));
       },
       ARDUINO_EVENT_WIFI_STA_GOT_IP);
   // STA_START = the driver finished esp_wifi_start() (PHY init + RF calibration). Splits
@@ -74,8 +84,10 @@ void WifiSelectionActivity::onEnter() {
   // alone cannot: measured begin->associated is a flat ~2.5 s regardless of scan method, hint,
   // or RSSI, and that invariance is what this pair exists to explain.
   evtIdStaStart = WiFi.onEvent(
-      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t /*info*/) {
-        LOG_DBG("WIFI", "EVT sta_start at %lu ms (driver up; scan/auth begins here)", millis() - connectionStartTime);
+      [eventGeneration](WiFiEvent_t /*event*/, WiFiEventInfo_t /*info*/) {
+        if (wifiEventGeneration.load(std::memory_order_acquire) != eventGeneration) return;
+        LOG_DBG("WIFI", "EVT sta_start at %lu ms (driver up; scan/auth begins here)",
+                millis() - wifiEventConnectionStartMs.load(std::memory_order_relaxed));
       },
       ARDUINO_EVENT_WIFI_STA_START);
   // The one that should settle it. A cost that flat across every configuration looks like a
@@ -84,14 +96,16 @@ void WifiSelectionActivity::onEnter() {
   // the AP taking that long and there is nothing here to win; if AUTH_EXPIRE / ASSOC_EXPIRE /
   // HANDSHAKE_TIMEOUT shows up mid-connect, that names the second we are paying for.
   evtIdDisconnected = WiFi.onEvent(
-      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t info) {
+      [eventGeneration](WiFiEvent_t /*event*/, WiFiEventInfo_t info) {
+        if (wifiEventGeneration.load(std::memory_order_acquire) != eventGeneration) return;
         const uint8_t reason = info.wifi_sta_disconnected.reason;
         // bssid/rssi name the AP that failed and how loud it was at the moment it gave up, which
         // is what separates "the driver picked a node it cannot actually hold" from "the whole
         // SSID is too weak here".
         LOG_DBG("WIFI", "EVT disconnected at %lu ms: reason=%u (%s) assoc=%d bssid=%s rssi=%d",
-                millis() - connectionStartTime, reason,
-                WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(reason)), currentAttemptAssociated ? 1 : 0,
+                millis() - wifiEventConnectionStartMs.load(std::memory_order_relaxed), reason,
+                WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(reason)),
+                wifiEventAttemptAssociated.load(std::memory_order_relaxed) ? 1 : 0,
                 formatMacDashed(info.wifi_sta_disconnected.bssid).c_str(),
                 static_cast<int>(info.wifi_sta_disconnected.rssi));
       },
@@ -158,6 +172,7 @@ void WifiSelectionActivity::onEnter() {
 }
 
 void WifiSelectionActivity::onExit() {
+  wifiEventGeneration.fetch_add(1, std::memory_order_acq_rel);
   Activity::onExit();
 
   if (evtIdConnected != 0) {
@@ -261,6 +276,7 @@ void WifiSelectionActivity::tryNextAutoCycleCandidate() {
 
   state = WifiSelectionState::AUTO_CYCLING;
   connectionStartTime = millis();
+  wifiEventConnectionStartMs.store(connectionStartTime, std::memory_order_relaxed);
   connectedIP.clear();
   connectionError.clear();
   requestUpdate();
@@ -387,6 +403,7 @@ void WifiSelectionActivity::selectNetwork(const int index) {
 void WifiSelectionActivity::attemptConnection() {
   state = autoConnecting ? WifiSelectionState::AUTO_CONNECTING : WifiSelectionState::CONNECTING;
   connectionStartTime = millis();
+  wifiEventConnectionStartMs.store(connectionStartTime, std::memory_order_relaxed);
   connectedIP.clear();
   connectionError.clear();
   requestUpdate();
@@ -490,7 +507,7 @@ void WifiSelectionActivity::applyScanBudget() {
 }
 
 void WifiSelectionActivity::issueWifiBegin() {
-  currentAttemptAssociated = false;
+  wifiEventAttemptAssociated.store(false, std::memory_order_relaxed);
 
   // Always a full, signal-sorted scan. The cached channel/BSSID hint that used to shortcut this
   // is gone, and the device data is unambiguous about why:

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -97,10 +97,6 @@ class WifiSelectionActivity final : public Activity {
 
   unsigned long connectionStartTime = 0;
 
-  // Set by the STA_CONNECTED handler; read by the disconnect log to tell a mid-connect failure
-  // apart from a drop after association.
-  volatile bool currentAttemptAssociated = false;
-
   // WiFi event handler IDs so we can deregister on exit.
   uint16_t evtIdConnected = 0;
   uint16_t evtIdGotIp = 0;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -730,7 +730,7 @@ void EpubReaderActivity::loop() {
   // After the progress flush and before input handling: this is the reader's LAST loop() pass —
   // the launch pushes it onto the activity stack, which stops loop() being called — so anything
   // still owed must be flushed above, and nothing below it will run again.
-  if (finishedBookLaunchPending_) {
+  if (finishedBookLaunchPending_.load(std::memory_order_acquire)) {
     serviceFinishedBookLaunch();
     return;
   }
@@ -746,11 +746,6 @@ void EpubReaderActivity::loop() {
       buttonEvents.drain();
       stopAutomaticPageTurn();
       // updates chapter title space to indicate page turn disabled
-      requestUpdate();
-      return;
-    }
-
-    if (!section) {
       requestUpdate();
       return;
     }
@@ -892,9 +887,12 @@ void EpubReaderActivity::loop() {
       const int lastSpineIndex = epub->getSpineItemsCount() - 1;
       int lastPageIndex = 0;
       int lastPageCount = 0;
-      if (section && currentSpineIndex == lastSpineIndex) {
-        lastPageCount = section->pageCount;
-        lastPageIndex = std::max(0, section->pageCount - 1);
+      {
+        RenderLock lock(*this);
+        if (section && currentSpineIndex == lastSpineIndex) {
+          lastPageCount = section->pageCount;
+          lastPageIndex = std::max(0, section->pageCount - 1);
+        }
       }
       writeReaderProgressCache(epub->getCachePath(), lastSpineIndex, lastPageIndex, lastPageCount, 100);
       finishedBookSyncSpineIndex_ = lastSpineIndex;
@@ -905,17 +903,23 @@ void EpubReaderActivity::loop() {
                                            epub->getSeriesIndex(), epub->getAuthor(), nullptr, nullptr,
                                            &EpubReaderActivity::onFinishedBookSyncRequested, this);
     } else {
-      currentSpineIndex = epub->getSpineItemsCount() - 1;
-      navTarget = NavigationTarget::makeLastPage();
+      {
+        RenderLock lock(*this);
+        currentSpineIndex = epub->getSpineItemsCount() - 1;
+        navTarget = NavigationTarget::makeLastPage();
+      }
       requestUpdate();
     }
     return;
   }
 
   // No current section, attempt to rerender the book
-  if (!section) {
-    requestUpdate();
-    return;
+  {
+    RenderLock lock(*this);
+    if (!section) {
+      requestUpdate();
+      return;
+    }
   }
 
   if (prevTriggered) {
@@ -933,13 +937,24 @@ void EpubReaderActivity::serviceBackgroundWork() {
   // the deferred AA pass first, then Background B (next-section pre-build) — B also
   // self-gates on A having finished, since A drives perceived page-turn speed.
   runDeferredGrayscalePass();
-  if (pendingGrayscale_.active) {
-    return;  // AA still owed (display bus busy); it keeps priority over B/C
+  if (RenderLock::peek()) {
+    return;
+  }
+  {
+    RenderLock lock;
+    if (pendingGrayscale_.active) {
+      return;  // AA still owed (display bus busy); it keeps priority over B/C
+    }
   }
   // Background C (build of the section the reader is waiting on) takes priority over A and B:
   // the user has nothing to read until it produces pages. A/B are look-ahead work for a section
   // that is already displayed, so they only matter once the current section is built.
-  if (section && section->hasActiveBuild()) {
+  bool currentSectionBuildActive = false;
+  {
+    RenderLock lock;
+    currentSectionBuildActive = section && section->hasActiveBuild();
+  }
+  if (currentSectionBuildActive) {
     stepCurrentSectionBuild();
     return;
   }
@@ -953,6 +968,7 @@ void EpubReaderActivity::serviceBackgroundDebugLog() {
     return;
   }
   lastBgDebugLogMs_ = now;
+  RenderLock lock;
   // B state + gate inputs so a stalled B explains itself from the log alone (e.g. parked
   // in waitheap because free/contig sit below the BG_BUILD_* floors, or css=1 with too
   // little heap for Section::heapAllowsEmbeddedStyle()).
@@ -979,15 +995,13 @@ void EpubReaderActivity::runDeferredGrayscalePass() {
   // run concurrently. isRefreshPending() is true from triggerDisplay() until
   // completeDisplay() clears it; when it returns false the render task has
   // finished all post-waveform SPI work and it is safe to issue new SPI writes.
-  if (!pendingGrayscale_.active || !pendingGrayscale_.page || renderer.isRefreshPending()) {
+  if (RenderLock::peek()) {
     return;
   }
-  // Serialize deferred AA with the render task. This prevents loop-side
-  // grayscale SPI/framebuffer work from racing with render() updates.
+  // Serialize both the guard reads and deferred AA with the render task. Reading
+  // the shared_ptr itself before taking this lock is a C++ data race even when
+  // the same conditions are checked again afterwards.
   RenderLock lock;
-  // Re-check under the lock: the render task may have flipped these between the
-  // unlocked test above and acquiring the lock.
-  // cppcheck-suppress knownConditionTrueFalse ; render task mutates these concurrently
   if (!pendingGrayscale_.active || !pendingGrayscale_.page || renderer.isRefreshPending()) {
     return;
   }
@@ -1107,13 +1121,13 @@ void EpubReaderActivity::startActivityForResult(std::unique_ptr<Activity>&& acti
 }
 
 void EpubReaderActivity::suspendBackgroundWork() {
-  if (backgroundWorkSuspended_) return;
-  backgroundWorkSuspended_ = true;
   {
     // Under the render lock, like every other borrow teardown: the render task
     // calls endBackgroundBorrow() from the top of every render(), and two
     // unlocked teardowns double-free the same Section.
     RenderLock lock(*this);
+    if (backgroundWorkSuspended_) return;
+    backgroundWorkSuspended_ = true;
     // endBackgroundBorrow(), NOT resetBackgroundBuild(). This releases what is
     // actually large — the lent 48 KB region and the build arena inside it —
     // and aborts only a build that is still live, which is resumable by design:
@@ -1130,19 +1144,19 @@ void EpubReaderActivity::suspendBackgroundWork() {
     // nothing about whether the parse fits between two page turns, so it must
     // not burn the budget that makes B abandon a spine.
     backgroundPreemptCount_ = preemptionsBeforeOverlay;
+    // Discard the pre-rendered next page: it lives in the secondary framebuffer,
+    // which the overlay is about to draw over.
+    preRenderedPage = {};
   }
-  // Discard the pre-rendered next page: it lives in the secondary framebuffer,
-  // which the overlay is about to draw over. render()'s prologue also clears
-  // this on any pass that is not PreRender/BufferDisplay, so the flag would not
-  // survive the reader's next render either -- but doing it here means the
-  // discard does not depend on which pass that render turns out to be.
-  preRenderedPage = {};
   LOG_INF("ERS", "Background work suspended for a dictionary interaction");
 }
 
 void EpubReaderActivity::resumeBackgroundWork() {
-  if (!backgroundWorkSuspended_) return;
-  backgroundWorkSuspended_ = false;
+  {
+    RenderLock lock(*this);
+    if (!backgroundWorkSuspended_) return;
+    backgroundWorkSuspended_ = false;
+  }
   // Nothing to restart explicitly: the look-ahead re-probes from Probe on the
   // next loop() and the pre-render re-arms on the next render().
   LOG_INF("ERS", "Background work resumed");
@@ -1236,43 +1250,26 @@ void EpubReaderActivity::endBackgroundBorrow() {
 }
 
 void EpubReaderActivity::stepBackgroundSectionBuild() {
-  if (!epub || !section || readerPhase_ != ReaderPhase::READING || backgroundWorkSuspended_) {
-    return;
-  }
-  // B no longer has to wait for footnotes.bin. makeSectionBuildParams() now keys the variant on
-  // actual preview availability, so a build started before the gather is cached under the
-  // previews-OFF hash rather than masquerading as preview-enabled. Blocking B here used to stall
-  // all background building for the whole of a preview-enabled book's first open.
-  // Background A keeps priority: it determines perceived page-turn speed, and its total
-  // cost is small against a multi-second page-read window. Wait until its pass has run
-  // (pendingPreRender clears whether or not it produced a ready page).
-  if (pendingPreRender || usePreRenderedBuffer) {
-    return;
-  }
   // B does SD I/O only, no SPI — but it must not contend with the render task for the
   // render lock while a waveform (or a render) is in flight: a blocked loop task cannot
   // service input. Skip the tick instead; idle ticks are plentiful while the user reads.
   // Note RenderLock::peek() returns true when the mutex is HELD (busy), not when free.
-  if (renderer.isRefreshPending() || RenderLock::peek()) {
-    return;
-  }
-  // Don't start a heap-hungry build slice while the render task is decoding an image:
-  // both compete for the same ~48-52 KB contiguous block. RenderLock::peek() above already
-  // excludes this in practice (renderContents() holds the lock for the whole warm pass), but
-  // check explicitly too — see the comment on imageProcessingActive_.
-  if (imageProcessingActive_) {
+  if (RenderLock::peek()) {
     return;
   }
   // One lock for the whole step: every branch below touches the SD (even discarding a
   // stale build removes its partial file) and the parse slice reads glyph metrics from
   // the shared renderer, so all of it must be serialised against the render task.
   RenderLock lock;
-  // Re-check under the lock: the render task may have scheduled A or started a refresh
-  // between the unlocked test above and acquiring the lock (mirrors runDeferredGrayscalePass).
-  // cppcheck-suppress knownConditionTrueFalse ; render task mutates these concurrently
-  if (pendingPreRender || renderer.isRefreshPending()) {
+  if (!epub || !section || readerPhase_ != ReaderPhase::READING || backgroundWorkSuspended_ || pendingPreRender ||
+      usePreRenderedBuffer || renderer.isRefreshPending() || imageProcessingActive_) {
     return;
   }
+
+  // B no longer has to wait for footnotes.bin. makeSectionBuildParams() now keys the variant on
+  // actual preview availability, so a build started before the gather is cached under the
+  // previews-OFF hash rather than masquerading as preview-enabled. Background A keeps priority:
+  // pendingPreRender clears whether or not it produced a ready page.
 
   // Background A re-arm (one retry per displayed page): A's pass runs right after the
   // page render, while the deferred AA still holds the just-rendered page (~10 KB) —
@@ -1591,24 +1588,13 @@ void EpubReaderActivity::stepBackgroundSectionBuild() {
 }
 
 void EpubReaderActivity::stepCurrentSectionBuild() {
-  if (!epub || !section || !section->hasActiveBuild()) {
-    return;
-  }
   // Don't contend with the render task for the lock while a refresh/render is in flight: a
   // blocked loop task can't service input. peek() is true when the mutex is HELD (busy).
-  if (renderer.isRefreshPending() || RenderLock::peek()) {
-    return;
-  }
-  // Don't start a build slice while the render task is mid image-decode — see the comment
-  // on imageProcessingActive_ in renderContents().
-  if (imageProcessingActive_) {
+  if (RenderLock::peek()) {
     return;
   }
   RenderLock lock;
-  // Re-check under the lock: the render task may have started a refresh, turned a page, or
-  // finished/aborted the build between the unlocked test above and acquiring the lock.
-  // cppcheck-suppress knownConditionTrueFalse ; render task mutates these concurrently
-  if (!section || !section->hasActiveBuild() || renderer.isRefreshPending()) {
+  if (!epub || !section || !section->hasActiveBuild() || renderer.isRefreshPending() || imageProcessingActive_) {
     return;
   }
 
@@ -1831,7 +1817,10 @@ void EpubReaderActivity::jumpToPercent(int percent) {
 }
 
 void EpubReaderActivity::openDictionary() {
-  if (!section) return;
+  {
+    RenderLock lock(*this);
+    if (!section) return;
+  }
 
   if (SETTINGS.dictionaryName[0] == '\0') {
     // Send the user somewhere they can act rather than showing a popup that
@@ -1847,8 +1836,13 @@ void EpubReaderActivity::openDictionary() {
 
   // During an active build the on-disk LUT is not written yet, so the page has
   // to come from the in-memory one -- the same choice the pre-render pass makes.
-  auto page = section->hasActiveBuild() ? section->loadPageFromActiveBuild(static_cast<uint16_t>(section->currentPage))
-                                        : section->loadPageFromSectionFile();
+  std::unique_ptr<Page> page;
+  {
+    RenderLock lock(*this);
+    if (!section) return;
+    page = section->hasActiveBuild() ? section->loadPageFromActiveBuild(static_cast<uint16_t>(section->currentPage))
+                                     : section->loadPageFromSectionFile();
+  }
   if (!page) {
     LOG_ERR("ERS", "Dictionary: could not load the current page");
     return;
@@ -1871,9 +1865,14 @@ void EpubReaderActivity::openDictionary() {
 void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action) {
   switch (action) {
     case EpubReaderMenuActivity::MenuAction::SELECT_CHAPTER: {
-      const int spineIdx = currentSpineIndex;
-      const int tocIdx = section ? section->getTocIndexForPage(section->currentPage)
-                                 : epub->getTocIndexForSpineIndex(currentSpineIndex);
+      int spineIdx;
+      int tocIdx;
+      {
+        RenderLock lock(*this);
+        spineIdx = currentSpineIndex;
+        tocIdx = section ? section->getTocIndexForPage(section->currentPage)
+                         : epub->getTocIndexForSpineIndex(currentSpineIndex);
+      }
       const std::string path = epub->getPath();
       startActivityForResult(
           std::make_unique<EpubReaderChapterSelectionActivity>(renderer, mappedInput, epub, path, spineIdx, tocIdx),
@@ -1924,9 +1923,13 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     }
     case EpubReaderMenuActivity::MenuAction::GO_TO_PERCENT: {
       float bookProgress = 0.0f;
-      if (epub && epub->getBookSize() > 0 && section && section->pageCount > 0) {
-        const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
-        bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
+      {
+        RenderLock lock(*this);
+        if (epub && epub->getBookSize() > 0 && section && section->pageCount > 0) {
+          const float chapterProgress =
+              static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+          bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
+        }
       }
       const int initialPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
       startActivityForResult(
@@ -1953,11 +1956,14 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       // two printed pages, so the closest prior anchor is the "you're here" hint). Falls
       // back to the lowest integer label in the book if no prior anchor exists.
       int initialValue = minLabel;
-      if (section) {
-        if (const auto rawLabel =
-                section->getNearestPrintedPageLabelAtOrBefore(static_cast<uint16_t>(section->currentPage))) {
-          if (const auto n = parsePrintedPageLabel(*rawLabel)) {
-            initialValue = *n;
+      {
+        RenderLock lock(*this);
+        if (section) {
+          if (const auto rawLabel =
+                  section->getNearestPrintedPageLabelAtOrBefore(static_cast<uint16_t>(section->currentPage))) {
+            if (const auto n = parsePrintedPageLabel(*rawLabel)) {
+              initialValue = *n;
+            }
           }
         }
       }
@@ -1993,9 +1999,14 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       break;
     }
     case EpubReaderMenuActivity::MenuAction::DISPLAY_QR: {
-      if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
-        auto p = section->loadPageFromSectionFile();
-        if (p) {
+      std::unique_ptr<Page> p;
+      {
+        RenderLock lock(*this);
+        if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
+          p = section->loadPageFromSectionFile();
+        }
+      }
+      if (p) {
           std::string fullText;
           for (const auto& el : p->elements) {
             if (el->getTag() == TAG_PageLine) {
@@ -2015,16 +2026,18 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
                                    [this](const ActivityResult& result) {});
             break;
           }
-        }
       }
       // If no text or page loading failed, just close menu
       requestUpdate();
       break;
     }
     case EpubReaderMenuActivity::MenuAction::STAR_PAGE: {
-      if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
-        bookmarkStore.toggle(static_cast<uint16_t>(currentSpineIndex), static_cast<uint16_t>(section->currentPage));
-        requestUpdate();
+      {
+        RenderLock lock(*this);
+        if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
+          bookmarkStore.toggle(static_cast<uint16_t>(currentSpineIndex), static_cast<uint16_t>(section->currentPage));
+          requestUpdate();
+        }
       }
       break;
     }
@@ -2034,8 +2047,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
           [this](const ActivityResult& result) {
             if (!result.isCancelled) {
               const auto& starred = std::get<StarredPageResult>(result.data);
+              RenderLock lock(*this);
               if (currentSpineIndex != starred.spineIndex || !section || section->currentPage != starred.pageNumber) {
-                RenderLock lock(*this);
                 currentSpineIndex = starred.spineIndex;
                 navTarget = NavigationTarget::makePage(starred.pageNumber);
                 section.reset();
@@ -2076,9 +2089,12 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         const int lastSpineIndex = spineCount - 1;
         int lastPageIndex = 0;
         int lastPageCount = 0;
-        if (section && currentSpineIndex == lastSpineIndex) {
-          lastPageCount = section->pageCount;
-          lastPageIndex = std::max(0, section->pageCount - 1);
+        {
+          RenderLock lock(*this);
+          if (section && currentSpineIndex == lastSpineIndex) {
+            lastPageCount = section->pageCount;
+            lastPageIndex = std::max(0, section->pageCount - 1);
+          }
         }
         if (lastPageCount > 0) {
           writeReaderProgressCache(epub->getCachePath(), lastSpineIndex, lastPageIndex, lastPageCount, 100);
@@ -2655,6 +2671,11 @@ void EpubReaderActivity::anchorNavTargetToCurrentPage() {
 }
 
 bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
+  RenderLock lock(*this);
+  return stepPageStateLocked(isForwardTurn);
+}
+
+bool EpubReaderActivity::stepPageStateLocked(const bool isForwardTurn) {
   if (!epub || !section) {
     return false;
   }
@@ -2669,12 +2690,6 @@ bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
     if (navTarget.kind != NavigationTarget::Kind::Page) {
       return false;
     }
-    // The lock must cover the GUARDS, not just the mutation: the PreRender pass temporarily
-    // sets section->currentPage to the page it is laying out, so a guard evaluated unlocked
-    // can pass on that transient value and the mutation then lands on the restored one —
-    // observed on-device as a back turn at page 0 reading a transient 1, then decrementing
-    // the restored 0 to -1 (a visible "out of bounds" frame).
-    RenderLock lock(*this);
     if (isForwardTurn) {
       section->currentPage++;
     } else if (section->currentPage > 0) {
@@ -2705,14 +2720,6 @@ bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
     pageHasPlaceholders = false;
     return true;
   }
-
-  // Serialize the WHOLE step decision against the render task, guards included: the
-  // PreRender pass temporarily writes section->currentPage while laying out the next page,
-  // so a guard evaluated outside the lock can pass on that transient value and the mutation
-  // then lands on the restored one. Observed on-device: a back turn at page 0 read the
-  // pre-render's transient 1, blocked on the lock, then decremented the restored 0 to -1 —
-  // a visible "out of bounds" frame. The forward mirror can double-advance past the end.
-  RenderLock lock(*this);
 
   // A 0-page section (permanently unparse-able chapter) has no within-chapter navigation,
   // but the user must still be able to cross spine boundaries to escape it.
@@ -2758,6 +2765,11 @@ bool EpubReaderActivity::stepPageState(const bool isForwardTurn) {
 }
 
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
+  // One lock covers cancellation, pre-render selection, navigation, and cleanup. The
+  // render task temporarily mutates section/pre-render state and publishes deferred-AA
+  // shared_ptrs, so even guard-only reads must be serialized.
+  RenderLock lock(*this);
+
   // Cancel any pending deferred AA pass — it belongs to the page we're leaving.
   pendingGrayscale_ = {};
 
@@ -2812,30 +2824,6 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
     // loop task, then hand off to render() via usePreRenderedBuffer — all display work (status
     // bar, flush, AA pass) stays on the render task where it belongs.
     //
-    // Serialize the shared-state mutation against the render task: the PreRender pass temporarily
-    // writes section->currentPage and rewrites preRenderedPage, so reading/advancing them here
-    // without the lock races (stale buffer shown, or a torn section pointer → reboot). Acquire the
-    // lock, then re-check the condition under it — the render task may have invalidated the
-    // pre-render between the unlocked test above and the lock.
-    RenderLock lock;
-    // The single-line form lands on the `if` only; cppcheck reports the sub-expression on the
-    // continuation line below, so the suppression has to span the whole condition.
-    // cppcheck-suppress-begin knownConditionTrueFalse ; render task mutates these concurrently
-    if (!(section && preRenderedPage.ready && preRenderedPage.spineIndex == currentSpineIndex &&
-          preRenderedPage.pageIndex == section->currentPage + 1)) {
-      // cppcheck-suppress-end knownConditionTrueFalse
-      lock.unlock();
-      if (!stepPageState(isForwardTurn)) {
-        return;
-      }
-      sessionPagesAdvanced++;
-      globalReadingSessionTracker().onPageTurn();
-      preRenderedPage.ready = false;
-      preRenderedPlanesStaged_ = false;
-      pendingPreRender = false;
-      requestUpdate();
-      return;
-    }
     const unsigned long nowMs = millis();
     const unsigned long idleSlackMs = (preRenderedPage.completedAtMs > 0 && nowMs >= preRenderedPage.completedAtMs)
                                           ? (nowMs - preRenderedPage.completedAtMs)
@@ -2868,7 +2856,7 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
     return;
   }
 
-  if (!stepPageState(isForwardTurn)) {
+  if (!stepPageStateLocked(isForwardTurn)) {
     return;
   }
 
@@ -3131,14 +3119,14 @@ void EpubReaderActivity::renderFinishedBookPass(const int spineCount) {
   // both mutated ActivityManager's pending-activity state from the wrong task and did SD work
   // (findNextBookInDirectory) on the render task's stack. The lock is now simply kept: nothing
   // below it is long-running any more.
-  finishedBookLaunchPending_ = true;
+  finishedBookLaunchPending_.store(true, std::memory_order_release);
 }
 
 void EpubReaderActivity::serviceFinishedBookLaunch() {
-  if (!finishedBookLaunchPending_ || !epub) {
+  if (!finishedBookLaunchPending_.load(std::memory_order_acquire) || !epub) {
     return;
   }
-  finishedBookLaunchPending_ = false;
+  finishedBookLaunchPending_.store(false, std::memory_order_relaxed);
   BookFinished::launchFinishedBookFlow(
       *this, renderer, mappedInput, epub->getPath(), epub->getSeries(), epub->getSeriesIndex(), epub->getAuthor(),
       [](void* ctx) { static_cast<EpubReaderActivity*>(ctx)->finishedBookActivityStarted_ = false; }, this,
@@ -5291,24 +5279,29 @@ bool EpubReaderActivity::handleLinkTouch() {
 void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool savePosition) {
   if (!epub) return;
 
+  int sourceSpineIndex;
   // Push current position onto saved stack
-  if (savePosition && section && footnoteDepth < MAX_FOOTNOTE_DEPTH) {
-    SavedPosition& saved = savedPositions[footnoteDepth];
-    saved = {};
-    saved.spineIndex = currentSpineIndex;
-    saved.pageNumber = section->currentPage;
-    // Mid-build pageCount is "pages so far", which would rescale the fallback against the wrong
-    // total; the paragraph anchor below is unaffected either way.
-    if (!section->hasActiveBuild()) {
-      saved.pageCount = section->pageCount;
-      if (const auto paragraphIndex = section->getParagraphIndexForPage(section->currentPage)) {
-        saved.paragraphIndex = *paragraphIndex;
-        saved.hasParagraph = true;
+  {
+    RenderLock lock(*this);
+    sourceSpineIndex = currentSpineIndex;
+    if (savePosition && section && footnoteDepth < MAX_FOOTNOTE_DEPTH) {
+      SavedPosition& saved = savedPositions[footnoteDepth];
+      saved = {};
+      saved.spineIndex = currentSpineIndex;
+      saved.pageNumber = section->currentPage;
+      // Mid-build pageCount is "pages so far", which would rescale the fallback against the wrong
+      // total; the paragraph anchor below is unaffected either way.
+      if (!section->hasActiveBuild()) {
+        saved.pageCount = section->pageCount;
+        if (const auto paragraphIndex = section->getParagraphIndexForPage(section->currentPage)) {
+          saved.paragraphIndex = *paragraphIndex;
+          saved.hasParagraph = true;
+        }
       }
+      footnoteDepth++;
+      LOG_DBG("ERS", "Saved position [%d]: spine %d, page %d, paragraph %d", footnoteDepth, saved.spineIndex,
+              saved.pageNumber, saved.hasParagraph ? saved.paragraphIndex : -1);
     }
-    footnoteDepth++;
-    LOG_DBG("ERS", "Saved position [%d]: spine %d, page %d, paragraph %d", footnoteDepth, currentSpineIndex,
-            section->currentPage, saved.hasParagraph ? saved.paragraphIndex : -1);
   }
 
   // Extract fragment anchor (e.g. "#note1" or "chapter2.xhtml#note1")
@@ -5323,7 +5316,7 @@ void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool s
 
   int targetSpineIndex;
   if (sameFile) {
-    targetSpineIndex = currentSpineIndex;
+    targetSpineIndex = sourceSpineIndex;
   } else {
     targetSpineIndex = epub->resolveHrefToSpineIndex(hrefStr);
   }
@@ -5537,21 +5530,26 @@ void EpubReaderActivity::openQuickOverrides() {
 }
 
 void EpubReaderActivity::openReaderMenu() {
-  const int currentPage = section ? section->currentPage + 1 : 0;
-  const int totalPages = section ? section->pageCount : 0;
-
   if (!epub) {
     return;
   }
 
+  int currentPage = 0;
+  int totalPages = 0;
   float bookProgress = 0.0f;
-  if (epub->getBookSize() > 0 && section && section->pageCount > 0) {
-    const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
-    bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
+  bool isCurrentPageStarred = false;
+  {
+    RenderLock lock(*this);
+    currentPage = section ? section->currentPage + 1 : 0;
+    totalPages = section ? section->pageCount : 0;
+    if (epub->getBookSize() > 0 && section && section->pageCount > 0) {
+      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+      bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
+    }
+    isCurrentPageStarred = section && bookmarkStore.has(static_cast<uint16_t>(currentSpineIndex),
+                                                        static_cast<uint16_t>(section->currentPage));
   }
   const int bookProgressPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
-  const bool isCurrentPageStarred = section && bookmarkStore.has(static_cast<uint16_t>(currentSpineIndex),
-                                                                 static_cast<uint16_t>(section->currentPage));
 
   // Show the "Go to printed page" item only when this book has at least one integer-labelled
   // entry in pagelist.bin. Roman-only or empty page lists are excluded — the numeric input
@@ -5591,7 +5589,10 @@ void EpubReaderActivity::openReaderMenu() {
         // corrupts the current image outright. Observed as an unreadable screen on
         // leaving the menu, with the AA landing ~14 s and nine menu refreshes after
         // the page it was computed for.
-        pendingGrayscale_ = {};
+        {
+          RenderLock lock(*this);
+          pendingGrayscale_ = {};
+        }
 
         // Arm a HALF for the resumed page, then repaint. Every other sub-activity handler
         // here already requests an update (book info, reading stats, chapter selection);
@@ -5636,9 +5637,12 @@ void EpubReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION 
       requestUpdate();
       break;
     case BA::BTN_STAR_PAGE:
-      if (section) {
-        bookmarkStore.toggle(static_cast<uint16_t>(currentSpineIndex), static_cast<uint16_t>(section->currentPage));
-        requestUpdate();
+      {
+        RenderLock lock(*this);
+        if (section) {
+          bookmarkStore.toggle(static_cast<uint16_t>(currentSpineIndex), static_cast<uint16_t>(section->currentPage));
+          requestUpdate();
+        }
       }
       break;
     case BA::BTN_DICTIONARY:
@@ -5664,9 +5668,14 @@ void EpubReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION 
       break;
     case BA::BTN_OPEN_TOC:
       if (epub) {
-        const int spineIdx = currentSpineIndex;
-        const int tocIdx = section ? section->getTocIndexForPage(section->currentPage)
-                                   : epub->getTocIndexForSpineIndex(currentSpineIndex);
+        int spineIdx;
+        int tocIdx;
+        {
+          RenderLock lock(*this);
+          spineIdx = currentSpineIndex;
+          tocIdx = section ? section->getTocIndexForPage(section->currentPage)
+                           : epub->getTocIndexForSpineIndex(currentSpineIndex);
+        }
         ReaderUtils::enforceExitFullRefresh(renderer);
         startActivityForResult(std::make_unique<EpubReaderChapterSelectionActivity>(renderer, mappedInput, epub,
                                                                                     epub->getPath(), spineIdx, tocIdx),
@@ -5818,12 +5827,15 @@ void EpubReaderActivity::onButtonAction(const CrossPointSettings::BUTTON_ACTION 
       // framebuffer may hold a Background-A pre-render of the *next* page, which would look
       // like a page turn). Clear the pre-render flags so classifyRenderPass() picks a Normal
       // render of the current page, request the forced mode for that render, and re-render.
-      pendingPreRender = false;
-      usePreRenderedBuffer = false;
-      preRenderedPage.ready = false;
-      preRenderedPlanesStaged_ = false;
-      forceRefreshModeNextRender_ = static_cast<int8_t>(
-          action == BA::BTN_FORCE_FAST_REFRESH ? HalDisplay::FAST_REFRESH : HalDisplay::HALF_REFRESH);
+      {
+        RenderLock lock(*this);
+        pendingPreRender = false;
+        usePreRenderedBuffer = false;
+        preRenderedPage.ready = false;
+        preRenderedPlanesStaged_ = false;
+        forceRefreshModeNextRender_ = static_cast<int8_t>(
+            action == BA::BTN_FORCE_FAST_REFRESH ? HalDisplay::FAST_REFRESH : HalDisplay::HALF_REFRESH);
+      }
       requestUpdate();
       break;
     default:

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -538,7 +538,7 @@ class EpubReaderActivity final : public Activity {
   // with no lock at all, because the invariant they rely on is "only the loop task touches
   // them", not "the render lock covers them". A unique_ptr assigned from one task while another
   // moves it is a double-free waiting to happen.
-  bool finishedBookLaunchPending_ = false;
+  std::atomic<bool> finishedBookLaunchPending_{false};
   // Last valid spine/page/pageCount at book-finish time, stashed for onFinishedBookSyncRequested()
   // — see the SyncPositionOverride comment for why currentSpineIndex/section can't be used there.
   int finishedBookSyncSpineIndex_ = 0;
@@ -863,6 +863,7 @@ class EpubReaderActivity final : public Activity {
   // section->currentPage that stays inside the loaded section — see the definition for why.
   void anchorNavTargetToCurrentPage();
   bool stepPageState(bool isForwardTurn);
+  bool stepPageStateLocked(bool isForwardTurn);
   void pageTurn(bool isForwardTurn);
 #if ENABLE_BENCHMARKS
   void runRenderBenchmark();

--- a/src/activities/settings/SyncTimeActivity.cpp
+++ b/src/activities/settings/SyncTimeActivity.cpp
@@ -211,8 +211,10 @@ void SyncTimeActivity::loop() {
     }
 
     if (state == FAILED && mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-      RenderLock lock(*this);
-      state = SYNCING;
+      {
+        RenderLock lock(*this);
+        state = SYNCING;
+      }
       requestUpdateAndWait();
       performSync();
     }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Prevent deterministic render deadlocks, unsafe cross-task state access, and concurrent peripheral operations discovered while following up on #235.
* **What changes are included?**
  * Release `RenderLock` before Sync Time waits synchronously for a render.
  * Make SPI and I2C bus locking fail closed, and cover display grayscale, RED-RAM, and framebuffer-release controller operations.
  * Preserve device topology: SPI-SD boards use `SPI -> storage` ordering, while X4 Pro's native SDMMC path does not take the display SPI lock.
  * Serialize implicit `HalFile` close and move replacement through the storage lock.
  * Protect EPUB deferred-AA, pre-render, section, page-turn, menu, navigation, and finished-book handoff state across loop/render tasks.
  * Remove WiFi event callbacks' dependency on activity lifetime.
  * Wait for the GPIO sampler task to exit before hardware teardown.

## Additional Context

* The earlier ActivityManager reader-entry lock-scope fix is already present on `master`, so this branch preserves it without adding a duplicate diff.
* Static concurrency re-audit found no remaining concrete defect in the requested scope.
* `git diff --check` passes.
* Firmware build was completed separately by the maintainer before this PR was opened.
* Hardware-focused follow-up should stress shared SPI rendering/storage, X4 Pro SDMMC sleep/wake, touch/RTC/gauge I2C contention, WiFi teardown, and rapid EPUB navigation.

Related to #235.

---

### AI Usage

Did you use AI tools to help write this code? **YES**