### PR TITLE
feat: X4 Pro bring-up: pre-flight audit, four blockers, and the fixes the device sessions found

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -8,7 +8,6 @@
 #include <ZipFile.h>
 #include <esp_heap_caps.h>
 #include <esp_system.h>
-#include <esp_task_wdt.h>
 #ifdef BENCH_EXTRACT_PROFILE
 #include <esp_timer.h>
 #endif
@@ -101,6 +100,8 @@ inline uint32_t paragraphLutEntryOffset(uint32_t lutStart, uint16_t page) {
   return lutStart + page * PARAGRAPH_LUT_ENTRY_SIZE;
 }
 }  // namespace
+
+#include <HalSystem.h>  // feedWatchdog()
 
 #include <algorithm>
 
@@ -1971,7 +1972,7 @@ void Section::warmAllImageCaches(const int xOffset, const int yOffset, const boo
     ++warmed;
     // Each image decode can take hundreds of ms; reset the WDT between pages
     // to avoid an interrupt watchdog timeout on image-heavy chapters.
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
   }
   currentPage = savedPage;
   if (warmed > 0) {

--- a/lib/Epub/Epub/converters/GifToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/GifToFramebufferConverter.cpp
@@ -4,8 +4,8 @@
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
-#include <esp_task_wdt.h>
 
 #include <cstring>
 #include <new>
@@ -425,7 +425,7 @@ bool GifToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
       aborted = true;
       return false;
     }
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     indexedToGray(idxRow, grayRow, w, *st);
 
     // Interlaced rows arrive out of order, so there is no monotonic cursor to run and no way

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -7,11 +7,11 @@
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
 #include <Memory.h>
 #include <ProgressiveJpegDc.h>
 #include <ZipFile.h>
-#include <esp_task_wdt.h>
 #include <tjpgd.h>
 
 #include <cstdlib>
@@ -507,7 +507,7 @@ int emitGrayBlock(JpegContext& ctxRef, const uint8_t* pixels, int blockX, int bl
   JpegContext* ctx = &ctxRef;
 
   // Feed the interrupt WDT every block — large JPEGs can take many seconds.
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
 
   if (stride <= 0 || blockH <= 0 || validW <= 0) return 1;
 

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -4,10 +4,10 @@
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
 #include <Memory.h>
 #include <PngStreamDecoder.h>
-#include <esp_task_wdt.h>
 
 #include <cstdlib>
 #include <memory>
@@ -402,7 +402,7 @@ bool PngToFramebufferConverter::decodeOpenFile(FsFile& file, const std::string& 
       }
       decodedSrcY++;
       // Feed the WDT periodically: a large image can take seconds to inflate.
-      if ((decodedSrcY & 31) == 0) esp_task_wdt_reset();
+      if ((decodedSrcY & 31) == 0) HalSystem::feedWatchdog();
     }
     if (!ok) break;
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -184,7 +184,17 @@ uint8_t* GfxRenderer::allocScaledGlyphMask(const void* fontData, const uint32_t 
   if (scaledGlyphCount_ >= SCALED_GLYPH_MAX_ENTRIES || scaledGlyphUsed_ + bytes > SCALED_GLYPH_ARENA_BYTES) {
     // Wholesale reset instead of LRU bookkeeping: the working set is one page's
     // distinct glyphs, so a reset costs at most one re-resample each.
-    LOG_DBG("GFX", "Scaled-glyph cache reset (%u entries, %u bytes used)", scaledGlyphCount_, scaledGlyphUsed_);
+    //
+    // TRC, not DBG, and deliberately not device-gated: this is a designed,
+    // cheap event that happens several times on a dense page (the 80-entry cap
+    // binds long before the 3584-byte arena does -- the X4 Pro hit it at ~1.9 KB
+    // used), so at DBG it is several lines per page turn reporting that the
+    // cache did exactly what it was built to do. It is not worth resizing
+    // either: the same page summaries measured glyphUs=1656 across 1120
+    // glyphCalls, i.e. ~1.5 us a call and under 2 ms of glyph work per page, so
+    // the re-resampling a reset causes is beneath notice. Rebuild with
+    // -DLOG_LEVEL=3 to watch it.
+    LOG_TRC("GFX", "Scaled-glyph cache reset (%u entries, %u bytes used)", scaledGlyphCount_, scaledGlyphUsed_);
     invalidateScaledGlyphCache();
   }
 

--- a/lib/Logging/Logging.cpp
+++ b/lib/Logging/Logging.cpp
@@ -3,6 +3,9 @@
 #include <BoardConfig.h>
 #include <HalClock.h>
 #include <esp_rom_sys.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
 
 #include <algorithm>
 #include <cstring>
@@ -29,6 +32,41 @@ static volatile bool serialWireMuted = false;
 
 void setSerialWireMuted(bool muted) { serialWireMuted = muted; }
 bool isSerialWireMuted() { return serialWireMuted; }
+
+// Serializes the EMIT half of logPrintf: the transport write and the RTC ring
+// append. Formatting stays outside it.
+//
+// Two tasks logging at once interleaved mid-line on the wire. Device log, X4 Pro:
+//
+//   [442] [DBG] [GPIO] getWakeupReason: wakeupCause=0, resetReason=11, [442] [INF] [MAIN] Serial log opened
+//
+// — the GPIO line is cut in half and its tail is lost. Cosmetic on its own, but
+// it happens precisely when several tasks are busy, which is when the log is
+// worth reading.
+//
+// The unlogged half is worse: logHead++ is not atomic, so two callers can claim
+// the same slot or skip one, corrupting the RTC_NOINIT ring that getLastLogs()
+// reads. That buffer exists to explain a crash, so racing it loses the evidence
+// exactly when something has gone wrong.
+//
+// STATIC allocation, deliberately, not xSemaphoreCreateMutex(): logPrintf is
+// reachable from global constructors, before setup() runs, and this codebase has
+// twice recorded that creating a mutex that early corrupts the TLSF heap
+// metadata (ActivityManager::begin, HalStorage::begin say so in as many words).
+// A StaticSemaphore_t lives in .bss and touches no heap. The function-local
+// static gives one-time, thread-safe initialisation without a second guard.
+static SemaphoreHandle_t logMutex() {
+  static StaticSemaphore_t storage;
+  static SemaphoreHandle_t handle = xSemaphoreCreateMutexStatic(&storage);
+  return handle;
+}
+
+// Whether it is legal to block on that mutex right now. Taking one from an ISR
+// is undefined, and from a suspended scheduler (a panic unwind) it cannot
+// succeed — in both cases an interleaved line is far better than a fault inside
+// the logger. logPrintf is a public entry point, so this is asserted here rather
+// than assumed of every caller.
+static bool logLockUsable() { return !xPortInIsrContext() && xTaskGetSchedulerState() == taskSCHEDULER_RUNNING; }
 
 void addToLogRingBuffer(const char* message) {
   // Add the message to the ring buffer, overwriting old messages if necessary.
@@ -80,6 +118,11 @@ void logPrintf(const char* level, const char* origin, const char* format, ...) {
     }
   }
   va_end(args);
+  // Everything above is local state (buf, and HalClock::formatLogTime, which is
+  // pure). Only the shared state below is serialised, so a slow USB-CDC write
+  // never holds up another task's formatting. See logMutex().
+  const bool locked = logLockUsable();
+  if (locked) xSemaphoreTake(logMutex(), portMAX_DELAY);
   // Log transport, chosen by the board profile (FREEINK_LOG_TRANSPORT).
   //
   // Boards with the same MCU expose logs differently, and getting this wrong is
@@ -108,6 +151,7 @@ void logPrintf(const char* level, const char* origin, const char* format, ...) {
 #endif
   }
   addToLogRingBuffer(buf);
+  if (locked) xSemaphoreGive(logMutex());
 }
 
 std::string getLastLogs() {

--- a/lib/hal/HalCapabilities.h
+++ b/lib/hal/HalCapabilities.h
@@ -107,6 +107,31 @@ inline bool hasBackAndConfirmButtons() {
 // arrangement rather than a yes/no capability.
 inline BoardConfig::InputStyle inputStyle() { return BoardConfig::ACTIVE.inputStyle; }
 
+// The MCU pin the ROM samples at reset to choose boot vs. download mode. Holding
+// it LOW while the chip comes out of reset enters ROM download mode, so firmware
+// never runs and no boot-time key combo on that pin can ever be observed.
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32H2)
+inline constexpr int8_t BOOT_MODE_STRAP_PIN = 9;
+#else  // ESP32 / ESP32-S2 / ESP32-S3
+inline constexpr int8_t BOOT_MODE_STRAP_PIN = 0;
+#endif
+
+// True when this board wires its Up key to that strapping pin, so a boot-time
+// combo must use a different key. The X4 Pro and X4 Classic both put Up on
+// GPIO0; on those, "hold Up + power" drops the device into ROM download mode
+// instead of into the firmware check the user was aiming for, which looks
+// exactly like a dead device. Derived from the profile rather than a board list,
+// so the next board that reuses the strap is covered without an edit.
+//
+// The InputStyle test is load-bearing, not defensive: on the X3/X4 ladder the
+// InputPins fields hold LADDER INDICES, not GPIO numbers (X4's tuple is
+// {0,1,2,3,4,5,...}), so comparing input.up against a pin number there is a
+// category error that happens to be false today only because no index reaches 9.
+inline bool upKeyIsBootStrap() {
+  return BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::XteinkAdcLadder &&
+         BoardConfig::ACTIVE.input.up == BOOT_MODE_STRAP_PIN;
+}
+
 // Chrome scale factor for finger-sized targets. 1.0 on button boards, 1.2 on the
 // touch boards. Read by ThemeMetrics in touch phase 5.
 inline float uiScale() { return BoardConfig::ACTIVE.uiScale; }

--- a/lib/hal/HalCapabilities.h
+++ b/lib/hal/HalCapabilities.h
@@ -107,6 +107,16 @@ inline bool hasBackAndConfirmButtons() {
 // arrangement rather than a yes/no capability.
 inline BoardConfig::InputStyle inputStyle() { return BoardConfig::ACTIVE.inputStyle; }
 
+// True when the SD card is reached over SPI, false when the board drives the
+// slot through the native SDMMC peripheral (X4 Pro, X4 Classic).
+//
+// Everything in the SdPins struct -- spiHz, cs, the shared-bus locking -- is
+// dead configuration on an SDMMC board, which mounts through SdmmcBlockDevice
+// and never touches those pins. Code that tunes or reports the SPI path must
+// ask this first, or it ends up announcing an SPI clock on a board that has no
+// SD SPI bus.
+inline bool sdUsesSpi() { return BoardConfig::ACTIVE.sdmmc.busWidth == 0; }
+
 // The MCU pin the ROM samples at reset to choose boot vs. download mode. Holding
 // it LOW while the chip comes out of reset enters ROM download mode, so firmware
 // never runs and no boot-time key combo on that pin can ever be observed.

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -5,6 +5,7 @@
 #include <HalGPIO.h>
 #include <HalPowerManager.h>
 #include <Logging.h>
+#include <XteinkDetect.h>  // applyXteinkDisplayController() — see begin()
 #include <esp_heap_caps.h>
 
 #include "HalSpiBus.h"
@@ -48,6 +49,38 @@ HalDisplay::HalDisplay()
 HalDisplay::~HalDisplay() {}
 
 void HalDisplay::begin(bool seamless) {
+#if !FREEINK_MCU_C3
+  // Resolve which panel controller this unit actually carries, before
+  // einkDisplay.begin() picks a driver from it.
+  //
+  // The Xteink 800x480 boards ship two different controllers depending on
+  // production batch -- the original SSD1677 and, in newer batches, an UltraChip
+  // UC8179/UC8279. FreeInkDisplay::begin() selects the driver purely from
+  // BoardConfig::ACTIVE.displayController, and the ONLY thing that ever writes
+  // that field is this probe. Without it a newer X4 Pro gets driven with
+  // SSD1677 command streams and develops no image.
+  //
+  // The C3 already does this inside HalGPIO::begin(), which is where it has to
+  // happen there: the probe bit-bangs the display pins, and the C3 pre-claims
+  // them with SPI.begin() in that same function. Every other board leaves the
+  // pins alone until EpdBus claims them inside einkDisplay.begin() below, so
+  // here is that board's equivalent moment -- after gpio.begin(), before SPI.
+  // Guarded rather than unconditional so the C3 does not probe a second time
+  // with SPI already holding the bus.
+  //
+  // Safe to run on a unit that turns out NOT to be UltraChip: the probe only
+  // resets and reads, and a part that does not answer the UC81xx read registers
+  // leaves the profile's own controller in place. Matches upstream/develop,
+  // which does the same call from setupDisplayAndFonts().
+  static bool controllerResolved = false;
+  if (!controllerResolved) {
+    controllerResolved = true;
+    if (freeink::applyXteinkDisplayController()) {
+      LOG_INF("DISP", "Panel controller: UltraChip UC81xx variant detected");
+    }
+  }
+#endif
+
   // Set X3-specific panel mode before initializing.
   if (gpio.deviceIsX3()) {
     einkDisplay.setDisplayX3();

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -1091,6 +1091,13 @@ bool HalGPIO::isUsbElectricalConnected() const {
   return digitalRead(usbDetect) == HIGH;
 }
 
+bool HalGPIO::canDetectUsbElectrically() const {
+  // X3 has no usable detect pin — GPIO20 is its gauge SDA — and infers the cable
+  // from fuel-gauge charge current instead, so it CAN answer the question.
+  if (deviceIsX3()) return true;
+  return BoardConfig::ACTIVE.usbDetect != BoardConfig::PIN_UNASSIGNED;
+}
+
 HalGPIO::WakeupReason HalGPIO::getWakeupReason() const {
   const auto wakeupCause = esp_sleep_get_wakeup_cause();
   const auto resetReason = esp_reset_reason();

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -453,6 +453,13 @@ class HalGPIO {
   // report the two terms apart.
   bool isUsbHostLinkActive() const;
 
+  // Whether this board can observe a cable at all WITHOUT an enumerated host —
+  // an X3-style gauge-current inference or a usbDetect pin. False on the
+  // native-USB boards whose profile leaves usbDetect unassigned (X4 Pro, T5S3):
+  // there, a false from isUsbConnected() means "no host enumerated right now",
+  // NOT "no cable", so nothing may treat it as a negative signal.
+  bool canDetectUsbElectrically() const;
+
   // USB state as sampled by the last update() call. Prefer this in per-loop
   // polling: isUsbConnected() performs a fresh I2C read on X3.
   bool isUsbConnectedCached() const { return lastUsbConnected; }

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -28,8 +28,11 @@
 #define X3_I2C_FREQ 400000
 
 // TI BQ27220 Fuel gauge I2C
+// StateOfCharge() is deliberately absent: percentage now comes from the SDK's
+// BatteryMonitor, which dispatches on the profile's GaugeType instead of
+// assuming every gauge is a BQ27220. Current() stays because the X3's USB
+// charge inference reads it directly, and the X3 really does carry a BQ27220.
 #define I2C_ADDR_BQ27220 0x55    // Fuel gauge I2C address
-#define BQ27220_SOC_REG 0x2C     // StateOfCharge() command code (%)
 #define BQ27220_CUR_REG 0x0C     // Current() command code (signed mA)
 #define BQ27220_VOLT_REG 0x08    // Voltage() command code (mV)
 #define BQ27220_FLAGS_REG 0x0A   // BatteryStatus() / Flags() command code (bit0=DSG, bit9=FC)

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -1,5 +1,6 @@
 #include "HalPowerManager.h"
 
+#include <BatteryMonitor.h>
 #include <BoardConfig.h>
 #include <HalCapabilities.h>
 #include <Logging.h>
@@ -11,6 +12,7 @@
 #include <cassert>
 
 #include "HalGPIO.h"
+#include "HalI2cBus.h"
 
 HalPowerManager powerManager;  // Singleton instance
 
@@ -62,12 +64,11 @@ void HalPowerManager::begin() {
     // board the SDK's InputManager has already started it. main.cpp calls the
     // owner after gpio.begin() so the touch driver gets first claim.
     //
-    // NOTE the gauge PROTOCOL is still BQ27220-specific (I2C_ADDR_BQ27220 and
-    // the BQ27220_*_REG offsets below). X4 Pro's CW2017 answers at a different
-    // address with different registers, so it needs its own read path -- taking
-    // the address from the profile alone would talk BQ27220 registers to a
-    // CW2017, the same trap as DS3231-vs-BM8563 in HalClock. T5S3's gauge is a
-    // BQ27220, so this path suits it as-is.
+    // The gauge PROTOCOL is no longer ours: getBatteryPercentage() dispatches
+    // through BatteryMonitor on ACTIVE.batteryGauge.gaugeType, so a BQ27220
+    // (X3, T5S3) and a CW2017 (X4 Pro) each get their own register map. This
+    // used to be a hardcoded BQ27220 read, which is the same trap as
+    // DS3231-vs-BM8563 in HalClock and failed on the X4 Pro for the same reason.
     _batteryUseI2C = true;
   } else if (HalCapabilities::hasAdcBattery()) {
     pinMode(BoardConfig::ACTIVE.batteryAdc, INPUT);
@@ -488,26 +489,65 @@ uint16_t HalPowerManager::getBatteryPercentage() const {
   // reused as X3_I2C_SCL on X3, so reading it as ADC would collide with the
   // fuel-gauge bus. _batteryUseI2C must match the detected device type.
   assert(_batteryUseI2C == HalCapabilities::hasI2cFuelGauge());
+
+  // One monitor for both backends, built from the WHOLE battery config rather
+  // than half of it: the default constructor takes the ADC pin, the divider
+  // multiplier AND the charge-status pin (with its per-board polarity) from
+  // BoardConfig::ACTIVE. The previous `BatteryMonitor(ACTIVE.batteryAdc)` passed
+  // the pin and defaulted the rest, which happens to be identical on X3/X4
+  // (divider 2.0, no charge-status pin) but silently drops both on any board
+  // that differs -- the X4 Pro's active-high STAT line on GPIO21 among them.
+  static const BatteryMonitor battery;
+
   if (_batteryUseI2C) {
     const unsigned long now = millis();
     if (_batteryLastPollMs != 0 && (now - _batteryLastPollMs) < BATTERY_POLL_MS) {
       return _batteryCachedPercent;
     }
+    _batteryLastPollMs = now;
 
-    // Read SOC from the I2C fuel gauge via the shared helper so the transaction
-    // shape stays consistent with other BQ27220/DS3231/QMI8658 reads.
-    // On I2C error, keep last known value to avoid UI jitter/slowdowns.
+    // Ask the SDK monitor, which dispatches on the profile's GaugeType, instead
+    // of reading BQ27220 registers by hand.
+    //
+    // The hand-rolled read was StateOfCharge() at 0x55 -- correct for the X3 and
+    // the T5S3, both of which carry a BQ27220, and wrong for the X4 Pro, whose
+    // gauge is a CW2017 at 0x63 with an entirely different register map. Nothing
+    // answers at 0x55 there, so every poll failed and the reported percentage was
+    // whatever the cache last held. Device-confirmed: two
+    // `i2cWriteReadNonStop ... ESP_ERR_INVALID_STATE` lines per Home render, one
+    // BATTERY_POLL_MS apart. (The error surfaces on the read rather than the
+    // address phase because endTransmission(false) defers the transfer under the
+    // ESP-IDF i2c_master driver.)
+    //
+    // The SDK already had the answer: BatteryMonitor carries the CW2017 driver,
+    // including the 80-byte BATINFO profile upload the part needs before it will
+    // report anything but 0%, and picks the backend from
+    // ACTIVE.batteryGauge.gaugeType. Its init is self-throttled to one attempt
+    // per second and returns false rather than blocking, so this stays cheap on
+    // the loop task.
+    //
+    // The bus lock is ours to take: BatteryMonitor talks to Wire directly, and on
+    // a touch board the GT911 is serviced from the sampler task on the same pins.
+    // Same arrangement as HalStorage::usbDriveExternalPower().
     uint16_t soc = 0;
-    if (X3GPIO::readI2CReg16LE(I2C_ADDR_BQ27220, BQ27220_SOC_REG, &soc)) {
+    bool read = false;
+    {
+      HalI2cBus::Lock i2cLock;
+      read = battery.readPercentageChecked(soc);
+    }
+    // On a failed read keep the last known value, to avoid UI jitter.
+    if (read) {
       _batteryCachedPercent = soc > 100 ? 100 : soc;
     }
-    _batteryLastPollMs = now;
     return _batteryCachedPercent;
   }
-  // ADC pin from the profile. Only reached when hasI2cFuelGauge() was false, so
-  // hasAdcBattery() holds and batteryAdc is a real pin -- the same gate that
-  // decides whether gpio.begin() configures it as an input.
-  static const BatteryMonitor battery = BatteryMonitor(BoardConfig::ACTIVE.batteryAdc);
+  // ADC path. Only reached when hasI2cFuelGauge() was false, so hasAdcBattery()
+  // holds and batteryAdc is a real pin -- the same gate that decides whether
+  // gpio.begin() configures it as an input.
+  //
+  // NOTE _batteryCachedPercent means different things in the two branches: a
+  // plain percent above, and percent x10 below. Safe only because a board takes
+  // one branch for its whole life.
 
   // Smooth the battery % with a 1/10-weight IIR. The cache stores the value
   // scaled ×10 so integer math keeps enough precision. Seed explicitly on the

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -18,6 +18,39 @@ HalPowerManager powerManager;  // Singleton instance
 // power control on the Xteink C3 units (see lightSleep()).
 static constexpr gpio_num_t GPIO_BATTERY_LATCH = GPIO_NUM_13;
 
+// Whether this build is allowed to call setCpuFrequencyMhz() at all.
+//
+// On the ESP32-S3 the PSRAM clock is derived from the CPU/APB clock, so changing
+// the CPU frequency while anything is touching PSRAM corrupts those accesses. On
+// the T5S3 that is not a corner case: the 960x540 framebuffer lives in PSRAM, so
+// the render path is in it more or less continuously. It is no better on the X4
+// Pro, whose prebuilt Arduino variant sets CONFIG_SPIRAM_USE_MALLOC with
+// CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096 — every allocation over 4 KB lands in
+// PSRAM — and which runs that PSRAM octal at 80 MHz.
+//
+// Observed on T5S3 hardware as a TG1WDT_SYS_RST immediately after the "Going to
+// low-power mode" line, on four consecutive boots and then intermittently —
+// intermittent because it depends on what is mid-access when the switch happens,
+// which is exactly the signature of this hazard rather than of a logic bug.
+//
+// This started life as an #if inside setPowerSaving() alone (commit 0a0851eb),
+// which left the two waveform hooks below scaling the clock unguarded. That gap
+// was invisible on the T5S3 — its panel is LGFX/parallel and never reaches
+// EpdBus::waitBusy, so the hooks never fire there — but on the X4 Pro they fire
+// on EVERY refresh (EpdBus fires them above a 20 ms wait), which would have made
+// the hot path the one that breaks PSRAM. Hence a single named predicate: every
+// setCpuFrequencyMhz() call site in this file is gated on it.
+//
+// The cost is idle power on a board that has 8 MB of PSRAM and a wired USB port;
+// the alternative is random resets. Revisit if ESP-IDF's dynamic frequency
+// scaling is ever configured properly for this build (it needs the PSRAM-aware
+// DFS path, not a bare setCpuFrequencyMhz()).
+#if defined(BOARD_HAS_PSRAM) && BOARD_HAS_PSRAM
+static constexpr bool CPU_SCALING_ALLOWED = false;
+#else
+static constexpr bool CPU_SCALING_ALLOWED = true;
+#endif
+
 void HalPowerManager::begin() {
   if (HalCapabilities::hasI2cFuelGauge()) {
     // Boards with an I2C fuel gauge read charge over the bus rather than from an
@@ -48,6 +81,10 @@ void HalPowerManager::setPowerSaving(bool enabled) {
   if (normalFreq <= 0) {
     return;  // invalid state
   }
+  if constexpr (!CPU_SCALING_ALLOWED) {
+    (void)enabled;
+    return;
+  }
 
   auto wifiMode = WiFi.getMode();
   if (wifiMode != WIFI_MODE_NULL) {
@@ -59,28 +96,6 @@ void HalPowerManager::setPowerSaving(bool enabled) {
   // that just won the race will re-call setPowerSaving anyway), but we want
   // defined semantics rather than relying on compiler behavior for a plain int.
   const LockMode mode = currentLockMode.load(std::memory_order_relaxed);
-
-#if defined(BOARD_HAS_PSRAM) && BOARD_HAS_PSRAM
-  // CPU frequency scaling is disabled on PSRAM boards.
-  //
-  // On the ESP32-S3 the PSRAM clock is derived from the CPU/APB clock, so
-  // changing the CPU frequency while anything is touching PSRAM corrupts those
-  // accesses. On the T5S3 that is not a corner case: the 960x540 framebuffer
-  // lives in PSRAM, so the render path is in it more or less continuously.
-  //
-  // Observed on hardware as a TG1WDT_SYS_RST immediately after the
-  // "Going to low-power mode" line, on four consecutive boots and then
-  // intermittently -- intermittent because it depends on what is mid-access when
-  // the switch happens, which is exactly the signature of this hazard rather
-  // than of a logic bug.
-  //
-  // The cost is idle power on a board that has 8 MB of PSRAM and a wired USB
-  // port; the alternative is random resets. Revisit if ESP-IDF's dynamic
-  // frequency scaling is ever configured properly for this build (it needs the
-  // PSRAM-aware DFS path, not a bare setCpuFrequencyMhz()).
-  (void)enabled;
-  return;
-#endif
 
   if (mode == None && enabled && !isLowPower) {
     LOG_DBG("PWR", "Going to low-power mode");
@@ -105,6 +120,9 @@ void HalPowerManager::setPowerSaving(bool enabled) {
 void HalPowerManager::ensureFullSpeedForRadio() {
   if (normalFreq <= 0) {
     return;  // begin() not called yet — nothing to restore to
+  }
+  if constexpr (!CPU_SCALING_ALLOWED) {
+    return;  // nothing ever lowered the clock, so there is nothing to restore
   }
   // Clear BOTH downclock owners before touching the frequency. The idle governor
   // (isLowPower) and the waveform hook (waveformLowPower_) track their drops separately, and
@@ -135,6 +153,11 @@ void HalPowerManager::enterWaveformWait() {
   if (normalFreq <= 0) {
     return;  // begin() not called yet — nothing to restore to
   }
+  if constexpr (!CPU_SCALING_ALLOWED) {
+    // EpdBus fires this hook above a 20 ms busy wait, i.e. on every refresh.
+    // Scaling here would be the most frequent PSRAM-clock change in the build.
+    return;
+  }
   if (WiFi.getMode() != WIFI_MODE_NULL) {
     return;  // WiFi requires the 80 MHz APB clock
   }
@@ -159,6 +182,9 @@ void HalPowerManager::enterWaveformWait() {
 }
 
 void HalPowerManager::exitWaveformWait() {
+  if constexpr (!CPU_SCALING_ALLOWED) {
+    return;  // enterWaveformWait() never lowered the clock; stay balanced with it
+  }
   xSemaphoreTake(modeMutex, portMAX_DELAY);
   if (waveformLowPower_) {
     waveformLowPower_ = false;

--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -3,6 +3,7 @@
 
 #include <BoardConfig.h>
 #include <FS.h>  // need to be included before SdFat.h for compatibility with FS.h's File class
+#include <HalCapabilities.h>
 #include <HalClock.h>
 #include <Logging.h>
 #include <SDCardManager.h>
@@ -65,8 +66,14 @@ bool HalStorage::begin() {
   // touches profiles that expressed no preference; a profile that sets spiHz
   // explicitly is left alone, so raising it later is a one-value profile change
   // rather than an edit here.
+  //
+  // Gated on the board actually having an SD SPI bus. The X4 Pro and X4 Classic
+  // mount through the native SDMMC peripheral, where sd.spiHz is dead config:
+  // setting it changed nothing and the log line announced a clock for a bus that
+  // does not exist, which is exactly the sort of line that costs someone an hour
+  // when they are reading a boot log looking for why storage is slow.
 #if !FREEINK_MCU_C3
-  if (BoardConfig::ACTIVE.sd.spiHz == 0) {
+  if (HalCapabilities::sdUsesSpi() && BoardConfig::ACTIVE.sd.spiHz == 0) {
     BoardConfig::ACTIVE.sd.spiHz = 20000000;
     LOG_INF("SD", "SPI clock held at 20 MHz on this board (SDK default is 40 MHz, unvalidated here)");
   }

--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -9,6 +9,7 @@
 #include "esp_private/esp_cpu_internal.h"
 #include "esp_private/esp_system_attr.h"
 #include "esp_private/panic_internal.h"
+#include "esp_task_wdt.h"
 
 #define MAX_PANIC_STACK_DEPTH 32
 
@@ -158,6 +159,15 @@ bool isRebootFromPanic() {
   // rebooted silently to Home with no diagnostic trail.
   return resetReason == ESP_RST_PANIC || resetReason == ESP_RST_CPU_LOCKUP || resetReason == ESP_RST_INT_WDT ||
          resetReason == ESP_RST_TASK_WDT || resetReason == ESP_RST_WDT;
+}
+
+void feedWatchdog() {
+  // ESP_OK means this task is subscribed; anything else (ESP_ERR_NOT_FOUND, or
+  // the watchdog not being initialised at all) means there is nothing to feed
+  // and calling reset would only log an error. See the header for the cost.
+  if (esp_task_wdt_status(nullptr) == ESP_OK) {
+    esp_task_wdt_reset();
+  }
 }
 
 }  // namespace HalSystem

--- a/lib/hal/HalSystem.h
+++ b/lib/hal/HalSystem.h
@@ -17,4 +17,28 @@ void clearPanic();
 
 std::string getPanicInfo(bool full = false);
 bool isRebootFromPanic();
+
+// Feed the task watchdog -- but only if the calling task is actually subscribed
+// to it.
+//
+// esp_task_wdt_reset() does not fail quietly. From a task that was never
+// esp_task_wdt_add()ed it returns ESP_ERR_NOT_FOUND and emits an ESP_LOGE
+// ("task not found") on EVERY call. None of this firmware's worker tasks are
+// subscribed, so a decode or layout loop that feeds the watchdog every few rows
+// turns into thousands of error lines on the console.
+//
+// That is not merely noise. Device-measured on the X4 Pro opening a book: a
+// ~4.8 second unbroken wall of those lines, during which the page render took
+// 9.6 s and one loop pass 5.7 s. Each line is a synchronous write to a USB-CDC
+// console that has to be drained by the host.
+//
+// So ask first. The lookup walks the watchdog's subscribed-task list, which is
+// two or three entries, and is far cheaper than the log line it replaces. It is
+// deliberately NOT cached in a static: this is called from several tasks and
+// the answer is per-task.
+//
+// The SDK reached the same conclusion independently for its SD streaming path
+// (SDCardManager::readFileToStream), which hoists the same query out of its
+// loop. Same idiom, one place.
+void feedWatchdog();
 }  // namespace HalSystem

--- a/src/SerialTransferDevice.cpp
+++ b/src/SerialTransferDevice.cpp
@@ -2,8 +2,8 @@
 
 #include <Arduino.h>
 #include <FsHelpers.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
-#include <esp_task_wdt.h>
 
 #include <cstdarg>
 #include <ctime>
@@ -128,7 +128,7 @@ int SerialTransferDevice::readByte() {
     if (millis() - start >= kReadTimeoutMs) return -1;
     // Yield + feed the watchdog while waiting so a slow/stalled host can't trip
     // the task WDT or peg the CPU (the old busy-wait did both).
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     vTaskDelay(1);
   }
   return logSerial.read();
@@ -149,7 +149,7 @@ void SerialTransferDevice::writeBytes(const uint8_t* data, size_t len) {
       lastProgressMs = millis();
     } else {
       if (millis() - lastProgressMs > kWriteStallAbortMs) break;  // host vanished
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
       vTaskDelay(1);
     }
   }
@@ -186,7 +186,7 @@ bool SerialTransferDevice::fileWrite(const uint8_t* data, size_t len) {
   if (!uploadOpen_) return false;
   // Feed the task WDT once per chunk so a long steady upload (which never waits
   // in readByte) can't trip it.
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
   uploadBytes_ += static_cast<uint32_t>(len);
   // Buffer into a larger block; flush when full. This lets the protocol ACK each
   // 2048-byte chunk without waiting on a fresh SD/FAT block write every time —
@@ -238,7 +238,7 @@ bool SerialTransferDevice::fileReadBegin(const std::string& path, uint32_t& outS
 
 size_t SerialTransferDevice::fileRead(uint8_t* buf, size_t len) {
   // Feed the task WDT once per chunk (a long download never waits in readByte).
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
   const int n = downloadFile_.read(buf, len);
   if (n <= 0) return 0;
   downloadBytes_ += static_cast<uint32_t>(n);

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -2,9 +2,9 @@
 
 #include <ESPmDNS.h>
 #include <GfxRenderer.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <I18n.h>
 #include <WiFi.h>
-#include <esp_task_wdt.h>
 
 #include "MappedInputManager.h"
 #include "SdCardFontGlobals.h"
@@ -133,12 +133,12 @@ void CalibreConnectActivity::loop() {
       LOG_DBG("CAL", "WARNING: %lu ms gap since last handleClient", timeSinceLastHandleClient);
     }
 
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     constexpr int MAX_ITERATIONS = 80;
     for (int i = 0; i < MAX_ITERATIONS && webServer->isRunning(); i++) {
       webServer->handleClient();
       if ((i & 0x07) == 0x07) {
-        esp_task_wdt_reset();
+        HalSystem::feedWatchdog();
       }
       if ((i & 0x0F) == 0x0F) {
         yield();

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -4,10 +4,10 @@
 #include <ESPmDNS.h>
 #include <GfxRenderer.h>
 #include <HalPowerManager.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <I18n.h>
 #include <Memory.h>
 #include <WiFi.h>
-#include <esp_task_wdt.h>
 
 #include <cstddef>
 
@@ -357,7 +357,7 @@ void CrossPointWebServerActivity::loop() {
       }
 
       // Reset watchdog BEFORE processing - HTTP header parsing can be slow
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
 
       // Process HTTP requests in tight loop for maximum throughput
       // More iterations = more data processed per main loop cycle
@@ -366,7 +366,7 @@ void CrossPointWebServerActivity::loop() {
         webServer->handleClient();
         // Reset watchdog every 32 iterations
         if ((i & 0x1F) == 0x1F) {
-          esp_task_wdt_reset();
+          HalSystem::feedWatchdog();
         }
         // Yield and check for exit button every 64 iterations
         if ((i & 0x3F) == 0x3F) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -394,8 +394,31 @@ inline void checkHeapIntegrity(const char*) {}
 // snapshot and this one — that is the bracket, not a point measurement.
 uint32_t g_lastHeapWatermark = 0;
 
+// The watermark of the pool that can actually run out on THIS board.
+//
+// esp_get_minimum_free_heap_size() sums every heap the allocator owns. On the
+// C3 that is the one pool the whole hunt above was about, so it is exactly
+// right. On a PSRAM board it also sums in 8 MB of SPI RAM, and the number stops
+// meaning anything: the X4 Pro reported drops of 152, 296 and 656 bytes against
+// an 8.4 MB total -- noise at ERROR level, several lines per page turn, in a
+// diagnostic whose entire job is to make a real dip stand out.
+//
+// Internal RAM is the pool under pressure there (DMA buffers, task stacks, and
+// everything under the 4 KB CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL threshold), and
+// it is what the periodic [MEM] line already reports as `internal=`. So watch
+// that instead. On a board without PSRAM the two are the same pool and the C3
+// behaviour is unchanged -- which is the point: this narrows the question to the
+// scarce resource rather than muting the alarm.
+uint32_t scarceHeapWatermark() {
+#if defined(BOARD_HAS_PSRAM) && BOARD_HAS_PSRAM
+  return heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL);
+#else
+  return esp_get_minimum_free_heap_size();
+#endif
+}
+
 void noteHeapWatermark(const char* stage) {
-  const uint32_t mark = esp_get_minimum_free_heap_size();
+  const uint32_t mark = scarceHeapWatermark();
   if (g_lastHeapWatermark == 0) {
     g_lastHeapWatermark = mark;  // first call: establish the baseline, nothing to report yet
     return;

--- a/src/activities/reader/FinishedBookActivity.cpp
+++ b/src/activities/reader/FinishedBookActivity.cpp
@@ -5,6 +5,7 @@
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <I18n.h>
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
@@ -12,7 +13,6 @@
 #include <SidecarFiles.h>
 #include <Txt.h>
 #include <Xtc.h>
-#include <esp_task_wdt.h>
 
 #include <algorithm>
 #include <cerrno>
@@ -349,7 +349,7 @@ std::string findSeriesSequel(const std::string& directory, const std::string& cu
     // folder is many seconds — feed the watchdog and let other tasks run between candidates. The
     // pre-fix scan full-loaded every EPUB (~2 s each) with no yield at all, the suspected cause of
     // the issue #104 reboot.
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     yield();
 
     const std::string candidatePath = pathWithFilename(directory, fileName);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -779,7 +779,16 @@ static bool openSerialLogIfHostPresent() {
   // isUsbConnected() is only consulted when there is none, since on X3 it costs
   // an I2C read and can only add a (harmless) false positive here.
   const bool hostLink = gpio.isUsbHostLinkActive();
-  if (!hostLink && !gpio.isUsbConnected()) {
+  // Close the gate only on a REAL negative. A board with no cable detect (X4
+  // Pro, T5S3: usbDetect unassigned) has nothing behind isUsbConnected() but the
+  // same SOF check hostLink already made, so a false there means "no host
+  // enumerated in this instant", not "no cable" — and a host that attaches a
+  // moment after boot, or a SOF read that lands in a quiet window, would cost
+  // the whole boot log. That is the T5S3 failure again (7c9f6623), where six
+  // rounds went into debugging a board that was simply not talking.
+  const bool cableDetectable = gpio.canDetectUsbElectrically();
+  const bool cable = cableDetectable && gpio.isUsbConnected();
+  if (!hostLink && cableDetectable && !cable) {
     // Ring-buffer only — the wire is closed by definition. Surfaces in the crash
     // report's "Last logs", so a session that produced no serial output at all
     // can still be explained after the fact.
@@ -799,12 +808,19 @@ static bool openSerialLogIfHostPresent() {
   // to "disconnected" and silently drops TX).
   logSerial.setTxBufferSize(8192);
   Serial.begin(115200);
-  const unsigned long start = millis();
-  while (!Serial && (millis() - start) < 500) {
-    delay(10);
+  // Only wait for the host when we have positive evidence one is there. On a
+  // board that cannot detect a cable we open the log speculatively, and paying
+  // 500 ms on every battery boot for a host that is not coming is not a trade
+  // worth making.
+  if (hostLink || cable) {
+    const unsigned long start = millis();
+    while (!Serial && (millis() - start) < 500) {
+      delay(10);
+    }
   }
   serialLogOpen = true;
-  LOG_INF("MAIN", "Serial log opened (%s)", hostLink ? "enumerated host link" : "charge-inferred cable");
+  LOG_INF("MAIN", "Serial log opened (%s)",
+          hostLink ? "enumerated host link" : (cable ? "charge-inferred cable" : "board has no cable detect"));
   return true;
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1099,9 +1099,14 @@ void setup() {
       gpio.update();
       delay(10);
     }
-    if (gpio.isHeldNow(HalGPIO::BTN_UP)) {
+    // Up normally, Down on a board that wires Up to the MCU's boot-mode strap.
+    // There, holding Up through the reset enters ROM download mode instead of
+    // running this firmware at all, so the combo could never fire and the user
+    // is left looking at a device that appears dead. See upKeyIsBootStrap().
+    const bool upIsStrap = HalCapabilities::upKeyIsBootStrap();
+    if (gpio.isHeldNow(upIsStrap ? HalGPIO::BTN_DOWN : HalGPIO::BTN_UP)) {
       recoveryFirmwareMode = true;
-      LOG_INF("MAIN", "Recovery firmware mode (UP + POWER held at boot)");
+      LOG_INF("MAIN", "Recovery firmware mode (%s + POWER held at boot)", upIsStrap ? "DOWN" : "UP");
     }
     BootDiag::markPhase(BootPhase::RecoverySettle);
   }

--- a/src/network/ChunkedResponse.h
+++ b/src/network/ChunkedResponse.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
 #include <Memory.h>
 #include <WebServer.h>
-#include <esp_task_wdt.h>
 
 #include <cstring>
 #include <memory>
@@ -63,13 +63,13 @@ class ChunkedResponse {
 
   void flush() {
     if (used == 0) return;
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     server->sendContent(buffer.get(), used);
     used = 0;
     // Yield so WiFi and the other tasks get to run: sendContent() is a blocking
     // network write that can stall for seconds under concurrent connections.
     yield();
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
   }
 
   WebServer* server;

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -5,12 +5,12 @@
 #include <FsHelpers.h>
 #include <HalClock.h>
 #include <HalStorage.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
 #include <Memory.h>
 #include <Txt.h>
 #include <WiFi.h>
 #include <Xtc.h>
-#include <esp_task_wdt.h>
 
 #include <algorithm>
 #include <cerrno>
@@ -122,7 +122,7 @@ void clearBookCacheIfNeeded(const String& filePath) {
 
 // Recursively clear book caches for all ebooks inside a directory
 void clearBookCachesInDirectory(const String& dirPath) {
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
   yield();
   FsFile dir = Storage.open(dirPath.c_str());
   if (!dir || !dir.isDirectory()) {
@@ -132,7 +132,7 @@ void clearBookCachesInDirectory(const String& dirPath) {
   char name[500];
   FsFile entry = dir.openNextFile();
   while (entry) {
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     yield();
     entry.getName(name, sizeof(name));
     String childPath = dirPath;
@@ -600,10 +600,10 @@ static void sendJson(WebServer* server, int code, const JsonDocument& doc) {
   serializeJson(doc, buf, payloadSize + 1);
   server->setContentLength(payloadSize);
   server->send(code, "application/json", "");
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
   server->sendContent(buf, payloadSize);
   free(buf);
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
 }
 
 void CrossPointWebServer::handleRoot() const {
@@ -874,8 +874,8 @@ void CrossPointWebServer::scanFiles(const char* path, const FileVisitor visitor,
     }
 
     file.close();
-    yield();               // Yield to allow WiFi and other tasks to process during long scans
-    esp_task_wdt_reset();  // Reset watchdog to prevent timeout on large directories
+    yield();                    // Yield to allow WiFi and other tasks to process during long scans
+    HalSystem::feedWatchdog();  // Reset watchdog to prevent timeout on large directories
     file = root.openNextFile();
   }
   root.close();
@@ -902,10 +902,10 @@ void CrossPointWebServer::handleFileListData() const {
   LOG_DBG("WEB", "File list request for path: %s", currentPath.c_str());
 
   LOG_WEB_MEM("files_enter");
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
   ChunkedJsonArray out(server.get());
   char output[512];
   constexpr size_t outputSize = sizeof(output);
@@ -921,7 +921,7 @@ void CrossPointWebServer::handleFileListData() const {
       currentPath.c_str(),
       [](const FileInfo& info, void* rawContext) {
         auto& ctx = *static_cast<FileListContext*>(rawContext);
-        esp_task_wdt_reset();
+        HalSystem::feedWatchdog();
         ctx.doc->clear();
         (*ctx.doc)["name"] = info.name;
         (*ctx.doc)["size"] = info.size;
@@ -937,7 +937,7 @@ void CrossPointWebServer::handleFileListData() const {
       },
       &context);
 
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
   out.finish();
   LOG_WEB_MEM("files_exit");
   LOG_DBG("WEB", "Served file listing page for path: %s", currentPath.c_str());
@@ -1016,12 +1016,12 @@ static size_t writeCount = 0;
 
 static bool flushUploadBuffer(CrossPointWebServer::UploadState& state) {
   if (state.bufferPos > 0 && state.file) {
-    esp_task_wdt_reset();  // Reset watchdog before potentially slow SD write
+    HalSystem::feedWatchdog();  // Reset watchdog before potentially slow SD write
     const unsigned long writeStart = millis();
     const size_t written = state.file.write(state.buffer.data(), state.bufferPos);
     totalWriteTime += millis() - writeStart;
     writeCount++;
-    esp_task_wdt_reset();  // Reset watchdog after SD write
+    HalSystem::feedWatchdog();  // Reset watchdog after SD write
 
     if (written != state.bufferPos) {
       LOG_DBG("WEB", "[UPLOAD] Buffer flush failed: expected %d, wrote %d", state.bufferPos, written);
@@ -1037,7 +1037,7 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
   static size_t lastLoggedSize = 0;
 
   // Reset watchdog at start of every upload callback - HTTP parsing can be slow
-  esp_task_wdt_reset();
+  HalSystem::feedWatchdog();
 
   // Safety check: ensure server is still valid
   if (!running || !server) {
@@ -1049,7 +1049,7 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
 
   if (upload.status == UPLOAD_FILE_START) {
     // Reset watchdog - this is the critical 1% crash point
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
 
     state.fileName = upload.filename;
     state.size = 0;
@@ -1089,21 +1089,21 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
     filePath += state.fileName;
 
     // Check if file already exists - SD operations can be slow
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     if (Storage.exists(filePath.c_str())) {
       LOG_DBG("WEB", "[UPLOAD] Overwriting existing file: %s", filePath.c_str());
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
       Storage.remove(filePath.c_str());
     }
 
     // Open file for writing - this can be slow due to FAT cluster allocation
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     if (!Storage.openFileForWrite("WEB", filePath, state.file)) {
       state.error = "Failed to create file on SD card";
       LOG_DBG("WEB", "[UPLOAD] FAILED to create file: %s", filePath.c_str());
       return;
     }
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
 
     LOG_DBG("WEB", "[UPLOAD] File created successfully: %s", filePath.c_str());
   } else if (upload.status == UPLOAD_FILE_WRITE) {
@@ -1996,7 +1996,7 @@ bool installRemoteFamily(HttpDownloader::Session& session, const RemoteManifestF
   // The session is owned by the caller (handleFontInstall) so it can be
   // reused across the manifest fetch and every family install in one batch.
   for (const auto& file : family.files) {
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     yield();
 
     std::string localFilename = file.name;
@@ -2248,7 +2248,7 @@ void CrossPointWebServer::handleFontDownload() {
 
   size_t installedCount = 0;
   for (auto& family : targetCopies) {
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     yield();
 
     LOG_DBG("WEB", "Installing font family: %s", family.name.c_str());
@@ -2277,7 +2277,7 @@ void CrossPointWebServer::handleFontUploadData() {
 
   switch (up.status) {
     case UPLOAD_FILE_START: {
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
       String family = server->arg("family");
       fontUpload.valid = false;
       fontUpload.magicChecked = false;
@@ -2325,7 +2325,7 @@ void CrossPointWebServer::handleFontUploadData() {
 
     case UPLOAD_FILE_WRITE: {
       if (!fontUpload.valid) break;
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
 
       if (!fontUpload.magicChecked) {
         size_t needed = 8 - fontUpload.headerBytesReceived;
@@ -2367,7 +2367,7 @@ void CrossPointWebServer::handleFontUploadData() {
             return;
           }
           fontUpload.bufferPos = 0;
-          esp_task_wdt_reset();
+          HalSystem::feedWatchdog();
         }
       }
       break;
@@ -2887,7 +2887,7 @@ void CrossPointWebServer::handleRelay() {
       server->send(200, "application/octet-stream", "");
       headerSent = true;
     }
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     server->sendContent(reinterpret_cast<const char*>(data), len);
     total += len;
     return true;
@@ -3085,20 +3085,20 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
                   filePath.c_str());
 
           // Check if file exists and remove it
-          esp_task_wdt_reset();
+          HalSystem::feedWatchdog();
           if (Storage.exists(filePath.c_str())) {
             Storage.remove(filePath.c_str());
           }
 
           // Open file for writing
-          esp_task_wdt_reset();
+          HalSystem::feedWatchdog();
           if (!Storage.openFileForWrite("WS", filePath, wsUploadFile)) {
             wsServer->sendTXT(num, "ERROR:Failed to create file");
             wsUploadInProgress = false;
             wsUploadClientNum = 255;
             return;
           }
-          esp_task_wdt_reset();
+          HalSystem::feedWatchdog();
 
           // Zero-byte upload: complete immediately without waiting for BIN frames
           if (wsUploadSize == 0) {
@@ -3136,9 +3136,9 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
         wsServer->sendTXT(num, "ERROR:Upload overflow");
         return;
       }
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
       size_t written = wsUploadFile.write(payload, length);
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
 
       if (written != length) {
         abortWsUpload("WS");

--- a/src/network/HttpFileStreamer.cpp
+++ b/src/network/HttpFileStreamer.cpp
@@ -1,8 +1,7 @@
 #include "HttpFileStreamer.h"
 
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
-#include <esp_task_wdt.h>
-
 namespace {
 constexpr size_t DOWNLOAD_CHUNK_SIZE = 4096;
 }
@@ -17,7 +16,7 @@ bool streamFileToClient(FsFile& file, NetworkClient& client) {
 
   bool ok = true;
   while (ok) {
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     int result = file.read(buffer, DOWNLOAD_CHUNK_SIZE);
     if (result < 0) {
       ok = false;
@@ -28,7 +27,7 @@ bool streamFileToClient(FsFile& file, NetworkClient& client) {
     size_t bytesRead = static_cast<size_t>(result);
     size_t totalWritten = 0;
     while (totalWritten < bytesRead) {
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
       size_t wrote = client.write(buffer + totalWritten, bytesRead - totalWritten);
       if (wrote == 0) {
         ok = false;

--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -3,10 +3,10 @@
 #include <Epub.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
+#include <HalSystem.h>  // feedWatchdog()
 #include <Logging.h>
 #include <Txt.h>
 #include <Xtc.h>
-#include <esp_task_wdt.h>
 
 #include "ChunkedResponse.h"
 #include "HttpFileStreamer.h"
@@ -89,7 +89,7 @@ void WebDAVHandler::raw(WebServer& server, const String& uri, HTTPRaw& raw) {
 
   } else if (raw.status == RAW_WRITE) {
     if (_putFile && _putOk) {
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
       size_t written = _putFile.write(raw.buf, raw.currentSize);
       if (written != raw.currentSize) {
         _putOk = false;
@@ -259,7 +259,7 @@ void WebDAVHandler::handlePropfind(WebServer& s) {
 
       file.close();
       yield();
-      esp_task_wdt_reset();
+      HalSystem::feedWatchdog();
       file = root.openNextFile();
     }
   }
@@ -639,7 +639,7 @@ void WebDAVHandler::handleCopy(WebServer& s) {
   uint8_t buf[4096];
   bool copyOk = true;
   while (srcFile.available()) {
-    esp_task_wdt_reset();
+    HalSystem::feedWatchdog();
     int bytesRead = srcFile.read(buf, sizeof(buf));
     if (bytesRead <= 0) break;
     size_t written = dstFile.write(buf, bytesRead);

--- a/test/shims/HalSystem.h
+++ b/test/shims/HalSystem.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+// Host-test shim for lib/hal/HalSystem.h.
+//
+// The real header is fine on its own, but its implementation pulls
+// esp_task_wdt.h, esp_debug_helpers.h and the ESP-IDF panic internals, none of
+// which exist on the host. The decode and layout code under test reaches it for
+// exactly one thing -- feedWatchdog() -- and on a host there is no watchdog to
+// feed, so this is a no-op.
+//
+// The panic helpers are declared but deliberately not defined: nothing under
+// test calls them, and leaving them undefined means a future caller fails at
+// link time here rather than silently testing a stub that lies.
+
+namespace HalSystem {
+
+inline void feedWatchdog() {}
+
+void begin();
+void checkPanic();
+void clearPanic();
+std::string getPanicInfo(bool full = false);
+bool isRebootFromPanic();
+
+}  // namespace HalSystem


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Get the X4 Pro from "deliberately unflashed" to a device that boots, reads and pages — without risking the replacement unit, and without regressing the shipped C3 boards.
* **What changes are included?**

An earlier X4 Pro was bricked permanently, so [`62ad534d`](https://github.com/jpirnay/witchhunt-reader/commit/62ad534d) made not flashing the replacement a standing decision until its boot, display-power and USB paths had a proper audit against upstream. This is that audit, the four blockers it found, and everything the resulting device sessions turned up.

### The audit found four things, all fixed before the first flash

| | |
|---|---|
| `7eda03b5` | **CPU frequency scaling on a PSRAM board.** The ban added by `0a0851eb` lived only in `setPowerSaving()`; `enterWaveformWait()`/`exitWaveformWait()` scaled the clock unguarded. `EpdBus` fires those above a 20 ms busy wait, i.e. **every refresh**, dropping 240→10 MHz while octal PSRAM runs at 80 MHz. Invisible on the T5S3, whose parallel LGFX panel never reaches `EpdBus::waitBusy`. |
| `a1ece23f` | **The panel-controller probe never ran.** `applyXteinkDisplayController()` sat inside `if constexpr (buildTargetsXteinkC3())`. It is the only thing that writes `ACTIVE.displayController`, which is what `FreeInkDisplay::begin()` selects a driver from. |
| `07387e1f` | **The recovery combo held GPIO0**, an S3 boot strap — holding it through reset enters ROM download mode, so the check could never fire. Derived from the profile rather than a board list. |
| `0d666d3c` | **The serial-log gate could close** on a board with no `usbDetect` pin, which is how the T5S3 lost six debugging rounds. |

**The controller probe was load-bearing, not theoretical.** The replacement unit reports `promoted SSD1677 -> UC8179 (LUT_VER=01)` — it is a newer batch. Without that fix the panel would have been driven with SSD1677 command streams and stayed dark.

### Then the device sessions found three more

* `49bfcf38` — **battery**: we read BQ27220 registers at 0x55; this board's gauge is a CW2017 at 0x63. Two `ESP_ERR_INVALID_STATE` per Home render, percentage stale. Now routed through the SDK's `BatteryMonitor`, which dispatches on `GaugeType` and owns the CW2017 BATINFO upload.
* `f69b8e90` — **task watchdog**: `esp_task_wdt_reset()` from unsubscribed tasks logs an `ESP_LOGE` per call, and 48 sites fed it unguarded. 4.8 s of unbroken error lines per book-open. Fixing it took `open=16725 page=33067` → `open=2630 page=10686` and max loop 5683 → 2372 ms.
* `5509a828`, `e61a2b41` — diagnostics that were sound on the C3 and wrong here: a heap watermark summing 8 MB of PSRAM, an SD SPI clock announced on an SDMMC board, and `logPrintf` racing itself across tasks (which also corrupts the RTC crash-report ring).

### SDK resync (`af6f6eda`, submodule `0443eae`)

48 upstream commits, for the UC8179/SSD1677 work this board now depends on. Two conflicts resolved rather than taken wholesale — see the submodule commit. One **deliberate fork deviation**: X3 is pinned to 20 MHz via a new `XTEINK_X3_DISPLAY_SPI_HZ` rather than following upstream's shared 10 MHz, because it is shipped, validated at the UC8253 serial-write maximum, and halving it roughly doubles plane-write time for users who are not the reason this resync happened.

## Additional Context

**Device-validated on the X4 Pro:** boots, mounts SDMMC, drives the UC8179, frontlight and PCF8563 RTC up, opens books, pages at 1277–1327 ms with pre-render hitting, AA/grayscale running. PSRAM total 8,388,608 — first time `dio_opi` and the octal assumption inherited from upstream have been measured on our own hardware.

**Measured and negative:** upstream's `39606d5` UC8179 plane-write consolidation does **not** reduce refresh time here. `8179_DRF` was 560 ms before the resync and 509–546 ms after. The cost is the electrophoretic waveform, not the SPI upload — worth recording so nobody chases it again.

**Areas to focus on:**

* **The C3 has not been re-flashed.** Every commit keeps its paths compiled out or byte-equivalent, and the numbers below show the cost, but the AA path and the X3 clock decision both want an X3 or X4 run before this merges.
* Nothing in CI can see the panel — the goldens dump the EPUB pipeline and the SDK driver tests drive a recording bus. A green build is not evidence about glass.

**Verification:** `default` 57,392 / 6,246,139 (95.3%) · `x4pro` 101,440 / 6,136,645 (93.6%) · `lilygo_t5s3` builds · host suite 896/897 (the failure is a pre-existing Windows `/` vs `\` assert in `DictionaryTest`) · the SDK's own driver tests pass against the merged tree (`run_pro.py` covering SSD1677 + UC8179 + UC8279X4 plane bytes, transaction counts and power state, plus `run_uc8279.py` and `run_uc8253_power.py`).

**Depends on** jpirnay/freeink-sdk@`resync/upstream-main-2026-09-12` (pushed; the submodule pointer references it).

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — Claude (Claude Code) did the audit, the fixes and the commit messages; every finding was verified against the source and, where the table above says so, against device logs.
