### PR TITLE
ci: full-fledged X4 Pro support (build, PR binaries, release, RC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,19 @@ jobs:
         run: pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
 
   build:
-    # The C3 boards (X3/X4) and the S3 LilyGo T5S3 are separate binaries built
-    # from different toolchains, so each gets its own leg. fail-fast is off so a
-    # break on one board still reports the other's result.
+    # The C3 boards (X3/X4), the X4 Pro and the S3 LilyGo T5S3 are separate
+    # binaries built from different toolchains, so each gets its own leg.
+    # fail-fast is off so a break on one board still reports the others' result.
     #
     # Asset names match what the firmware's own OTA check asks GitHub for (see
     # src/network/FirmwareBoardTag.h): plain firmware.bin for the combined C3
     # X3/X4 binary, firmware-<board>.bin for every other board.
+    #
+    # x4pro builds here for CI coverage and PR test artifacts only -- there is
+    # no x4pro_gh_release/x4pro_gh_release_rc env yet, so it is deliberately
+    # absent from release.yml/release_candidate.yml. Add those only once the
+    # board is validated enough to publish: doing so makes the binary eligible
+    # for the firmware's own OTA update check on every X4 Pro in the field.
     name: Build (${{ matrix.label }})
     runs-on: ubuntu-latest
     strategy:
@@ -97,6 +103,9 @@ jobs:
           - env: default
             label: X3/X4
             asset: firmware.bin
+          - env: x4pro
+            label: X4 Pro
+            asset: firmware-x4pro.bin
           - env: lilygo_t5s3
             label: LilyGo T5S3
             asset: firmware-lilygo.bin

--- a/.github/workflows/pr-firmware-links.yml
+++ b/.github/workflows/pr-firmware-links.yml
@@ -75,6 +75,7 @@ jobs:
             // comment, so the two lists have to move together.
             const builds = [
               { name: 'firmware.bin', device: 'X3 / X4' },
+              { name: 'firmware-x4pro.bin', device: 'X4 Pro' },
               { name: 'firmware-lilygo.bin', device: 'LilyGo T5S3' },
             ];
             const { data: artifactResponse } =

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,13 @@ name: Compile Release
 # devices in the field keep updating — and firmware-<board>.bin for every other
 # board. The legs build in parallel and a single publish job attaches them, so
 # two jobs never race on the same release.
+#
+# Publishing an env here (and in release_candidate.yml) makes that board's
+# binary eligible for the firmware's own OTA update check on every device of
+# that board in the field -- so an env only belongs in this matrix once it is
+# validated enough to ship, not merely once it compiles. x4pro joined
+# 2026-09-12 after its preflight fixes (PR #246) landed and initial on-device
+# testing came back positive.
 
 on:
   release:
@@ -25,6 +32,9 @@ jobs:
           - env: gh_release
             label: X3/X4
             asset: firmware.bin
+          - env: x4pro_gh_release
+            label: X4 Pro
+            asset: firmware-x4pro.bin
           - env: lilygo_gh_release
             label: LilyGo T5S3
             asset: firmware-lilygo.bin

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -80,6 +80,9 @@ jobs:
           - env: gh_release_rc
             label: X3/X4
             asset: firmware.bin
+          - env: x4pro_gh_release_rc
+            label: X4 Pro
+            asset: firmware-x4pro.bin
           - env: lilygo_gh_release_rc
             label: LilyGo T5S3
             asset: firmware-lilygo.bin

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Witch(hunt) Reader
 
-This firmware is based on the [crosspoint-reader](https://github.com/crosspoint-reader/crosspoint-reader) for the XTEINK X3/X4, a great piece of software by Dave Allie and others.
+This firmware is based on the [crosspoint-reader](https://github.com/crosspoint-reader/crosspoint-reader), a great piece of software by Dave Allie and others.
 
-**Caveat: new hardware batches of the X3 / X4 from xteink seem to come with a newer display panels. These models should work with Witch(hunt) Reader from version 2.21 onwards.**
+It supports the following devices:
+- ESP32C3-based Xteink X4 and X3.
+- ESP32S3-based Xteink X4Pro, LilyGo T5S3 Pro
 
 # Installation
 
@@ -10,7 +12,7 @@ Flashing is done from the browser — no toolchain or driver install needed. Use
 
 1. Download `firmware.bin` for your device from the [latest release](../../releases/latest).
 2. Open the [CrossPoint flash tools](https://crosspointreader.com/#flash-tools).
-3. Pick your device (X3 or X4).
+3. Pick your device.
 4. Choose **Custom .bin** and upload the `firmware.bin` you downloaded in step 1.
 5. Connect the device via USB and start the flash — pick the device's serial port when the browser asks.
 
@@ -20,7 +22,7 @@ Flashing is done from the browser — no toolchain or driver install needed. Use
 - Memory - where others fail Witch Reader still works
 - Proper KOReader Snychronisation
 - Additional sleep screens support (information overlay, transparent pictures over current reader screen)
-- Clock-Support for X4 and X3
+- Clock-Support for all supported devices
 - Weather information panel
 - Multiple under-the-hood performance improvements
 - Book information screen

--- a/platformio.ini
+++ b/platformio.ini
@@ -301,8 +301,13 @@ lib_deps =
 ; Lead board for multi-board bring-up; see docs/multi-board-bringup-2026-08-14.md.
 ; Build & flash: pio run -e x4pro -t upload
 ; ---------------------------------------------------------------------------
-[env:x4pro]
-extends = base
+; ---------------------------------------------------------------------------
+; X4 Pro board configuration, shared by the dev env and the two release envs
+; below. Not an env itself -- interpolation only, like [c3], [s3] and
+; [lilygo_board]. Everything that identifies the BOARD lives here; the envs
+; add only what identifies the BUILD (version string, log level).
+; ---------------------------------------------------------------------------
+[x4pro_board]
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 ; DIO flash + octal PSRAM, and NOT the board manifest's default.
@@ -334,14 +339,38 @@ build_flags =
 ; env does not silently lose PSRAM if that manifest ever changes, matching
 ; upstream/develop.
   -DBOARD_HAS_PSRAM
-  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4pro\"
   -DUSB_PRODUCT=\"CrossPoint_X4_Pro\"
   -DUSB_MANUFACTURER=\"CrossPoint\"
-  -DENABLE_SERIAL_LOG
-  -DLOG_LEVEL=2
 ; X4 Pro's SD is native SDMMC (1-bit), mounted through SdFat's block-device API
 ; rather than the SPI path the C3 boards use.
   -DUSE_BLOCK_DEVICE_INTERFACE=1
+
+[env:x4pro]
+extends = base, x4pro_board
+build_flags =
+  ${x4pro_board.build_flags}
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4pro\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=2 ; Set log level to debug for development builds
+
+; X4 Pro counterparts of [env:gh_release] / [env:gh_release_rc]. The release
+; asset built from these is firmware-x4pro.bin, which is the name the
+; firmware's own OTA check asks GitHub for (see FirmwareBoardTag.h).
+[env:x4pro_gh_release]
+extends = base, x4pro_board
+build_flags =
+  ${x4pro_board.build_flags}
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4pro\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=1 ; Set log level to info for release builds
+
+[env:x4pro_gh_release_rc]
+extends = base, x4pro_board
+build_flags =
+  ${x4pro_board.build_flags}
+  ; CROSSPOINT_VERSION is set by scripts/git_branch.py from the CI RC tag
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
 
 ; ---------------------------------------------------------------------------
 ; LilyGo T5S3 board configuration, shared by the dev env and the two release


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make X4 Pro a full-fledged firmware target: CI build coverage,
  a flashable PR test binary, and now a real release/RC pipeline — the same three-tier treatment the
  LilyGo T5S3 already has.
* **What changes are included?**
  * `ci.yml`: `env:x4pro` added to the `build` job's matrix (asset `firmware-x4pro.bin`).
  * `pr-firmware-links.yml`: the same asset added to the PR-comment board list.
  * `platformio.ini`: `env:x4pro` refactored so its board-identity flags (chip config, USB strings,
    memory type, `USE_BLOCK_DEVICE_INTERFACE`) live in a new `[x4pro_board]` interpolation-only
    section, mirroring `[lilygo_board]`. `env:x4pro_gh_release` and `env:x4pro_gh_release_rc` added
    on top of it, following the `lilygo_gh_release[_rc]` pattern exactly. Every flag `env:x4pro`
    carried before is still present after the split — only the order of independent `-D` defines
    changed, which has no compile-time effect.
  * `release.yml` / `release_candidate.yml`: X4 Pro added as a third matrix leg in each, asset
    `firmware-x4pro.bin`.
  * `README.md`: device list and install steps updated for the current three-board lineup (X3/X4,
    X4 Pro, LilyGo T5S3).

## Additional Context

**Scope changed since this PR opened.** It started as CI-coverage-only, deliberately excluding
`release.yml`/`release_candidate.yml` because an asset published there becomes an OTA update every
X4 Pro in the field is offered, and `env:x4pro` was dev-only with no release/RC envs to publish from.
Initial on-device testing on the X4 Pro (after the preflight fixes in #246) came back positive, so
the full pipeline is now wired.

`scripts/git_branch.py` needs no change: its `pioenv.endswith('gh_release_rc')` check and
board-suffix derivation from the env name (`x4pro_gh_release_rc` → `-x4pro` version suffix) are
already fully generic — verified by reading the script, not just by analogy with LilyGo. Same for
`scripts/patch_min_chip_rev.py` and `scripts/generate_release_notes.py`: neither has any board-name
assumption.

**Verified on all three envs** (local, after the refactor):

```
x4pro                SUCCESS  RAM 101,440  Flash 6,136,629 (93.6%)
x4pro_gh_release     SUCCESS  RAM 101,424  Flash 6,065,413 (92.6%)
x4pro_gh_release_rc  SUCCESS  RAM 101,424  Flash 6,065,573 (92.6%)
```

The release envs come out ~71 KB smaller than dev, which is `LOG_LEVEL` 2→1 dropping debug format
strings; release vs RC differ by 160 bytes, the version string. The RC leg printed
`CrossPoint build version: 2.28.0-rc.0+local-x4pro`, confirming `git_branch.py` derives the `-x4pro`
suffix from the env name by itself (`+local` becomes the real RC tag in CI).

The `env:x4pro` refactor is proven inert rather than assumed: dumping `pio project config` before and
after the `[x4pro_board]` split gives **byte-identical resolved build flags** (27 flags, no
addition, removal or change). So the split is a pure reorganisation, and a board fix now lands once
instead of three times.

**Worth knowing, not blocking:** this PR's own CI run only exercises `env:x4pro` (the `build` job).
`env:x4pro_gh_release`/`_rc` are only invoked by an actual `release: published` or a push to
`release/**`, so the RC pipeline is the real first end-to-end test of those two — same as it already
is for every other board.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
